### PR TITLE
feat: add cloudflow-support and external-org-autopilot extensions

### DIFF
--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -1,0 +1,47 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createAuditLogger } from "./src/audit.js";
+import { registerGhTools } from "./src/gh-tools.js";
+import { registerCfOpsTools } from "./src/cf-ops-tools.js";
+import { sendComfortMessage } from "./src/comfort.js";
+
+type PluginConfig = { cfRepos?: string[] };
+
+const plugin = {
+  id: "cloudflow-support",
+  name: "CloudFlowSupport",
+  description: "CloudFlow platform support, operations API, and issue management tools",
+  configSchema: {
+    type: "object" as const,
+    additionalProperties: false,
+    properties: {
+      cfRepos: {
+        type: "array",
+        items: { type: "string" },
+        default: ["cloudwarriors-ai/cloudflow"],
+        description: "GitHub repos scoped for CloudFlow issue management",
+      },
+    },
+  },
+
+  register(api: OpenClawPluginApi, config?: PluginConfig) {
+    const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
+    const logger = createAuditLogger(workspaceDir);
+    const pluginConfig: PluginConfig = config ?? { cfRepos: ["cloudwarriors-ai/cloudflow"] };
+
+    registerCfOpsTools(api, logger);
+    registerGhTools(api, logger, pluginConfig);
+
+    // Send comfort message when a message arrives in the CloudFlow channel
+    api.on("message_received", async (event, ctx) => {
+      if (ctx.channelId === "zoom" && ctx.conversationId) {
+        const messageId =
+          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+        void sendComfortMessage(ctx.conversationId, messageId);
+      }
+    });
+
+    console.log("[cloudflow-support] Registered 15 tools (9 ops + 6 GH)");
+  },
+};
+
+export default plugin;

--- a/extensions/cloudflow-support/openclaw.plugin.json
+++ b/extensions/cloudflow-support/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "cloudflow-support",
+  "name": "CloudFlowSupport",
+  "description": "CloudFlow platform support, operations API, and issue management tools",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "cfRepos": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["cloudwarriors-ai/cloudflow"],
+        "description": "GitHub repos scoped for CloudFlow issue management"
+      }
+    }
+  }
+}

--- a/extensions/cloudflow-support/src/audit.ts
+++ b/extensions/cloudflow-support/src/audit.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface AuditEntry {
+  ts: string;
+  tool: string;
+  actor: string;
+  trigger?: string;
+  params?: Record<string, unknown>;
+  resultSummary?: string;
+  durationMs?: number;
+  error?: string;
+}
+
+export function createAuditLogger(workspaceDir: string) {
+  const auditDir = path.join(workspaceDir, "cloudflow-support");
+  const auditFile = path.join(auditDir, "audit.jsonl");
+
+  try {
+    fs.mkdirSync(auditDir, { recursive: true });
+  } catch {
+    // ignore if exists
+  }
+
+  return function logAudit(entry: AuditEntry) {
+    const line = JSON.stringify(entry) + "\n";
+    try {
+      fs.appendFileSync(auditFile, line);
+    } catch (err) {
+      console.error("[cf-audit] Failed to write audit log:", err);
+    }
+  };
+}
+
+export type AuditLogger = ReturnType<typeof createAuditLogger>;
+
+export function wrapToolWithAudit(
+  toolDef: {
+    name: string;
+    description: string;
+    parameters: unknown;
+    execute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: "text"; text: string }[] }>;
+  },
+  logger: AuditLogger,
+) {
+  const origExecute = toolDef.execute;
+  toolDef.execute = async (id: string, params: Record<string, unknown>) => {
+    const start = Date.now();
+    try {
+      const result = await origExecute(id, params);
+      const durationMs = Date.now() - start;
+      let resultSummary = "";
+      try {
+        const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+        if (parsed.ok === false) resultSummary = `error: ${parsed.error ?? "unknown"}`;
+        else if (Array.isArray(parsed.data)) resultSummary = `${parsed.data.length} items`;
+        else resultSummary = "ok";
+      } catch {
+        resultSummary = "ok";
+      }
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "cloudflow-support",
+        params: sanitizeParams(params),
+        resultSummary,
+        durationMs,
+      });
+      return result;
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "cloudflow-support",
+        params: sanitizeParams(params),
+        error: err instanceof Error ? err.message : String(err),
+        durationMs,
+      });
+      throw err;
+    }
+  };
+  return toolDef;
+}
+
+function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (typeof v === "string" && v.length > 200) {
+      clean[k] = v.slice(0, 200) + "...[truncated]";
+    } else {
+      clean[k] = v;
+    }
+  }
+  return clean;
+}

--- a/extensions/cloudflow-support/src/cf-auth.ts
+++ b/extensions/cloudflow-support/src/cf-auth.ts
@@ -1,0 +1,121 @@
+/**
+ * Firebase Auth for CloudFlow Operations API.
+ *
+ * Uses Firebase Admin SDK to mint a custom token for the bot user,
+ * then exchanges it for an ID token via the Firebase Auth REST API.
+ *
+ * Required env vars:
+ *   CF_FIREBASE_API_KEY        — Firebase Web API key (for token exchange)
+ *   CF_FIREBASE_PROJECT_ID     — Firebase project ID (default: cloudflow-a78f0)
+ *   CF_FIREBASE_CLIENT_EMAIL   — Service account email
+ *   CF_FIREBASE_PRIVATE_KEY    — Service account private key (PEM, with \n)
+ *   CF_BOT_USER_UID            — UID of the bot user in Firestore users collection
+ *   CF_API_BASE_URL            — CloudFlow API base URL (default: https://cloudflow.cx)
+ */
+
+let cachedIdToken: { token: string; expiresAt: number } | null = null;
+
+function getEnv(key: string, fallback?: string): string {
+  const value = process.env[key]?.trim();
+  if (value) return value;
+  if (fallback !== undefined) return fallback;
+  throw new Error(`Missing required env var: ${key}`);
+}
+
+/**
+ * Create a custom token using Firebase Admin SDK approach (JWT signing).
+ * We sign a JWT with the service account credentials that Firebase Auth accepts.
+ */
+async function createCustomToken(uid: string): Promise<string> {
+  const clientEmail = getEnv("CF_FIREBASE_CLIENT_EMAIL");
+  const privateKeyRaw = getEnv("CF_FIREBASE_PRIVATE_KEY");
+  // Handle escaped newlines from env vars
+  const privateKey = privateKeyRaw.replace(/\\n/g, "\n");
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: clientEmail,
+    sub: clientEmail,
+    aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit",
+    iat: now,
+    exp: now + 3600,
+    uid,
+  };
+
+  const enc = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  const unsigned = `${enc(header)}.${enc(payload)}`;
+
+  const crypto = await import("crypto");
+  const sign = crypto.createSign("RSA-SHA256");
+  sign.update(unsigned);
+  const signature = sign.sign(privateKey, "base64url");
+
+  return `${unsigned}.${signature}`;
+}
+
+/**
+ * Exchange a custom token for a Firebase ID token via the REST API.
+ */
+async function exchangeCustomTokenForIdToken(customToken: string): Promise<{ idToken: string; expiresIn: number }> {
+  const apiKey = getEnv("CF_FIREBASE_API_KEY");
+  const resp = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: customToken, returnSecureToken: true }),
+    },
+  );
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Firebase token exchange failed (${resp.status}): ${body.slice(0, 300)}`);
+  }
+
+  const data = (await resp.json()) as { idToken?: string; expiresIn?: string };
+  if (!data.idToken) throw new Error("Firebase token exchange returned no idToken");
+
+  return {
+    idToken: data.idToken,
+    expiresIn: parseInt(data.expiresIn ?? "3600", 10),
+  };
+}
+
+/**
+ * Get a valid Firebase ID token for the bot user, with caching.
+ */
+export async function getFirebaseIdToken(): Promise<string> {
+  // Return cached token if still valid (with 60s buffer)
+  if (cachedIdToken && Date.now() < cachedIdToken.expiresAt - 60_000) {
+    return cachedIdToken.token;
+  }
+
+  const uid = getEnv("CF_BOT_USER_UID");
+  const customToken = await createCustomToken(uid);
+  const { idToken, expiresIn } = await exchangeCustomTokenForIdToken(customToken);
+
+  cachedIdToken = {
+    token: idToken,
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+
+  return cachedIdToken.token;
+}
+
+/**
+ * Get the CloudFlow API base URL.
+ */
+/**
+ * Clear the cached Firebase token (used for 401 retry).
+ */
+export function clearFirebaseToken(): void {
+  cachedIdToken = null;
+}
+
+/**
+ * Get the CloudFlow API base URL.
+ */
+export function getApiBaseUrl(): string {
+  return getEnv("CF_API_BASE_URL", "https://cloudflow.cx");
+}

--- a/extensions/cloudflow-support/src/cf-ops-tools.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.ts
@@ -1,0 +1,270 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, errorResult } from "./helpers.js";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { getFirebaseIdToken, getApiBaseUrl, clearFirebaseToken } from "./cf-auth.js";
+
+async function cfApi(path: string, opts?: { method?: string; body?: unknown; retried?: boolean }): Promise<unknown> {
+  const token = await getFirebaseIdToken();
+  const baseUrl = getApiBaseUrl();
+  const resp = await fetch(`${baseUrl}${path}`, {
+    method: opts?.method ?? "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    ...(opts?.body ? { body: JSON.stringify(opts.body) } : {}),
+  });
+
+  // 401 retry: clear cached token and retry once
+  if (resp.status === 401 && !opts?.retried) {
+    clearFirebaseToken();
+    return cfApi(path, { ...opts, retried: true });
+  }
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`CloudFlow API ${resp.status}: ${text.slice(0, 500)}`);
+  }
+
+  return resp.json();
+}
+
+async function executeOp(operationId: string, payload: Record<string, unknown>): Promise<unknown> {
+  return cfApi("/api/internal/ops/execute", {
+    method: "POST",
+    body: {
+      operationId,
+      requestId: crypto.randomUUID(),
+      payload,
+    },
+  });
+}
+
+export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // cf_discover_ops
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_discover_ops",
+        description: "List all available CloudFlow operations with their domains, descriptions, required scopes, and input/output schemas.",
+        parameters: Type.Object({}),
+        async execute(_id: string, _params: Record<string, unknown>) {
+          try {
+            const data = await cfApi("/api/internal/discovery");
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_execute_op
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_execute_op",
+        description: "Execute any CloudFlow operation by ID. Use cf_discover_ops first to see available operations and their required payloads.",
+        parameters: Type.Object({
+          operationId: Type.String({ description: "The operation ID (e.g., 'listTickets', 'getDeployment')" }),
+          payload: Type.Optional(Type.Object({}, { additionalProperties: true, description: "Operation-specific input payload" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const operationId = params.operationId as string;
+            const payload = (params.payload as Record<string, unknown>) ?? {};
+            const data = await executeOp(operationId, payload);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_list_tickets
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_list_tickets",
+        description: "List CloudFlow support tickets. Optionally filter by status or tenant.",
+        parameters: Type.Object({
+          status: Type.Optional(Type.String({ description: "Filter by ticket status (open, in_progress, resolved, closed)" })),
+          tenantId: Type.Optional(Type.String({ description: "Filter by tenant ID" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 25)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const payload: Record<string, unknown> = {};
+            if (params.status) payload.status = params.status;
+            if (params.tenantId) payload.tenantId = params.tenantId;
+            if (params.limit) payload.limit = params.limit;
+            const data = await executeOp("listTickets", payload);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_get_ticket
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_get_ticket",
+        description: "Get details of a specific CloudFlow support ticket including chat history.",
+        parameters: Type.Object({
+          ticketId: Type.String({ description: "Ticket document ID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = await executeOp("getTicket", { ticketId: params.ticketId });
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_list_deployments
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_list_deployments",
+        description: "List CloudFlow deployment workbooks with milestones and status.",
+        parameters: Type.Object({
+          tenantId: Type.Optional(Type.String({ description: "Filter by tenant ID" })),
+          status: Type.Optional(Type.String({ description: "Filter by deployment status" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const payload: Record<string, unknown> = {};
+            if (params.tenantId) payload.tenantId = params.tenantId;
+            if (params.status) payload.status = params.status;
+            const data = await executeOp("listDeployments", payload);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_get_deployment
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_get_deployment",
+        description: "Get details of a specific CloudFlow deployment workbook.",
+        parameters: Type.Object({
+          deploymentId: Type.String({ description: "Deployment document ID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = await executeOp("getDeployment", { deploymentId: params.deploymentId });
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_list_users
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_list_users",
+        description: "List CloudFlow platform users. Filter by role or search by name/email.",
+        parameters: Type.Object({
+          role: Type.Optional(Type.String({ description: "Filter by platform role (PM, PE, SM, Dev, HR)" })),
+          search: Type.Optional(Type.String({ description: "Search by name or email" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const payload: Record<string, unknown> = {};
+            if (params.role) payload.role = params.role;
+            if (params.search) payload.search = params.search;
+            const data = await executeOp("listUsers", payload);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_list_tenants
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_list_tenants",
+        description: "List CloudFlow customer tenants/organizations.",
+        parameters: Type.Object({
+          search: Type.Optional(Type.String({ description: "Search by tenant name" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const payload: Record<string, unknown> = {};
+            if (params.search) payload.search = params.search;
+            const data = await executeOp("listTenants", payload);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // cf_get_deploy_status
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_get_deploy_status",
+        description: "Check the latest Firebase App Hosting deployment status via GitHub Actions.",
+        parameters: Type.Object({
+          limit: Type.Optional(Type.Number({ description: "Number of recent runs to check (default 5)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const { execSync } = await import("child_process");
+            const limit = (params.limit as number) || 5;
+            const result = execSync(
+              `gh run list --repo cloudwarriors-ai/cloudflow --limit ${limit} --json databaseId,displayTitle,status,conclusion,createdAt,updatedAt,headBranch`,
+              {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            const data = JSON.parse(result);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/cloudflow-support/src/comfort.ts
+++ b/extensions/cloudflow-support/src/comfort.ts
@@ -1,0 +1,72 @@
+const CF_CHANNEL = "82a0a9b6ca134457b58151734ee5643b@conference.xmpp.zoom.us";
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+  const clientId = process.env.ZOOM_CLIENT_ID ?? "";
+  const clientSecret = process.env.ZOOM_CLIENT_SECRET ?? "";
+  const auth = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const resp = await fetch("https://zoom.us/oauth/token?grant_type=client_credentials", {
+    method: "POST",
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  if (!resp.ok) throw new Error(`Zoom token failed: ${resp.status}`);
+  const data = (await resp.json()) as { access_token: string; expires_in: number };
+  cachedToken = { token: data.access_token, expiresAt: Date.now() + data.expires_in * 1000 };
+  return cachedToken.token;
+}
+
+const COMFORT_MESSAGES = [
+  "On it — pulling up the details now...",
+  "Looking into that, one moment...",
+  "Checking CloudFlow, hang tight...",
+  "Gathering the info now...",
+  "Let me dig into that...",
+];
+
+export async function sendComfortMessage(
+  channelJid: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  if (channelJid !== CF_CHANNEL) return;
+
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!botJid || !accountId) return;
+
+  const text = COMFORT_MESSAGES[Math.floor(Math.random() * COMFORT_MESSAGES.length)];
+  const normalizedReplyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: {
+        head: { text: "CloudFlowSupport" },
+        body: [{ type: "message", text }],
+      },
+    };
+    if (normalizedReplyTo) {
+      body.reply_to = normalizedReplyTo;
+      body.reply_main_message_id = normalizedReplyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[cf] comfort message failed:", err);
+  }
+}

--- a/extensions/cloudflow-support/src/gh-tools.ts
+++ b/extensions/cloudflow-support/src/gh-tools.ts
@@ -1,0 +1,223 @@
+import { Type } from "@sinclair/typebox";
+import { execSync } from "child_process";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, errorResult } from "./helpers.js";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import {
+  buildStakeholderWorkPrefix,
+  extractStakeholdersFromIssue,
+  formatStakeholderBlock,
+  parseIssueNumberFromUrl,
+  resolveStakeholderDmTarget,
+  upsertStakeholderBlock,
+} from "./stakeholders.js";
+import { sendStakeholderZoomDm } from "./zoom-dm.js";
+
+type PluginConfig = { cfRepos?: string[] };
+
+function getAllowedRepos(config: PluginConfig): string[] {
+  return config.cfRepos ?? ["cloudwarriors-ai/cloudflow"];
+}
+
+function assertAllowedRepo(repo: string, config: PluginConfig) {
+  const allowed = getAllowedRepos(config);
+  if (!allowed.includes(repo)) throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
+}
+
+function gh(args: string): unknown {
+  const result = execSync(`gh ${args}`, {
+    encoding: "utf-8",
+    timeout: 30000,
+    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+  });
+  try { return JSON.parse(result); } catch { return result.trim(); }
+}
+
+type GhIssueLike = {
+  number?: number; url?: string; title?: string; body?: string;
+  assignees?: Array<{ login?: string }>; comments?: Array<{ body?: string }>;
+};
+
+function stringifyReason(reason: unknown): string {
+  const raw = typeof reason === "string" ? reason.trim().toLowerCase() : "";
+  return raw === "not_planned" ? "not planned" : "completed";
+}
+
+function formatDmMessage(p: { issueNumber: number; issueTitle: string; repo: string; closedBy?: string; closingComment?: string }): string {
+  const url = `https://github.com/${p.repo}/issues/${p.issueNumber}`;
+  return [
+    `Issue #${p.issueNumber} was updated and closed: ${p.issueTitle}`,
+    p.closedBy ? `Closed by: ${p.closedBy}` : undefined,
+    p.closingComment ? `Update: ${p.closingComment}` : undefined,
+    url,
+  ].filter(Boolean).join("\n");
+}
+
+export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_list_issues",
+    description: "List GitHub issues from the CloudFlow repo.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary CF repo." })),
+      state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+      label: Type.Optional(Type.String({ description: "Filter by label" })),
+      limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const state = (params.state as string) || "open";
+        const limit = (params.limit as number) || 30;
+        const labelFlag = params.label ? ` --label "${params.label}"` : "";
+        const data = gh(`issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`);
+        return jsonResult({ ok: true, data });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_get_issue",
+    description: "Get details of a specific GitHub issue including comments and stakeholder metadata.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+      number: Type.Number({ description: "Issue number" }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const data = gh(`issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`) as GhIssueLike;
+        const stakeholders = extractStakeholdersFromIssue(data);
+        return jsonResult({ ok: true, data, stakeholders });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_create_issue",
+    description: "Create a new GitHub issue in the CloudFlow repo with stakeholder metadata.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+      title: Type.String({ description: "Issue title" }),
+      body: Type.String({ description: "Issue body (markdown)" }),
+      labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
+      reporter: Type.Optional(Type.String({ description: "Reporter identity." })),
+      stakeholders: Type.Optional(Type.Array(Type.String(), { description: "Additional stakeholder identities." })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const labels = params.labels as string[] | undefined;
+        const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+        const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+        const stakeholders = Array.isArray(params.stakeholders) ? (params.stakeholders as string[]) : [];
+        const enrichedBody = upsertStakeholderBlock(String(params.body ?? ""), { reporter, stakeholders });
+        const result = execSync(
+          `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+          { encoding: "utf-8", input: enrichedBody, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" } },
+        );
+        const url = result.trim();
+        const issueNumber = parseIssueNumberFromUrl(url);
+        if (issueNumber) {
+          execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+            encoding: "utf-8", input: formatStakeholderBlock({ reporter, stakeholders }), timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+          });
+        }
+        return jsonResult({ ok: true, url, issueNumber, reporter, stakeholders, metadataSaved: Boolean(issueNumber) });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_add_comment",
+    description: "Add a comment to a GitHub issue. Auto-mentions stored stakeholders.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+      number: Type.Number({ description: "Issue number" }),
+      body: Type.String({ description: "Comment body (markdown)" }),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const issue = gh(`issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`) as GhIssueLike;
+        const extracted = extractStakeholdersFromIssue(issue);
+        const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+        const originalBody = String(params.body ?? "");
+        const body = prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody) ? `${prefix}\n\n${originalBody}` : originalBody;
+        const result = execSync(`gh issue comment ${params.number} --repo ${repo} --body-file -`, {
+          encoding: "utf-8", input: body, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+        });
+        return jsonResult({ ok: true, url: result.trim(), stakeholders: extracted.stakeholders, reporter: extracted.reporter });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_search_issues",
+    description: "Search GitHub issues by keyword in CloudFlow repos.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+      limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const limit = (params.limit as number) || 20;
+        const query = (params.query as string).replace(/"/g, '\\"');
+        const data = gh(`search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`);
+        return jsonResult({ ok: true, data });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+
+  api.registerTool(() => wrapToolWithAudit({
+    name: "cf_gh_close_issue",
+    description: "Close a GitHub issue, mention stakeholders, and DM them on Zoom.",
+    parameters: Type.Object({
+      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+      number: Type.Number({ description: "Issue number" }),
+      comment: Type.Optional(Type.String({ description: "Closing comment." })),
+      reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      try {
+        const repo = (params.repo as string) || getAllowedRepos(config)[0];
+        assertAllowedRepo(repo, config);
+        const issueNumber = Number(params.number);
+        const closeReason = stringifyReason(params.reason);
+        const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
+        const issue = gh(`issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`) as GhIssueLike;
+        const extracted = extractStakeholdersFromIssue(issue);
+        const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+        if (closingComment || prefix) {
+          const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+          if (commentBody) execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+            encoding: "utf-8", input: commentBody, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+          });
+        }
+        const closeOutput = execSync(`gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`, {
+          encoding: "utf-8", timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+        }).trim();
+        const dmTargets = extracted.stakeholders
+          .map((s) => resolveStakeholderDmTarget(s, { mapEnv: process.env.CF_STAKEHOLDER_MAP, defaultDomain: process.env.CF_STAKEHOLDER_EMAIL_DOMAIN }))
+          .filter((v): v is string => Boolean(v));
+        const uniqueTargets = [...new Set(dmTargets.map((t) => t.toLowerCase()))];
+        const dmMessage = formatDmMessage({ issueNumber, issueTitle: issue.title || `Issue ${issueNumber}`, repo, closedBy: "cloudflow-support", closingComment });
+        const notified: string[] = [];
+        const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+        for (const target of uniqueTargets) {
+          const r = await sendStakeholderZoomDm({ toContact: target, message: dmMessage });
+          if (r.ok) notified.push(target);
+          else notifyErrors.push({ stakeholder: target, error: r.error ?? "unknown" });
+        }
+        return jsonResult({ ok: true, number: issueNumber, repo, closeOutput, closeReason, stakeholders: extracted.stakeholders, reporter: extracted.reporter, notified, notifyErrors });
+      } catch (err) { return errorResult(err); }
+    },
+  }, logger));
+}

--- a/extensions/cloudflow-support/src/helpers.ts
+++ b/extensions/cloudflow-support/src/helpers.ts
@@ -1,0 +1,8 @@
+export function jsonResult(data: unknown): { content: { type: "text"; text: string }[] } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function errorResult(err: unknown): { content: { type: "text"; text: string }[] } {
+  const message = err instanceof Error ? err.message : String(err);
+  return jsonResult({ ok: false, error: message });
+}

--- a/extensions/cloudflow-support/src/stakeholders.ts
+++ b/extensions/cloudflow-support/src/stakeholders.ts
@@ -1,0 +1,200 @@
+const STAKEHOLDER_BLOCK_START = "<!-- cf:stakeholders:start -->";
+const STAKEHOLDER_BLOCK_END = "<!-- cf:stakeholders:end -->";
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const GH_MENTION_RE = /(^|[^\w])@([a-z0-9](?:-?[a-z0-9]){0,38})(?=$|[^\w-])/gi;
+
+export type StakeholderSet = {
+  reporter?: string;
+  stakeholders: string[];
+};
+
+type IssueCommentLike = { body?: string };
+type IssueLike = {
+  body?: string;
+  assignees?: Array<{ login?: string }>;
+  comments?: IssueCommentLike[];
+};
+
+export function normalizeStakeholder(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const cleaned = trimmed.replace(/^mailto:/i, "").replace(/[<>]/g, "").trim();
+  if (!cleaned) return null;
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(cleaned)) return cleaned.toLowerCase();
+  if (/@xmpp\.zoom\.us$/i.test(cleaned)) return cleaned.toLowerCase();
+  if (/^@[a-z0-9](?:-?[a-z0-9]){0,38}$/i.test(cleaned)) return cleaned.toLowerCase();
+  if (/^[a-z0-9](?:-?[a-z0-9]){0,38}$/i.test(cleaned)) return `@${cleaned.toLowerCase()}`;
+  return cleaned;
+}
+
+function uniquePreserveOrder(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = normalizeStakeholder(value);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(normalized);
+  }
+  return out;
+}
+
+function parseStakeholderList(raw: string): string[] {
+  return uniquePreserveOrder(raw.split(/[,\n]/g).map((token) => token.trim()).filter(Boolean));
+}
+
+function extractEmails(text: string): string[] {
+  return uniquePreserveOrder(text.match(EMAIL_RE) ?? []);
+}
+
+function extractMentions(text: string): string[] {
+  const mentions: string[] = [];
+  let match: RegExpExecArray | null;
+  GH_MENTION_RE.lastIndex = 0;
+  while ((match = GH_MENTION_RE.exec(text)) !== null) {
+    mentions.push(`@${match[2]}`);
+  }
+  return uniquePreserveOrder(mentions);
+}
+
+export function formatStakeholderBlock(input: StakeholderSet): string {
+  const reporter = normalizeStakeholder(input.reporter ?? "") ?? "unknown";
+  const stakeholders = uniquePreserveOrder([reporter, ...input.stakeholders]);
+  return [
+    STAKEHOLDER_BLOCK_START,
+    `Reporter: ${reporter}`,
+    `Stakeholders: ${stakeholders.join(", ") || "none"}`,
+    STAKEHOLDER_BLOCK_END,
+  ].join("\n");
+}
+
+export function upsertStakeholderBlock(body: string, input: StakeholderSet): string {
+  const block = formatStakeholderBlock(input);
+  const source = body.trim();
+  const blockRe = new RegExp(
+    `${escapeForRegex(STAKEHOLDER_BLOCK_START)}[\\s\\S]*?${escapeForRegex(STAKEHOLDER_BLOCK_END)}`,
+    "i",
+  );
+  if (blockRe.test(source)) return source.replace(blockRe, block).trim();
+  if (!source) return block;
+  return `${source}\n\n${block}`.trim();
+}
+
+function parseBlock(text: string): StakeholderSet {
+  const out: StakeholderSet = { stakeholders: [] };
+  for (const line of text.split(/\r?\n/g)) {
+    const reporterMatch = line.match(/^\s*Reporter:\s*(.+)\s*$/i);
+    if (reporterMatch) { out.reporter = normalizeStakeholder(reporterMatch[1]) ?? out.reporter; continue; }
+    const stakeholdersMatch = line.match(/^\s*Stakeholders:\s*(.+)\s*$/i);
+    if (stakeholdersMatch) out.stakeholders = uniquePreserveOrder([...out.stakeholders, ...parseStakeholderList(stakeholdersMatch[1])]);
+  }
+  if (out.reporter) out.stakeholders = uniquePreserveOrder([out.reporter, ...out.stakeholders]);
+  return out;
+}
+
+function parseStakeholderBlocks(text: string): StakeholderSet {
+  const out: StakeholderSet = { stakeholders: [] };
+  const blockRe = new RegExp(`${escapeForRegex(STAKEHOLDER_BLOCK_START)}([\\s\\S]*?)${escapeForRegex(STAKEHOLDER_BLOCK_END)}`, "gi");
+  let match: RegExpExecArray | null;
+  while ((match = blockRe.exec(text)) !== null) {
+    const parsed = parseBlock(match[1] ?? "");
+    if (!out.reporter && parsed.reporter) out.reporter = parsed.reporter;
+    out.stakeholders = uniquePreserveOrder([...out.stakeholders, ...parsed.stakeholders]);
+  }
+  return out;
+}
+
+function collectFromText(text: string): StakeholderSet {
+  const block = parseStakeholderBlocks(text);
+  const fallbackReporter = (() => {
+    const line = text.match(/^\s*Reporter:\s*(.+)\s*$/im)?.[1];
+    return line ? normalizeStakeholder(line) ?? undefined : undefined;
+  })();
+  const inlineStakeholders = (() => {
+    const line = text.match(/^\s*Stakeholders:\s*(.+)\s*$/im)?.[1];
+    return line ? parseStakeholderList(line) : [];
+  })();
+  const discovered = uniquePreserveOrder([...block.stakeholders, ...inlineStakeholders, ...extractEmails(text), ...extractMentions(text)]);
+  return {
+    reporter: block.reporter ?? fallbackReporter,
+    stakeholders: block.reporter ? uniquePreserveOrder([block.reporter, ...discovered]) : discovered,
+  };
+}
+
+export function extractStakeholdersFromIssue(issue: IssueLike): StakeholderSet {
+  const combined: StakeholderSet = { stakeholders: [] };
+  const fromIssue = collectFromText(typeof issue.body === "string" ? issue.body : "");
+  combined.reporter = fromIssue.reporter;
+  combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, ...fromIssue.stakeholders]);
+  for (const assignee of issue.assignees ?? []) {
+    const mention = normalizeStakeholder(`@${assignee.login ?? ""}`);
+    if (mention) combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, mention]);
+  }
+  for (const comment of issue.comments ?? []) {
+    const fromComment = collectFromText(typeof comment.body === "string" ? comment.body : "");
+    if (!combined.reporter && fromComment.reporter) combined.reporter = fromComment.reporter;
+    combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, ...fromComment.stakeholders]);
+  }
+  if (combined.reporter) combined.stakeholders = uniquePreserveOrder([combined.reporter, ...combined.stakeholders]);
+  return combined;
+}
+
+export function buildStakeholderWorkPrefix(stakeholders: string[]): string {
+  const normalized = uniquePreserveOrder(stakeholders);
+  if (normalized.length === 0) return "";
+  const mentions = normalized.filter((t) => t.startsWith("@"));
+  const lines: string[] = [];
+  if (mentions.length > 0) lines.push(`/cc ${mentions.join(" ")}`);
+  lines.push(`Stakeholders: ${normalized.join(", ")}`);
+  return lines.join("\n");
+}
+
+export function parseIssueNumberFromUrl(url: string): number | null {
+  const match = url.match(/\/issues\/(\d+)\b/);
+  return match ? (Number.isFinite(Number(match[1])) ? Number(match[1]) : null) : null;
+}
+
+export function resolveStakeholderDmTarget(input: string, params?: { mapEnv?: string; defaultDomain?: string }): string | null {
+  const normalized = normalizeStakeholder(input);
+  if (!normalized) return null;
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized)) return normalized;
+  if (/@xmpp\.zoom\.us$/i.test(normalized)) return normalized;
+  const username = normalized.startsWith("@") ? normalized.slice(1) : normalized;
+  if (!username) return null;
+  const explicit = parseStakeholderMap(params?.mapEnv);
+  const mapped = explicit.get(username.toLowerCase());
+  if (mapped) return mapped;
+  const domain = params?.defaultDomain?.trim();
+  if (!domain) return null;
+  return `${username.toLowerCase()}@${domain.replace(/^@/, "").toLowerCase()}`;
+}
+
+function parseStakeholderMap(raw: string | undefined): Map<string, string> {
+  const mapping = new Map<string, string>();
+  const source = raw?.trim();
+  if (!source) return mapping;
+  if (source.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(source) as Record<string, unknown>;
+      for (const [key, value] of Object.entries(parsed)) {
+        const nv = normalizeStakeholder(String(value ?? ""));
+        const nk = key.trim().toLowerCase().replace(/^@/, "");
+        if (nk && nv) mapping.set(nk, nv);
+      }
+      return mapping;
+    } catch { /* fall through */ }
+  }
+  for (const pair of source.split(/[,\n]/g)) {
+    const [keyRaw, valueRaw] = pair.split("=");
+    const key = keyRaw?.trim().toLowerCase().replace(/^@/, "");
+    const value = normalizeStakeholder(valueRaw ?? "");
+    if (key && value) mapping.set(key, value);
+  }
+  return mapping;
+}
+
+function escapeForRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/extensions/cloudflow-support/src/zoom-dm.ts
+++ b/extensions/cloudflow-support/src/zoom-dm.ts
@@ -1,0 +1,97 @@
+type ZoomDmResult = {
+  ok: boolean;
+  error?: string;
+};
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+function hasValue(value: string | undefined): value is string {
+  return Boolean(value && value.trim());
+}
+
+async function getZoomReportToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+
+  const clientId = process.env.ZOOM_REPORT_CLIENT_ID?.trim();
+  const clientSecret = process.env.ZOOM_REPORT_CLIENT_SECRET?.trim();
+  const accountId = process.env.ZOOM_REPORT_ACCOUNT_ID?.trim() || process.env.ZOOM_ACCOUNT_ID?.trim();
+  if (!hasValue(clientId) || !hasValue(clientSecret) || !hasValue(accountId)) {
+    throw new Error(
+      "Zoom report credentials missing. Set ZOOM_REPORT_CLIENT_ID/ZOOM_REPORT_CLIENT_SECRET/ZOOM_REPORT_ACCOUNT_ID.",
+    );
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const response = await fetch(
+    `https://zoom.us/oauth/token?grant_type=account_credentials&account_id=${encodeURIComponent(accountId)}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Basic ${basic}` },
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Zoom token request failed (${response.status}): ${body.slice(0, 300)}`);
+  }
+
+  const data = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token || !data.expires_in) {
+    throw new Error("Zoom token response missing access_token/expires_in.");
+  }
+
+  cachedToken = {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+  return cachedToken.token;
+}
+
+export async function sendStakeholderZoomDm(params: {
+  toContact: string;
+  message: string;
+  fromUser?: string;
+}): Promise<ZoomDmResult> {
+  const toContact = params.toContact.trim();
+  if (!toContact) return { ok: false, error: "missing toContact" };
+
+  const fromUser =
+    params.fromUser?.trim() ||
+    process.env.ZOOM_REPORT_USER?.trim() ||
+    process.env.MENTION_PROXY?.trim();
+  if (!fromUser) {
+    return {
+      ok: false,
+      error: "missing from user (set ZOOM_REPORT_USER or MENTION_PROXY)",
+    };
+  }
+
+  try {
+    const token = await getZoomReportToken();
+    const response = await fetch(
+      `https://api.zoom.us/v2/chat/users/${encodeURIComponent(fromUser)}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          to_contact: toContact,
+          message: params.message,
+        }),
+      },
+    );
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        ok: false,
+        error: `zoom dm failed (${response.status}): ${body.slice(0, 300)}`,
+      };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/extensions/external-org-autopilot/index.ts
+++ b/extensions/external-org-autopilot/index.ts
@@ -1,0 +1,49 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createAuditLogger } from "./src/audit.js";
+import { registerGhTools } from "./src/gh-tools.js";
+import { registerEoaCliTools } from "./src/eoa-cli-tools.js";
+import { registerEoaStateTools } from "./src/eoa-state-tools.js";
+import { sendComfortMessage } from "./src/comfort.js";
+
+type PluginConfig = { eoaRepos?: string[] };
+
+const plugin = {
+  id: "external-org-autopilot",
+  name: "EOAutopilot",
+  description: "External Org Autopilot onboarding, sync, execution, and reporting tools",
+  configSchema: {
+    type: "object" as const,
+    additionalProperties: false,
+    properties: {
+      eoaRepos: {
+        type: "array",
+        items: { type: "string" },
+        default: ["cloudwarriors-ai/external-org-autopilot"],
+        description: "GitHub repos scoped for EOA issue management",
+      },
+    },
+  },
+
+  register(api: OpenClawPluginApi, config?: PluginConfig) {
+    const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
+    const logger = createAuditLogger(workspaceDir);
+    const pluginConfig: PluginConfig = config ?? { eoaRepos: ["cloudwarriors-ai/external-org-autopilot"] };
+
+    registerEoaCliTools(api, logger);
+    registerEoaStateTools(api, logger);
+    registerGhTools(api, logger, pluginConfig);
+
+    // Send comfort message when a message arrives in the EOA channel
+    api.on("message_received", async (event, ctx) => {
+      if (ctx.channelId === "zoom" && ctx.conversationId) {
+        const messageId =
+          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+        void sendComfortMessage(ctx.conversationId, messageId);
+      }
+    });
+
+    console.log("[external-org-autopilot] Registered 23 tools (11 CLI + 6 state + 6 GH)");
+  },
+};
+
+export default plugin;

--- a/extensions/external-org-autopilot/openclaw.plugin.json
+++ b/extensions/external-org-autopilot/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "external-org-autopilot",
+  "name": "EOAutopilot",
+  "description": "External Org Autopilot onboarding, sync, execution, and reporting tools",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "eoaRepos": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["cloudwarriors-ai/external-org-autopilot"],
+        "description": "GitHub repos scoped for EOA issue management"
+      }
+    }
+  }
+}

--- a/extensions/external-org-autopilot/src/audit.ts
+++ b/extensions/external-org-autopilot/src/audit.ts
@@ -1,0 +1,96 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface AuditEntry {
+  ts: string;
+  tool: string;
+  actor: string;
+  trigger?: string;
+  params?: Record<string, unknown>;
+  resultSummary?: string;
+  durationMs?: number;
+  error?: string;
+}
+
+export function createAuditLogger(workspaceDir: string) {
+  const auditDir = path.join(workspaceDir, "external-org-autopilot");
+  const auditFile = path.join(auditDir, "audit.jsonl");
+
+  try {
+    fs.mkdirSync(auditDir, { recursive: true });
+  } catch {
+    // ignore if exists
+  }
+
+  return function logAudit(entry: AuditEntry) {
+    const line = JSON.stringify(entry) + "\n";
+    try {
+      fs.appendFileSync(auditFile, line);
+    } catch (err) {
+      console.error("[eoa-audit] Failed to write audit log:", err);
+    }
+  };
+}
+
+export type AuditLogger = ReturnType<typeof createAuditLogger>;
+
+export function wrapToolWithAudit(
+  toolDef: {
+    name: string;
+    description: string;
+    parameters: unknown;
+    execute: (id: string, params: Record<string, unknown>) => Promise<{ content: { type: "text"; text: string }[] }>;
+  },
+  logger: AuditLogger,
+) {
+  const origExecute = toolDef.execute;
+  toolDef.execute = async (id: string, params: Record<string, unknown>) => {
+    const start = Date.now();
+    try {
+      const result = await origExecute(id, params);
+      const durationMs = Date.now() - start;
+      let resultSummary = "";
+      try {
+        const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+        if (parsed.ok === false) resultSummary = `error: ${parsed.error ?? "unknown"}`;
+        else if (Array.isArray(parsed.data)) resultSummary = `${parsed.data.length} items`;
+        else resultSummary = "ok";
+      } catch {
+        resultSummary = "ok";
+      }
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "external-org-autopilot",
+        params: sanitizeParams(params),
+        resultSummary,
+        durationMs,
+      });
+      return result;
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "external-org-autopilot",
+        params: sanitizeParams(params),
+        error: err instanceof Error ? err.message : String(err),
+        durationMs,
+      });
+      throw err;
+    }
+  };
+  return toolDef;
+}
+
+function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (typeof v === "string" && v.length > 200) {
+      clean[k] = v.slice(0, 200) + "...[truncated]";
+    } else {
+      clean[k] = v;
+    }
+  }
+  return clean;
+}

--- a/extensions/external-org-autopilot/src/comfort.ts
+++ b/extensions/external-org-autopilot/src/comfort.ts
@@ -1,0 +1,72 @@
+const EOA_CHANNEL = "2edb7334f4d6497997dfed97c42dc862@conference.xmpp.zoom.us";
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+  const clientId = process.env.ZOOM_CLIENT_ID ?? "";
+  const clientSecret = process.env.ZOOM_CLIENT_SECRET ?? "";
+  const auth = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const resp = await fetch("https://zoom.us/oauth/token?grant_type=client_credentials", {
+    method: "POST",
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  if (!resp.ok) throw new Error(`Zoom token failed: ${resp.status}`);
+  const data = (await resp.json()) as { access_token: string; expires_in: number };
+  cachedToken = { token: data.access_token, expiresAt: Date.now() + data.expires_in * 1000 };
+  return cachedToken.token;
+}
+
+const COMFORT_MESSAGES = [
+  "On it — pulling up the details now...",
+  "Looking into that, one moment...",
+  "Checking the autopilot state, hang tight...",
+  "Gathering the info now...",
+  "Let me dig into that...",
+];
+
+export async function sendComfortMessage(
+  channelJid: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  if (channelJid !== EOA_CHANNEL) return;
+
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!botJid || !accountId) return;
+
+  const text = COMFORT_MESSAGES[Math.floor(Math.random() * COMFORT_MESSAGES.length)];
+  const normalizedReplyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: {
+        head: { text: "EOAutopilot" },
+        body: [{ type: "message", text }],
+      },
+    };
+    if (normalizedReplyTo) {
+      body.reply_to = normalizedReplyTo;
+      body.reply_main_message_id = normalizedReplyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[eoa] comfort message failed:", err);
+  }
+}

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.ts
@@ -1,0 +1,276 @@
+import { Type } from "@sinclair/typebox";
+import { execSync } from "child_process";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, errorResult } from "./helpers.js";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+
+const EOA_ROOT = "/root/code/external-org-autopilot";
+
+function eoa(args: string, timeoutMs = 120000): unknown {
+  const result = execSync(`npx tsx src/cli.ts ${args}`, {
+    encoding: "utf-8",
+    cwd: EOA_ROOT,
+    timeout: timeoutMs,
+    env: { ...process.env },
+  });
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result.trim();
+  }
+}
+
+export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // eoa_release_validate
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_release_validate",
+        description: "Validate a release JSON contract. Returns the validated release object.",
+        parameters: Type.Object({
+          releasePath: Type.String({ description: "Path to the release JSON file" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`release validate ${params.releasePath}`);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_release_lock
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_release_lock",
+        description: "Lock a release JSON with pinned SHAs. Returns the locked release object.",
+        parameters: Type.Object({
+          releasePath: Type.String({ description: "Path to the release JSON file" }),
+          outPath: Type.String({ description: "Output path for the locked release file" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`release lock ${params.releasePath} --out ${params.outPath}`);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_onboard_project
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_onboard_project",
+        description: "Onboard a new customer project. Takes a release JSON and onboarding YAML. Returns {customerRepo, mirrorRepo}.",
+        parameters: Type.Object({
+          releasePath: Type.String({ description: "Path to the release JSON contract" }),
+          onboardingPath: Type.String({ description: "Path to the onboarding YAML contract" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`customer onboard ${params.releasePath} ${params.onboardingPath}`, 300000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_doctor
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_doctor",
+        description: "Run health checks on a customer repo. Returns {ok, checks[]}.",
+        parameters: Type.Object({
+          customerRepoId: Type.String({ description: "Customer repo UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`customer doctor ${params.customerRepoId}`);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_sync
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_sync",
+        description: "Pull latest from customer repo. Returns {sourceSha, shadowMainSha, driftDetected}.",
+        parameters: Type.Object({
+          customerRepoId: Type.String({ description: "Customer repo UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`sync pull ${params.customerRepoId}`, 180000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_ingest_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_ingest_issue",
+        description: "Ingest a single issue from the customer repo. Returns {issueMirrorId, baselineSha}.",
+        parameters: Type.Object({
+          customerRepoId: Type.String({ description: "Customer repo UUID" }),
+          issueNumber: Type.Number({ description: "GitHub issue number to ingest" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`issue ingest ${params.customerRepoId} ${params.issueNumber}`);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_ingest_batch
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_ingest_batch",
+        description: "Batch ingest issues from a customer repo. Returns {ingested[], skipped[]}.",
+        parameters: Type.Object({
+          customerRepoId: Type.String({ description: "Customer repo UUID" }),
+          limit: Type.Optional(Type.Number({ description: "Max issues to ingest (optional)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const limitFlag = params.limit ? ` --limit ${params.limit}` : "";
+            const data = eoa(`issue ingest-batch ${params.customerRepoId}${limitFlag}`, 300000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_run_execute
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_run_execute",
+        description: "Execute a fix run for an issue mirror. Returns {run, evidenceBundleId}.",
+        parameters: Type.Object({
+          issueMirrorId: Type.String({ description: "Issue mirror UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`run execute ${params.issueMirrorId} --detach`, 300000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_run_resume
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_run_resume",
+        description: "Resume a previously started run. Returns {run, evidenceBundleId}.",
+        parameters: Type.Object({
+          runId: Type.String({ description: "Run UUID to resume" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`run resume ${params.runId}`, 300000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_smoke_test
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_smoke_test",
+        description: "Run a full pipeline smoke test. Returns the complete pipeline result.",
+        parameters: Type.Object({
+          releasePath: Type.String({ description: "Path to release contract" }),
+          onboardingPath: Type.String({ description: "Path to onboarding contract" }),
+          issueNumber: Type.Number({ description: "Issue number to test" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(
+              `smoke run ${params.releasePath} ${params.onboardingPath} ${params.issueNumber} --detach`,
+              600000,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_report
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_report",
+        description: "Generate a customer report with all runs. Returns the full CustomerReport.",
+        parameters: Type.Object({
+          customerRepoId: Type.String({ description: "Customer repo UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const data = eoa(`report generate ${params.customerRepoId}`, 180000);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/external-org-autopilot/src/eoa-state-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-state-tools.ts
@@ -1,0 +1,200 @@
+import { Type } from "@sinclair/typebox";
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, errorResult } from "./helpers.js";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+
+const STATE_DIR = "/root/code/external-org-autopilot/.autopilot-state";
+
+export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // eoa_list_runs
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_list_runs",
+        description: "List all autopilot runs. Optionally filter by mirrorRepoId.",
+        parameters: Type.Object({
+          mirrorRepoId: Type.Optional(Type.String({ description: "Filter runs by mirror repo UUID" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const runsDir = path.join(STATE_DIR, "autopilot-runs");
+            if (!fs.existsSync(runsDir)) {
+              return jsonResult({ ok: true, data: [], message: "No runs directory found" });
+            }
+            const files = fs.readdirSync(runsDir).filter((f) => f.endsWith(".json"));
+            const runs = files.map((f) => {
+              const content = fs.readFileSync(path.join(runsDir, f), "utf-8");
+              try {
+                return JSON.parse(content);
+              } catch {
+                return { file: f, parseError: true };
+              }
+            });
+            const mirrorFilter = params.mirrorRepoId as string | undefined;
+            const filtered = mirrorFilter
+              ? runs.filter((r: Record<string, unknown>) => r.mirrorRepoId === mirrorFilter)
+              : runs;
+            return jsonResult({ ok: true, data: filtered, total: filtered.length });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_get_run
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_get_run",
+        description: "Read a specific autopilot run status by ID.",
+        parameters: Type.Object({
+          runId: Type.String({ description: "Run UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const filePath = path.join(STATE_DIR, "autopilot-runs", `${params.runId}.json`);
+            if (!fs.existsSync(filePath)) {
+              return jsonResult({ ok: false, error: `Run ${params.runId} not found` });
+            }
+            const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_get_evidence
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_get_evidence",
+        description: "Read a full evidence bundle by ID. Contains verdict, validation summary, runtime evidence, worker summary, and artifact links.",
+        parameters: Type.Object({
+          bundleId: Type.String({ description: "Evidence bundle UUID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const filePath = path.join(STATE_DIR, "evidence-bundles", `${params.bundleId}.json`);
+            if (!fs.existsSync(filePath)) {
+              return jsonResult({ ok: false, error: `Evidence bundle ${params.bundleId} not found` });
+            }
+            const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_get_workflow_status
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_get_workflow_status",
+        description: "Check a GitHub Actions workflow run status. Returns status, conclusion, and jobs.",
+        parameters: Type.Object({
+          workflowRunId: Type.String({ description: "GitHub Actions workflow run ID" }),
+          repo: Type.String({ description: "Shadow repo (owner/name) from the run JSON." }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = params.repo as string;
+            if (!repo) {
+              return jsonResult({ ok: false, error: "repo is required (shadow repo from run JSON)" });
+            }
+            const result = execSync(
+              `gh run view ${params.workflowRunId} --repo ${repo} --json status,conclusion,jobs,name,createdAt,updatedAt`,
+              {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            const data = JSON.parse(result);
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_get_workflow_logs
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_get_workflow_logs",
+        description: "Download full workflow logs from GitHub Actions. Returns the log output.",
+        parameters: Type.Object({
+          workflowRunId: Type.String({ description: "GitHub Actions workflow run ID" }),
+          repo: Type.String({ description: "Shadow repo (owner/name)" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const result = execSync(
+              `gh run view ${params.workflowRunId} --repo ${params.repo} --log`,
+              {
+                encoding: "utf-8",
+                timeout: 60000,
+                maxBuffer: 10 * 1024 * 1024,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            // Truncate if very large
+            const output = result.length > 50000 ? result.slice(-50000) + "\n...[truncated to last 50k chars]" : result;
+            return jsonResult({ ok: true, data: output });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_get_commit_diff
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_get_commit_diff",
+        description: "View what changed in a specific commit (the diff Claude produced).",
+        parameters: Type.Object({
+          sha: Type.String({ description: "Commit SHA" }),
+          repo: Type.String({ description: "Shadow repo (owner/name)" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const result = execSync(
+              `gh api repos/${params.repo}/commits/${params.sha} --jq '.files[] | {filename, status, additions, deletions, patch}'`,
+              {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            return jsonResult({ ok: true, data: result.trim() });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/external-org-autopilot/src/gh-tools.ts
+++ b/extensions/external-org-autopilot/src/gh-tools.ts
@@ -1,0 +1,392 @@
+import { Type } from "@sinclair/typebox";
+import { execSync } from "child_process";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { jsonResult, errorResult } from "./helpers.js";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import {
+  buildStakeholderWorkPrefix,
+  extractStakeholdersFromIssue,
+  formatStakeholderBlock,
+  parseIssueNumberFromUrl,
+  resolveStakeholderDmTarget,
+  upsertStakeholderBlock,
+} from "./stakeholders.js";
+import { sendStakeholderZoomDm } from "./zoom-dm.js";
+
+type PluginConfig = { eoaRepos?: string[] };
+
+function getAllowedRepos(config: PluginConfig): string[] {
+  return config.eoaRepos ?? ["cloudwarriors-ai/external-org-autopilot"];
+}
+
+function assertAllowedRepo(repo: string, config: PluginConfig) {
+  const allowed = getAllowedRepos(config);
+  if (!allowed.includes(repo)) {
+    throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
+  }
+}
+
+function gh(args: string): unknown {
+  const result = execSync(`gh ${args}`, {
+    encoding: "utf-8",
+    timeout: 30000,
+    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+  });
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result.trim();
+  }
+}
+
+type GhIssueLike = {
+  number?: number;
+  url?: string;
+  title?: string;
+  body?: string;
+  assignees?: Array<{ login?: string }>;
+  comments?: Array<{ body?: string }>;
+};
+
+function stringifyReason(reason: unknown): string {
+  const raw = typeof reason === "string" ? reason.trim().toLowerCase() : "";
+  return raw === "not_planned" ? "not planned" : "completed";
+}
+
+function formatStakeholderDmMessage(params: {
+  issueNumber: number;
+  issueTitle: string;
+  repo: string;
+  closedBy?: string;
+  closingComment?: string;
+}): string {
+  const issueUrl = `https://github.com/${params.repo}/issues/${params.issueNumber}`;
+  const lines = [
+    `Issue #${params.issueNumber} was updated and closed: ${params.issueTitle}`,
+    params.closedBy ? `Closed by: ${params.closedBy}` : undefined,
+    params.closingComment ? `Update: ${params.closingComment}` : undefined,
+    issueUrl,
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+
+export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+  // eoa_gh_list_issues
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_list_issues",
+        description: "List GitHub issues from the external-org-autopilot repo. Returns title, number, state, labels, assignees.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+          label: Type.Optional(Type.String({ description: "Filter by label" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const state = (params.state as string) || "open";
+            const limit = (params.limit as number) || 30;
+            const labelFlag = params.label ? ` --label "${params.label}"` : "";
+            const data = gh(
+              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_gh_get_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_get_issue",
+        description: "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          number: Type.Number({ description: "Issue number" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const data = gh(
+              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
+            ) as GhIssueLike;
+            const stakeholders = extractStakeholdersFromIssue(data);
+            return jsonResult({ ok: true, data, stakeholders });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_gh_create_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_create_issue",
+        description: "Create a new GitHub issue in the EOA repo. Persists reporter/stakeholders in a metadata block.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          title: Type.String({ description: "Issue title" }),
+          body: Type.String({ description: "Issue body (markdown)" }),
+          labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
+          reporter: Type.Optional(
+            Type.String({ description: "Reporter identity (email, @github-user, or Zoom JID)." }),
+          ),
+          stakeholders: Type.Optional(
+            Type.Array(Type.String(), { description: "Additional stakeholder identities." }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const labels = params.labels as string[] | undefined;
+            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+            const bodyStr = String(params.body ?? "");
+            const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+            const stakeholders = Array.isArray(params.stakeholders)
+              ? (params.stakeholders as string[])
+              : [];
+            const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
+
+            const result = execSync(
+              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              {
+                encoding: "utf-8",
+                input: enrichedBody,
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            const url = result.trim();
+            const issueNumber = parseIssueNumberFromUrl(url);
+
+            if (issueNumber) {
+              const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
+              execSync(
+                `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: metadataComment,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+            }
+
+            return jsonResult({
+              ok: true,
+              url,
+              issueNumber,
+              reporter,
+              stakeholders,
+              metadataSaved: Boolean(issueNumber),
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_gh_add_comment
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_add_comment",
+        description: "Add a comment to an existing GitHub issue. Auto-mentions stored stakeholders.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          number: Type.Number({ description: "Issue number" }),
+          body: Type.String({ description: "Comment body (markdown)" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const issue = gh(
+              `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
+            ) as GhIssueLike;
+            const extracted = extractStakeholdersFromIssue(issue);
+            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+            const originalBody = String(params.body ?? "");
+            const body =
+              prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
+                ? `${prefix}\n\n${originalBody}`
+                : originalBody;
+
+            const result = execSync(
+              `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+              {
+                encoding: "utf-8",
+                input: body,
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            return jsonResult({
+              ok: true,
+              url: result.trim(),
+              stakeholders: extracted.stakeholders,
+              reporter: extracted.reporter,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_gh_search_issues
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_search_issues",
+        description: "Search GitHub issues by keyword in external-org-autopilot repos.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const limit = (params.limit as number) || 20;
+            const query = (params.query as string).replace(/"/g, '\\"');
+            const data = gh(
+              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // eoa_gh_close_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "eoa_gh_close_issue",
+        description: "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          number: Type.Number({ description: "Issue number" }),
+          comment: Type.Optional(Type.String({ description: "Closing update comment to post before close." })),
+          reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const issueNumber = Number(params.number);
+            const closeReason = stringifyReason(params.reason);
+            const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
+
+            const issue = gh(
+              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
+            ) as GhIssueLike;
+            const extracted = extractStakeholdersFromIssue(issue);
+            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+            if (closingComment || prefix) {
+              const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+              if (commentBody) {
+                execSync(
+                  `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+                  {
+                    encoding: "utf-8",
+                    input: commentBody,
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                );
+              }
+            }
+
+            const closeOutput = execSync(
+              `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+              {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            ).trim();
+
+            const dmTargets = extracted.stakeholders
+              .map((stakeholder) =>
+                resolveStakeholderDmTarget(stakeholder, {
+                  mapEnv: process.env.EOA_STAKEHOLDER_MAP,
+                  defaultDomain: process.env.EOA_STAKEHOLDER_EMAIL_DOMAIN,
+                }),
+              )
+              .filter((value): value is string => Boolean(value));
+
+            const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
+            const issueTitle = issue.title || `Issue ${issueNumber}`;
+            const dmMessage = formatStakeholderDmMessage({
+              issueNumber,
+              issueTitle,
+              repo,
+              closedBy: "eoa-autopilot",
+              closingComment,
+            });
+
+            const notified: string[] = [];
+            const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+            for (const stakeholder of uniqueTargets) {
+              const dmResult = await sendStakeholderZoomDm({
+                toContact: stakeholder,
+                message: dmMessage,
+              });
+              if (dmResult.ok) {
+                notified.push(stakeholder);
+              } else {
+                notifyErrors.push({
+                  stakeholder,
+                  error: dmResult.error ?? "unknown error",
+                });
+              }
+            }
+
+            return jsonResult({
+              ok: true,
+              number: issueNumber,
+              repo,
+              closeOutput,
+              closeReason,
+              stakeholders: extracted.stakeholders,
+              reporter: extracted.reporter,
+              notified,
+              notifyErrors,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/external-org-autopilot/src/helpers.ts
+++ b/extensions/external-org-autopilot/src/helpers.ts
@@ -1,0 +1,8 @@
+export function jsonResult(data: unknown): { content: { type: "text"; text: string }[] } {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function errorResult(err: unknown): { content: { type: "text"; text: string }[] } {
+  const message = err instanceof Error ? err.message : String(err);
+  return jsonResult({ ok: false, error: message });
+}

--- a/extensions/external-org-autopilot/src/stakeholders.ts
+++ b/extensions/external-org-autopilot/src/stakeholders.ts
@@ -1,0 +1,243 @@
+const STAKEHOLDER_BLOCK_START = "<!-- eoa:stakeholders:start -->";
+const STAKEHOLDER_BLOCK_END = "<!-- eoa:stakeholders:end -->";
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const GH_MENTION_RE = /(^|[^\w])@([a-z0-9](?:-?[a-z0-9]){0,38})(?=$|[^\w-])/gi;
+
+export type StakeholderSet = {
+  reporter?: string;
+  stakeholders: string[];
+};
+
+type IssueCommentLike = { body?: string };
+type IssueLike = {
+  body?: string;
+  assignees?: Array<{ login?: string }>;
+  comments?: IssueCommentLike[];
+};
+
+export function normalizeStakeholder(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const cleaned = trimmed.replace(/^mailto:/i, "").replace(/[<>]/g, "").trim();
+  if (!cleaned) return null;
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(cleaned)) return cleaned.toLowerCase();
+  if (/@xmpp\.zoom\.us$/i.test(cleaned)) return cleaned.toLowerCase();
+  if (/^@[a-z0-9](?:-?[a-z0-9]){0,38}$/i.test(cleaned)) return cleaned.toLowerCase();
+  if (/^[a-z0-9](?:-?[a-z0-9]){0,38}$/i.test(cleaned)) return `@${cleaned.toLowerCase()}`;
+  return cleaned;
+}
+
+function uniquePreserveOrder(values: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = normalizeStakeholder(value);
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(normalized);
+  }
+  return out;
+}
+
+function parseStakeholderList(raw: string): string[] {
+  return uniquePreserveOrder(raw.split(/[,\n]/g).map((token) => token.trim()).filter(Boolean));
+}
+
+function extractEmails(text: string): string[] {
+  const matches = text.match(EMAIL_RE) ?? [];
+  return uniquePreserveOrder(matches);
+}
+
+function extractMentions(text: string): string[] {
+  const mentions: string[] = [];
+  let match: RegExpExecArray | null;
+  GH_MENTION_RE.lastIndex = 0;
+  while ((match = GH_MENTION_RE.exec(text)) !== null) {
+    mentions.push(`@${match[2]}`);
+  }
+  return uniquePreserveOrder(mentions);
+}
+
+export function formatStakeholderBlock(input: StakeholderSet): string {
+  const reporter = normalizeStakeholder(input.reporter ?? "") ?? "unknown";
+  const stakeholders = uniquePreserveOrder([reporter, ...input.stakeholders]);
+  return [
+    STAKEHOLDER_BLOCK_START,
+    `Reporter: ${reporter}`,
+    `Stakeholders: ${stakeholders.join(", ") || "none"}`,
+    STAKEHOLDER_BLOCK_END,
+  ].join("\n");
+}
+
+export function upsertStakeholderBlock(body: string, input: StakeholderSet): string {
+  const block = formatStakeholderBlock(input);
+  const source = body.trim();
+  const blockRe = new RegExp(
+    `${escapeForRegex(STAKEHOLDER_BLOCK_START)}[\\s\\S]*?${escapeForRegex(STAKEHOLDER_BLOCK_END)}`,
+    "i",
+  );
+  if (blockRe.test(source)) {
+    return source.replace(blockRe, block).trim();
+  }
+  if (!source) return block;
+  return `${source}\n\n${block}`.trim();
+}
+
+function parseBlock(text: string): StakeholderSet {
+  const out: StakeholderSet = { stakeholders: [] };
+  const lines = text.split(/\r?\n/g);
+  for (const line of lines) {
+    const reporterMatch = line.match(/^\s*Reporter:\s*(.+)\s*$/i);
+    if (reporterMatch) {
+      out.reporter = normalizeStakeholder(reporterMatch[1]) ?? out.reporter;
+      continue;
+    }
+    const stakeholdersMatch = line.match(/^\s*Stakeholders:\s*(.+)\s*$/i);
+    if (stakeholdersMatch) {
+      out.stakeholders = uniquePreserveOrder([...out.stakeholders, ...parseStakeholderList(stakeholdersMatch[1])]);
+    }
+  }
+  if (out.reporter) {
+    out.stakeholders = uniquePreserveOrder([out.reporter, ...out.stakeholders]);
+  }
+  return out;
+}
+
+function parseStakeholderBlocks(text: string): StakeholderSet {
+  const out: StakeholderSet = { stakeholders: [] };
+  const blockRe = new RegExp(
+    `${escapeForRegex(STAKEHOLDER_BLOCK_START)}([\\s\\S]*?)${escapeForRegex(STAKEHOLDER_BLOCK_END)}`,
+    "gi",
+  );
+  let match: RegExpExecArray | null;
+  while ((match = blockRe.exec(text)) !== null) {
+    const parsed = parseBlock(match[1] ?? "");
+    if (!out.reporter && parsed.reporter) out.reporter = parsed.reporter;
+    out.stakeholders = uniquePreserveOrder([...out.stakeholders, ...parsed.stakeholders]);
+  }
+  return out;
+}
+
+function collectFromText(text: string): StakeholderSet {
+  const block = parseStakeholderBlocks(text);
+  const fallbackReporter = (() => {
+    const reporterLine = text.match(/^\s*Reporter:\s*(.+)\s*$/im)?.[1];
+    return reporterLine ? normalizeStakeholder(reporterLine) ?? undefined : undefined;
+  })();
+  const inlineStakeholders = (() => {
+    const line = text.match(/^\s*Stakeholders:\s*(.+)\s*$/im)?.[1];
+    return line ? parseStakeholderList(line) : [];
+  })();
+  const discovered = uniquePreserveOrder([
+    ...block.stakeholders,
+    ...inlineStakeholders,
+    ...extractEmails(text),
+    ...extractMentions(text),
+  ]);
+  return {
+    reporter: block.reporter ?? fallbackReporter,
+    stakeholders: block.reporter
+      ? uniquePreserveOrder([block.reporter, ...discovered])
+      : discovered,
+  };
+}
+
+export function extractStakeholdersFromIssue(issue: IssueLike): StakeholderSet {
+  const combined: StakeholderSet = { stakeholders: [] };
+
+  const issueBody = typeof issue.body === "string" ? issue.body : "";
+  const fromIssue = collectFromText(issueBody);
+  combined.reporter = fromIssue.reporter;
+  combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, ...fromIssue.stakeholders]);
+
+  for (const assignee of issue.assignees ?? []) {
+    const mention = normalizeStakeholder(`@${assignee.login ?? ""}`);
+    if (mention) combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, mention]);
+  }
+
+  for (const comment of issue.comments ?? []) {
+    const body = typeof comment.body === "string" ? comment.body : "";
+    const fromComment = collectFromText(body);
+    if (!combined.reporter && fromComment.reporter) combined.reporter = fromComment.reporter;
+    combined.stakeholders = uniquePreserveOrder([...combined.stakeholders, ...fromComment.stakeholders]);
+  }
+
+  if (combined.reporter) {
+    combined.stakeholders = uniquePreserveOrder([combined.reporter, ...combined.stakeholders]);
+  }
+  return combined;
+}
+
+export function buildStakeholderWorkPrefix(stakeholders: string[]): string {
+  const normalized = uniquePreserveOrder(stakeholders);
+  if (normalized.length === 0) return "";
+  const mentions = normalized.filter((token) => token.startsWith("@"));
+  const lines: string[] = [];
+  if (mentions.length > 0) lines.push(`/cc ${mentions.join(" ")}`);
+  lines.push(`Stakeholders: ${normalized.join(", ")}`);
+  return lines.join("\n");
+}
+
+export function parseIssueNumberFromUrl(url: string): number | null {
+  const match = url.match(/\/issues\/(\d+)\b/);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function resolveStakeholderDmTarget(input: string, params?: {
+  mapEnv?: string;
+  defaultDomain?: string;
+}): string | null {
+  const normalized = normalizeStakeholder(input);
+  if (!normalized) return null;
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(normalized)) return normalized;
+  if (/@xmpp\.zoom\.us$/i.test(normalized)) return normalized;
+
+  const username = normalized.startsWith("@") ? normalized.slice(1) : normalized;
+  if (!username) return null;
+
+  const explicit = parseStakeholderMap(params?.mapEnv);
+  const mapped = explicit.get(username.toLowerCase());
+  if (mapped) return mapped;
+
+  const domain = params?.defaultDomain?.trim();
+  if (!domain) return null;
+  return `${username.toLowerCase()}@${domain.replace(/^@/, "").toLowerCase()}`;
+}
+
+export function parseStakeholderMap(raw: string | undefined): Map<string, string> {
+  const mapping = new Map<string, string>();
+  const source = raw?.trim();
+  if (!source) return mapping;
+
+  if (source.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(source) as Record<string, unknown>;
+      for (const [key, value] of Object.entries(parsed)) {
+        const normalizedValue = normalizeStakeholder(String(value ?? ""));
+        const normalizedKey = key.trim().toLowerCase().replace(/^@/, "");
+        if (!normalizedKey || !normalizedValue) continue;
+        mapping.set(normalizedKey, normalizedValue);
+      }
+      return mapping;
+    } catch {
+      // Fall through to CSV format.
+    }
+  }
+
+  for (const pair of source.split(/[,\n]/g)) {
+    const [keyRaw, valueRaw] = pair.split("=");
+    const key = keyRaw?.trim().toLowerCase().replace(/^@/, "");
+    const value = normalizeStakeholder(valueRaw ?? "");
+    if (!key || !value) continue;
+    mapping.set(key, value);
+  }
+  return mapping;
+}
+
+function escapeForRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/extensions/external-org-autopilot/src/zoom-dm.ts
+++ b/extensions/external-org-autopilot/src/zoom-dm.ts
@@ -1,0 +1,97 @@
+type ZoomDmResult = {
+  ok: boolean;
+  error?: string;
+};
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+function hasValue(value: string | undefined): value is string {
+  return Boolean(value && value.trim());
+}
+
+async function getZoomReportToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+
+  const clientId = process.env.ZOOM_REPORT_CLIENT_ID?.trim();
+  const clientSecret = process.env.ZOOM_REPORT_CLIENT_SECRET?.trim();
+  const accountId = process.env.ZOOM_REPORT_ACCOUNT_ID?.trim() || process.env.ZOOM_ACCOUNT_ID?.trim();
+  if (!hasValue(clientId) || !hasValue(clientSecret) || !hasValue(accountId)) {
+    throw new Error(
+      "Zoom report credentials missing. Set ZOOM_REPORT_CLIENT_ID/ZOOM_REPORT_CLIENT_SECRET/ZOOM_REPORT_ACCOUNT_ID.",
+    );
+  }
+
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const response = await fetch(
+    `https://zoom.us/oauth/token?grant_type=account_credentials&account_id=${encodeURIComponent(accountId)}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Basic ${basic}` },
+    },
+  );
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Zoom token request failed (${response.status}): ${body.slice(0, 300)}`);
+  }
+
+  const data = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token || !data.expires_in) {
+    throw new Error("Zoom token response missing access_token/expires_in.");
+  }
+
+  cachedToken = {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+  return cachedToken.token;
+}
+
+export async function sendStakeholderZoomDm(params: {
+  toContact: string;
+  message: string;
+  fromUser?: string;
+}): Promise<ZoomDmResult> {
+  const toContact = params.toContact.trim();
+  if (!toContact) return { ok: false, error: "missing toContact" };
+
+  const fromUser =
+    params.fromUser?.trim() ||
+    process.env.ZOOM_REPORT_USER?.trim() ||
+    process.env.MENTION_PROXY?.trim();
+  if (!fromUser) {
+    return {
+      ok: false,
+      error: "missing from user (set ZOOM_REPORT_USER or MENTION_PROXY)",
+    };
+  }
+
+  try {
+    const token = await getZoomReportToken();
+    const response = await fetch(
+      `https://api.zoom.us/v2/chat/users/${encodeURIComponent(fromUser)}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          to_contact: toContact,
+          message: params.message,
+        }),
+      },
+    );
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        ok: false,
+        error: `zoom dm failed (${response.status}): ${body.slice(0, 300)}`,
+      };
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}


### PR DESCRIPTION
## Summary

- **CloudFlow Support extension** (10 files, 15 tools: 9 ops + 6 GH)
  - Firebase Auth with custom JWT token minting, cached ID tokens, and 401 auto-retry
  - CloudFlow Operations API wrapper (`cf_discover_ops`, `cf_execute_op`, `cf_list_tickets`, `cf_get_ticket`, `cf_list_deployments`, `cf_get_deployment`, `cf_list_users`, `cf_list_tenants`, `cf_get_deploy_status`)
  - GitHub issue management (`cf_gh_list_issues`, `cf_gh_get_issue`, `cf_gh_create_issue`, `cf_gh_add_comment`, `cf_gh_search_issues`, `cf_gh_close_issue`)
  - Stakeholder tracking with HTML comment metadata blocks in issues
  - Zoom DM notifications to stakeholders on issue close
  - Comfort messages in Zoom Team Chat channel

- **External Org Autopilot extension** (10 files, 23 tools: 11 CLI + 6 state + 6 GH)
  - CLI pipeline tools: `eoa_release_validate`, `eoa_release_lock`, `eoa_onboard_project`, `eoa_doctor`, `eoa_sync`, `eoa_ingest_issue`, `eoa_ingest_batch`, `eoa_run_execute`, `eoa_run_resume`, `eoa_smoke_test`, `eoa_report`
  - State inspection tools: `eoa_list_runs`, `eoa_get_run`, `eoa_get_evidence`, `eoa_get_workflow_status`, `eoa_get_workflow_logs`, `eoa_get_commit_diff`
  - GitHub issue management (`eoa_gh_list_issues`, `eoa_gh_get_issue`, `eoa_gh_create_issue`, `eoa_gh_add_comment`, `eoa_gh_search_issues`, `eoa_gh_close_issue`)
  - Same stakeholder tracking, Zoom DM, and comfort message patterns

## Changes from review

- Added 401 retry with token cache clearing to CloudFlow `cfApi()` (matching pulsebot's `ppFetch` pattern)
- Fixed `eoa_get_workflow_status` schema: `repo` changed from `Type.Optional` to `Type.String` to match handler requirement

## Known hardening items (not addressed in this PR)

- Command injection risk in `execSync` calls — should migrate to `execFileSync` with array args
- Path traversal risk in EOA state tools (`runId`, `bundleId`) and CLI tools (`releasePath`, `outPath`)
- Duplicated shared modules (`audit.ts`, `helpers.ts`, `stakeholders.ts`, `zoom-dm.ts`, `comfort.ts`) across extensions — candidates for a shared package
- Hardcoded paths in EOA (`/root/code/external-org-autopilot`) should be env vars
- Silent auth failure in `comfort.ts` when Zoom creds are empty strings

## Required env vars

**CloudFlow Support:**
- `CF_FIREBASE_API_KEY`, `CF_FIREBASE_CLIENT_EMAIL`, `CF_FIREBASE_PRIVATE_KEY`, `CF_BOT_USER_UID`
- `CF_API_BASE_URL` (default: `https://cloudflow.cx`)
- `CF_STAKEHOLDER_MAP`, `CF_STAKEHOLDER_EMAIL_DOMAIN` (for DM resolution)

**External Org Autopilot:**
- EOA CLI at `/root/code/external-org-autopilot`
- `EOA_STAKEHOLDER_MAP`, `EOA_STAKEHOLDER_EMAIL_DOMAIN` (for DM resolution)

**Shared (already set):**
- `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET`, `ZOOM_ACCOUNT_ID`, `ZOOM_BOT_JID`
- `ZOOM_REPORT_CLIENT_ID`, `ZOOM_REPORT_CLIENT_SECRET`, `ZOOM_REPORT_USER`

## Test plan

- [ ] Verify CloudFlow Firebase auth token flow with valid credentials
- [ ] Test 401 retry by invalidating cached token
- [ ] Run `cf_discover_ops` to confirm API connectivity
- [ ] Test EOA CLI tools with a valid customer repo onboarded
- [ ] Verify `eoa_get_workflow_status` rejects missing `repo` param
- [ ] Confirm stakeholder DMs fire on issue close for both extensions
- [ ] Validate audit JSONL output in workspace directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)
