### PR TITLE
docs(team-lead): fix Serve-based remote agent setup

### DIFF
--- a/extensions/team-lead/agent-config/README.md
+++ b/extensions/team-lead/agent-config/README.md
@@ -7,8 +7,10 @@ This directory contains everything a remote agent needs to join the team and com
 ```bash
 cd extensions/team-lead/agent-config
 ./setup.sh \
-  --lead-gateway "http://daniels-macbook-pro.tailcc6c5f.ts.net:18789" \
-  --lead-token "7473becb31f9da2ba22763f3c6d893219941ab3dd8833b4a" \
+  --lead-gateway "https://lead-host.tailnet.ts.net" \
+  --lead-token "$OPENCLAW_GATEWAY_TOKEN" \
+  --lead-session-key "agent:main:main" \
+  --lead-mcp "http://lead-host.tailnet:8400/mcp" \
   --agent-name "$(hostname -s | tr '[:upper:]' '[:lower:]')"
 ```
 
@@ -20,7 +22,7 @@ Or run `./setup.sh` with no flags for interactive mode.
 | -------------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
 | 6 skill files        | `~/.openclaw/skills/`    | Slash commands: /report-status, /heartbeat, /check-team, /check-task, /send-task, /apply-config |
 | REMOTE-AGENT.md      | `~/.openclaw/workspace/` | Instructions for how to report to the lead gateway (with concrete curl commands)                |
-| team-roster.json     | `~/.openclaw/workspace/` | Lead gateway URL and auth token                                                                 |
+| team-roster.json     | `~/.openclaw/workspace/` | Lead gateway URL, gateway token, and lead session key                                           |
 | current-project.json | `~/.openclaw/workspace/` | Tracks the active project being worked on                                                       |
 
 ## What this does NOT install
@@ -31,15 +33,40 @@ The **team-lead extension** (the TypeScript plugin in the parent directory) runs
 
 - `~/.openclaw/` directory must exist (OpenClaw installed)
 - Tailscale connected to the team tailnet
-- Lead's gateway must be running and bound to a non-loopback interface
+- Lead's gateway must be running
+- If the lead uses Tailscale Serve, use the Serve URL here and keep the gateway loopback-bound on the lead machine
+- If the lead uses a raw tailnet host:port instead, make sure that port is actually reachable from other machines
+
+## Lead-side Requirements
+
+Modern `/tools/invoke` usage needs these lead-side settings:
+
+```json
+{
+  "gateway": { "tools": { "allow": ["sessions_send"] } },
+  "tools": { "sessions": { "visibility": "agent" } }
+}
+```
 
 ## Verification
 
-The setup script tests connectivity automatically. If it says "Tool invocation works", you're good. If not, check:
+The setup script tests connectivity automatically:
+
+1. HTTP reachability and auth on `/tools/invoke`
+2. A real `sessions_send` ping into the lead session
+3. An optional `team_lead_list_projects` probe if the extension is loaded
+
+If it says `sessions_send works`, the transport path to the lead is ready. If the final `team_lead_*` probe warns, the gateway path is still good and the lead just needs the `team-lead` extension loaded.
+
+If something fails, check:
 
 1. Is Tailscale connected? (`tailscale status`)
 2. Is the lead's gateway running?
-3. Is the lead's gateway bound to `0.0.0.0` (not `loopback`)?
+3. Is the gateway token correct?
+4. Does the lead allow `sessions_send` over `/tools/invoke`?
+5. On macOS, if the service is loaded but not responding, try `openclaw gateway start` or `launchctl kickstart -kp gui/$UID/ai.openclaw.gateway`
+
+The script intentionally avoids `openclaw gateway health` for first-time remote setup, because remote unpaired clients can be rejected even when the HTTP tool path is working correctly.
 
 After setup, test with:
 

--- a/extensions/team-lead/agent-config/REMOTE-AGENT.md
+++ b/extensions/team-lead/agent-config/REMOTE-AGENT.md
@@ -12,6 +12,9 @@ Do both when you make meaningful progress.
 - **Gateway:** `__LEAD_GATEWAY__`
 - **MCP:** `__LEAD_MCP__`
 - **Auth token:** `__LEAD_TOKEN__`
+- **Lead session key:** `__LEAD_SESSION_KEY__`
+
+If the lead uses Tailscale Serve, keep using the HTTPS tailnet URL here even if the gateway itself listens only on `127.0.0.1` on the lead machine.
 
 ---
 
@@ -24,9 +27,10 @@ curl -sS __LEAD_GATEWAY__/tools/invoke \
   -H 'Authorization: Bearer __LEAD_TOKEN__' \
   -H 'Content-Type: application/json' \
   -d '{
+    "sessionKey": "__LEAD_SESSION_KEY__",
     "tool": "sessions_send",
     "args": {
-      "sessionKey": "main",
+      "sessionKey": "__LEAD_SESSION_KEY__",
       "message": "{\"type\":\"status_update\",\"from\":\"YOUR_NAME\",\"project\":\"PROJECT_NAME\",\"signal\":\"SIGNAL\",\"summary\":\"ONE_LINE_SUMMARY\",\"timestamp\":\"ISO_TIMESTAMP\"}",
       "timeoutSeconds": 0
     }
@@ -46,6 +50,8 @@ curl -sS __LEAD_GATEWAY__/tools/invoke \
 ## 2. Log to Team MCP (persistent task tracking)
 
 The MCP uses Streamable HTTP. Every call needs an MCP session: initialize first, then call tools with the session ID.
+
+If the lead gave you an HTTPS Serve URL for the gateway, ask them for the MCP URL explicitly. It is often a separate endpoint and may not be derivable from the Serve URL.
 
 ### Step 1: Initialize a session
 
@@ -157,6 +163,7 @@ curl -sS __LEAD_GATEWAY__/tools/invoke \
   -H "Authorization: Bearer __LEAD_TOKEN__" \
   -H 'Content-Type: application/json' \
   -d '{
+    "sessionKey": "__LEAD_SESSION_KEY__",
     "tool": "team_lead_get_docs",
     "args": {
       "repo": "org/repo-name"
@@ -173,6 +180,7 @@ curl -sS __LEAD_GATEWAY__/tools/invoke \
   -H "Authorization: Bearer __LEAD_TOKEN__" \
   -H 'Content-Type: application/json' \
   -d '{
+    "sessionKey": "__LEAD_SESSION_KEY__",
     "tool": "team_lead_get_docs",
     "args": {
       "projectId": "<projectId from doc metadata>",

--- a/extensions/team-lead/agent-config/setup.sh
+++ b/extensions/team-lead/agent-config/setup.sh
@@ -44,14 +44,25 @@ fatal() { error "$@"; exit 1; }
 LEAD_GATEWAY=""
 LEAD_TOKEN=""
 LEAD_MCP=""
+LEAD_SESSION_KEY=""
 LEAD_NAME=""
 AGENT_NAME=""
+
+derive_default_mcp_url() {
+  local gateway="${1%/}"
+  if [[ "$gateway" =~ ^http://[^/]+:[0-9]+$ ]]; then
+    printf '%s\n' "${gateway%:*}:8400/mcp"
+    return
+  fi
+  printf '\n'
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --lead-gateway) LEAD_GATEWAY="$2"; shift 2 ;;
     --lead-token)   LEAD_TOKEN="$2"; shift 2 ;;
     --lead-mcp)     LEAD_MCP="$2"; shift 2 ;;
+    --lead-session-key) LEAD_SESSION_KEY="$2"; shift 2 ;;
     --lead-name)    LEAD_NAME="$2"; shift 2 ;;
     --agent-name)   AGENT_NAME="$2"; shift 2 ;;
     -h|--help)
@@ -62,9 +73,10 @@ while [[ $# -gt 0 ]]; do
       echo "extension as an OpenClaw plugin — that's separate."
       echo ""
       echo "Options:"
-      echo "  --lead-gateway URL    Lead's gateway URL (e.g. http://host.tailnet:18789)"
-      echo "  --lead-token TOKEN    Auth token for the lead gateway"
-      echo "  --lead-mcp URL        Lead's MCP URL (default: derived from gateway, port 8400)"
+      echo "  --lead-gateway URL    Lead's gateway URL (e.g. https://lead-host.tailnet.ts.net)"
+      echo "  --lead-token TOKEN    Lead gateway token for /tools/invoke"
+      echo "  --lead-mcp URL        Lead's MCP URL (required if not derivable from the gateway URL)"
+      echo "  --lead-session-key KEY  Lead session key for /tools/invoke (default: agent:main:main)"
       echo "  --lead-name NAME      Lead's name (default: 'daniel')"
       echo "  --agent-name NAME     Your agent name (defaults to hostname)"
       exit 0
@@ -91,7 +103,7 @@ if [[ -z "$AGENT_NAME" ]]; then
 fi
 
 if [[ -z "$LEAD_GATEWAY" ]]; then
-  read -rp "Lead gateway URL (e.g. http://daniels-macbook-pro.tailcc6c5f.ts.net:18789): " LEAD_GATEWAY
+  read -rp "Lead gateway URL (e.g. https://lead-host.tailnet.ts.net): " LEAD_GATEWAY
 fi
 [[ -z "$LEAD_GATEWAY" ]] && fatal "Lead gateway URL is required."
 
@@ -100,11 +112,25 @@ if [[ -z "$LEAD_TOKEN" ]]; then
 fi
 [[ -z "$LEAD_TOKEN" ]] && fatal "Lead gateway auth token is required."
 
-# Derive MCP URL from gateway if not provided (swap port to 8400, append /mcp)
+if [[ -z "$LEAD_SESSION_KEY" ]]; then
+  read -rp "Lead session key [agent:main:main]: " LEAD_SESSION_KEY
+  LEAD_SESSION_KEY="${LEAD_SESSION_KEY:-agent:main:main}"
+fi
+
+# Derive MCP URL from the raw gateway host:port when possible.
 if [[ -z "$LEAD_MCP" ]]; then
-  LEAD_MCP="$(echo "$LEAD_GATEWAY" | sed 's|:[0-9]*$|:8400|')/mcp"
-  read -rp "Lead MCP URL [$LEAD_MCP]: " LEAD_MCP_INPUT
-  LEAD_MCP="${LEAD_MCP_INPUT:-$LEAD_MCP}"
+  DEFAULT_LEAD_MCP="$(derive_default_mcp_url "$LEAD_GATEWAY")"
+  if [[ -n "$DEFAULT_LEAD_MCP" ]]; then
+    read -rp "Lead MCP URL [$DEFAULT_LEAD_MCP]: " LEAD_MCP_INPUT
+    LEAD_MCP="${LEAD_MCP_INPUT:-$DEFAULT_LEAD_MCP}"
+  else
+    read -rp "Lead MCP URL (required when the gateway uses a Serve URL): " LEAD_MCP
+  fi
+fi
+
+if [[ -z "$LEAD_MCP" ]]; then
+  warn "Lead MCP URL not set; REMOTE-AGENT.md will keep a placeholder for MCP calls"
+  LEAD_MCP="ASK_THE_LEAD_FOR_MCP_URL"
 fi
 
 if [[ -z "$LEAD_NAME" ]]; then
@@ -149,6 +175,7 @@ sed \
   -e "s|__LEAD_GATEWAY__|${LEAD_GATEWAY}|g" \
   -e "s|__LEAD_MCP__|${LEAD_MCP}|g" \
   -e "s|__LEAD_TOKEN__|${LEAD_TOKEN}|g" \
+  -e "s|__LEAD_SESSION_KEY__|${LEAD_SESSION_KEY}|g" \
   "$REMOTE_AGENT_SRC" > "$REMOTE_AGENT_DST"
 
 # Verify no placeholders remain
@@ -167,6 +194,8 @@ cat > "$ROSTER_FILE" <<EOF
   "description": "Team configuration. Lead gateway and auth for status reporting.",
   "lead_gateway": "${LEAD_GATEWAY}",
   "lead_token": "${LEAD_TOKEN}",
+  "gateway_token": "${LEAD_TOKEN}",
+  "lead_session_key": "${LEAD_SESSION_KEY}",
   "lead": "${LEAD_NAME}",
   "members": {}
 }
@@ -193,48 +222,68 @@ else
   info "current-project.json already exists (keeping)"
 fi
 
-# --- Step 5: Connectivity check ---
+# --- Step 5: Reachability + auth check ---
 echo ""
 echo "--- Testing connectivity to lead gateway ---"
 
-HTTP_CODE=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" \
-  "${LEAD_GATEWAY}/health" 2>/dev/null || echo "000")
+INVOKE_HTTP_CODE=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" \
+  -X POST "${LEAD_GATEWAY}/tools/invoke" \
+  -H "Authorization: Bearer ${LEAD_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{}' 2>/dev/null || echo "000")
 
-if [[ "$HTTP_CODE" == "200" ]]; then
-  info "Lead gateway reachable (HTTP 200)"
-elif [[ "$HTTP_CODE" == "000" ]]; then
+if [[ "$INVOKE_HTTP_CODE" == "400" ]]; then
+  info "Gateway HTTP reachability works via ${LEAD_GATEWAY}/tools/invoke"
+elif [[ "$INVOKE_HTTP_CODE" == "401" ]] || [[ "$INVOKE_HTTP_CODE" == "403" ]]; then
+  error "Lead gateway is reachable but auth failed (HTTP ${INVOKE_HTTP_CODE})"
+  fatal "Setup incomplete — fix the gateway token and re-run"
+else
   error "Cannot reach lead gateway at ${LEAD_GATEWAY}"
+  error "Tried HTTP probe: ${LEAD_GATEWAY}/tools/invoke"
   error "Possible causes:"
   error "  - Tailscale not connected"
   error "  - Lead's gateway not running"
-  error "  - Lead's gateway bound to loopback (needs 0.0.0.0)"
+  error "  - Wrong gateway token"
+  error "  - Wrong Serve URL or remote host:port"
   echo ""
   fatal "Setup incomplete — fix connectivity and re-run"
-elif [[ "$HTTP_CODE" == "401" ]] || [[ "$HTTP_CODE" == "403" ]]; then
-  warn "Lead gateway reachable but auth failed (HTTP ${HTTP_CODE})"
-  warn "The gateway URL works but the token may be wrong"
-else
-  warn "Lead gateway returned HTTP ${HTTP_CODE} (expected 200)"
-  warn "Gateway may be reachable but not healthy"
 fi
 
 # --- Step 6: Test actual tool invocation ---
 echo ""
 echo "--- Testing tool access ---"
 
-TOOL_RESPONSE=$(curl -sS --max-time 10 -X POST "${LEAD_GATEWAY}/tools/invoke" \
+SESSION_RESPONSE=$(curl -sS --max-time 10 -X POST "${LEAD_GATEWAY}/tools/invoke" \
   -H "Authorization: Bearer ${LEAD_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d '{"tool": "team_lead_list_projects", "args": {}}' 2>/dev/null || echo '{"error":"connection_failed"}')
+  -d "{\"tool\":\"sessions_send\",\"sessionKey\":\"${LEAD_SESSION_KEY}\",\"args\":{\"sessionKey\":\"${LEAD_SESSION_KEY}\",\"message\":\"[setup] Connectivity check from ${AGENT_NAME}\",\"timeoutSeconds\":0}}" 2>/dev/null || echo '{"error":"connection_failed"}')
 
-if echo "$TOOL_RESPONSE" | grep -q '"ok"'; then
-  info "Tool invocation works — agent can communicate with lead"
-elif echo "$TOOL_RESPONSE" | grep -q 'connection_failed'; then
-  error "Tool invocation failed — could not connect"
+if echo "$SESSION_RESPONSE" | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
+  info "sessions_send works — the lead should see a one-time setup ping"
+elif echo "$SESSION_RESPONSE" | grep -q 'connection_failed'; then
+  error "sessions_send failed — could not connect"
   fatal "Setup incomplete — fix connectivity and re-run"
+elif echo "$SESSION_RESPONSE" | grep -q '"not_found"'; then
+  error "sessions_send is blocked on the lead gateway"
+  error "Lead needs gateway.tools.allow=[\"sessions_send\"] and tools.sessions.visibility=\"agent\""
+  fatal "Setup incomplete — fix the lead gateway config and re-run"
 else
-  warn "Tool invocation returned unexpected response: ${TOOL_RESPONSE:0:200}"
-  warn "Gateway is reachable but tools may not be configured correctly on the lead's side"
+  error "sessions_send returned unexpected response: ${SESSION_RESPONSE:0:200}"
+  fatal "Setup incomplete — fix the lead gateway config and re-run"
+fi
+
+TEAM_LEAD_RESPONSE=$(curl -sS --max-time 10 -X POST "${LEAD_GATEWAY}/tools/invoke" \
+  -H "Authorization: Bearer ${LEAD_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"tool\":\"team_lead_list_projects\",\"sessionKey\":\"${LEAD_SESSION_KEY}\",\"args\":{}}" 2>/dev/null || echo '{"error":"connection_failed"}')
+
+if echo "$TEAM_LEAD_RESPONSE" | grep -q '"ok"[[:space:]]*:[[:space:]]*true'; then
+  info "team_lead_* tools are available on the lead gateway"
+elif echo "$TEAM_LEAD_RESPONSE" | grep -q '"not_found"'; then
+  warn "team_lead_* tools are not available yet"
+  warn "Transport is working; the lead still needs the team-lead extension loaded"
+else
+  warn "team_lead_list_projects returned: ${TEAM_LEAD_RESPONSE:0:200}"
 fi
 
 # --- Done ---
@@ -245,6 +294,7 @@ echo "Installed:"
 echo "  - 6 skills in ${SKILLS_DIR}/"
 echo "  - REMOTE-AGENT.md in ${WORKSPACE_DIR}/"
 echo "  - team-roster.json in ${WORKSPACE_DIR}/"
+echo "  - lead session key: ${LEAD_SESSION_KEY}"
 echo ""
 echo "Your agent (${AGENT_NAME}) can now:"
 echo "  - Report status:  /report-status --new \"project\" \"description\""

--- a/extensions/team-lead/agent-config/skills/apply-config/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/apply-config/SKILL.md
@@ -20,12 +20,12 @@ Check for a config profile in this order:
 
 1. **Argument**: If the user provided a bundle name (e.g. `/apply-config personal/chad`), use that.
 2. **current-project.json**: Read `~/.openclaw/workspace/current-project.json`. If it has a `configProfile` field, use that.
-3. **Lead gateway**: If `current-project.json` has a `projectId` and `leadGateway`, call the lead to fetch the project:
+3. **Lead gateway**: If `current-project.json` has a `projectId` and `leadGateway`, call the lead to fetch the project. Use the lead session key from `team-roster.json` (`lead_session_key`, default `agent:main:main`):
    ```bash
    curl -sS -X POST "${LEAD_GATEWAY}/tools/invoke" \
      -H "Authorization: Bearer ${LEAD_TOKEN}" \
      -H "Content-Type: application/json" \
-     -d '{"tool": "team_lead_get_project", "args": {"projectId": "<projectId>"}}'
+     -d '{"sessionKey": "${LEAD_SESSION_KEY}", "tool": "team_lead_get_project", "args": {"projectId": "<projectId>"}}'
    ```
    Read `configProfile` from the response's `project` object.
 4. **No config found**: If none of the above yields a config profile, report: "No config profile found. Provide one as an argument: `/apply-config personal/chad`"
@@ -128,6 +128,7 @@ curl -sS -X POST "${LEAD_GATEWAY}/tools/invoke" \
   -H "Authorization: Bearer ${LEAD_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "${LEAD_SESSION_KEY}",
     "tool": "team_lead_update",
     "args": {
       "projectId": "<projectId>",

--- a/extensions/team-lead/agent-config/skills/check-task/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/check-task/SKILL.md
@@ -47,6 +47,7 @@ curl -sS -X POST "<gateway-url>/tools/invoke" \
   -H "Authorization: Bearer <gateway-token>" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "<session-key>",
     "tool": "sessions_send",
     "args": {
       "sessionKey": "<session-key>",

--- a/extensions/team-lead/agent-config/skills/check-team/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/check-team/SKILL.md
@@ -7,7 +7,7 @@ metadata: { "openclaw": { "emoji": "👥", "requires": { "bins": ["curl"] } } }
 
 # check-team — Check Team Member Connectivity
 
-Pings each team member's gateway to see who's online and reachable. Reads the team roster and checks each gateway's health endpoint.
+Pings each team member's gateway to see who's online and reachable. Reads the team roster and checks whether the HTTP `/tools/invoke` endpoint responds, which works with both raw host:port URLs and Tailscale Serve URLs.
 
 ## Arguments
 
@@ -24,12 +24,15 @@ Read `~/.openclaw/workspace/team-roster.json`.
 For each member in the roster (or just the specified person):
 
 ```bash
-curl -sS --connect-timeout 3 "<gateway-url>/health"
+curl -sS --connect-timeout 3 -o /dev/null -w "%{http_code}" \
+  -X POST "<gateway-url>/tools/invoke" \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 ```
 
 Record the result:
 
-- **Online:** Health check returned successfully
+- **Online:** Any HTTP response is returned (for example `400` or `401`)
 - **Offline:** Connection refused, timed out, or error
 
 If a member has `"status": "not-configured"`, mark them as "Not configured (hooks not enabled)" without pinging.
@@ -41,9 +44,9 @@ Display a table:
 ```
 | Name     | Status          | Gateway                                           |
 |----------|-----------------|---------------------------------------------------|
-| gerald   | Online          | geralds-macbook-pro.tailcc6c5f.ts.net:18789       |
-| dev-test | Offline         | 127.0.0.1:19001                                   |
-| chad     | Not configured  | chads-macbook-pro.tail...:18789                    |
+| gerald   | Online          | https://geralds-macbook-pro.tailnet.ts.net        |
+| dev-test | Offline         | ws://127.0.0.1:19001                              |
+| chad     | Not configured  | https://chads-macbook-pro.tailnet.ts.net          |
 ```
 
 If everyone is offline, suggest checking Tailscale connectivity (`tailscale status`).

--- a/extensions/team-lead/agent-config/skills/heartbeat/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/heartbeat/SKILL.md
@@ -18,7 +18,11 @@ Send a heartbeat signal to the team lead coordinator. Reports that this agent is
 
 ### Step 1: Determine the lead gateway
 
-Read `~/.openclaw/workspace/team-roster.json` and use the `lead_gateway` top-level field. Extract the gateway URL and auth token (`gateway_token` or `hooks_token`).
+Read `~/.openclaw/workspace/team-roster.json` and use the `lead_gateway` top-level field. Extract:
+
+- the gateway URL
+- the gateway auth token (`gateway_token`, or `lead_token` for older files)
+- the lead session key (`lead_session_key`, default `agent:main:main`)
 
 ### Step 2: Gather agent info
 
@@ -37,6 +41,7 @@ curl -sS -X POST "${LEAD_GATEWAY}/tools/invoke" \
   -H "Authorization: Bearer ${LEAD_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "${LEAD_SESSION_KEY}",
     "tool": "team_lead_heartbeat",
     "args": {
       "agentName": "<agent name>",

--- a/extensions/team-lead/agent-config/skills/report-status/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/report-status/SKILL.md
@@ -18,7 +18,11 @@ Send a structured project update to the team lead. Automatically gathers git bra
 
 ### Step 1: Determine the lead gateway
 
-Read `~/.openclaw/workspace/team-roster.json` and find the member with `"role": "lead"`, or use the `lead_gateway` top-level field. Extract the `gateway` URL and auth token (`gateway_token` or `hooks_token`).
+Read `~/.openclaw/workspace/team-roster.json` and find the member with `"role": "lead"`, or use the `lead_gateway` top-level field. Extract:
+
+- the gateway URL
+- the gateway auth token (`gateway_token`, or `lead_token` for older files)
+- the lead session key (`lead_session_key`, default `agent:main:main`)
 
 ### Step 2: Gather git context automatically
 
@@ -99,6 +103,7 @@ curl -sS -X POST "${LEAD_GATEWAY}/tools/invoke" \
   -H "Authorization: Bearer ${LEAD_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "${LEAD_SESSION_KEY}",
     "tool": "team_lead_update",
     "args": <payload from step 4>
   }'
@@ -191,6 +196,7 @@ curl -sS -X POST "${LEAD_GATEWAY}/tools/invoke" \
   -H "Authorization: Bearer ${LEAD_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "${LEAD_SESSION_KEY}",
     "tool": "team_lead_upload_doc",
     "args": {
       "projectId": "<projectId from current-project.json>",

--- a/extensions/team-lead/agent-config/skills/send-task/SKILL.md
+++ b/extensions/team-lead/agent-config/skills/send-task/SKILL.md
@@ -53,7 +53,7 @@ The roster has this format:
 {
   "members": {
     "name": {
-      "gateway": "http://hostname:port",
+      "gateway": "https://hostname.tailnet.ts.net",
       "hooks_token": "token-for-hooks-endpoint",
       "gateway_token": "token-for-tools-invoke-endpoint",
       "tailscale_ip": "100.x.y.z"
@@ -69,17 +69,20 @@ The roster has this format:
 
 If only `hooks_token` is present and `--wait` was requested, fall back to fire-and-forget mode and tell the user that `gateway_token` is needed in the roster for `--wait` to work.
 
-If the person isn't in the roster, tell the user and ask for their Tailscale hostname, gateway port, and hooks token.
+If the person isn't in the roster, tell the user and ask for their Tailscale hostname (or Serve URL), plus hooks and gateway tokens if they want both fire-and-forget and `--wait` mode to work.
 
 If the person has `"status": "not-configured"` in their roster entry, tell the user that person hasn't enabled hooks yet and explain what they need to do (see Adding New Team Members section).
 
 ### Step 3: Verify Connectivity
 
 ```bash
-curl -sS --connect-timeout 5 "<gateway-url>/health"
+curl -sS --connect-timeout 5 -o /dev/null -w "%{http_code}" \
+  -X POST "<gateway-url>/tools/invoke" \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 ```
 
-If this fails, the remote gateway is down or unreachable. Tell the user.
+If this fails at the network level, the remote gateway is down or unreachable. If it returns an HTTP code like `400` or `401`, the gateway is reachable and you can continue with the real send step.
 
 ### Step 4: Build the Session Key
 
@@ -136,6 +139,7 @@ curl -sS -X POST "<gateway-url>/tools/invoke" \
   -H "Authorization: Bearer <gateway-token>" \
   -H "Content-Type: application/json" \
   -d '{
+    "sessionKey": "<session-key>",
     "tool": "sessions_send",
     "args": {
       "sessionKey": "<session-key>",
@@ -215,10 +219,13 @@ To add someone to the roster, update `~/.openclaw/workspace/team-roster.json`:
 
 ```json
 {
-  "name": {
-    "gateway": "http://<their-tailscale-hostname>:18789",
-    "hooks_token": "<their-hooks-token>",
-    "tailscale_ip": "<their-tailscale-ip>"
+  "members": {
+    "name": {
+      "gateway": "https://<their-tailscale-hostname>.ts.net",
+      "hooks_token": "<their-hooks-token>",
+      "gateway_token": "<their-gateway-token>",
+      "tailscale_ip": "<their-tailscale-ip>"
+    }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- update the remote-agent setup docs for Tailscale Serve URLs instead of raw `:18789` examples
- add an explicit `lead_session_key` and store `gateway_token` in `team-roster.json`
- fix `/tools/invoke` examples to include the invoke-context `sessionKey`
- switch setup and connectivity guidance away from `/health` and paired-client checks to HTTP `/tools/invoke` probes that work on fresh remote machines
- make the setup script validate `sessions_send` first, then warn separately if `team_lead_*` tools are not loaded yet

## Why
The current branch assumes:
- raw `http://host:18789` access instead of Tailscale Serve
- the lead default agent is `main`
- `sessions_send` works over HTTP without extra gateway/session visibility config
- health checks from a fresh remote machine can use paired WebSocket flows

That broke on Trent's laptop even though the actual transport path was working. The updated docs and setup flow now match the modern Serve + `/tools/invoke` path that was verified live.

## Verification
- `bash -n extensions/team-lead/agent-config/setup.sh`
- `git diff --check`
- throwaway-home smoke test of `extensions/team-lead/agent-config/setup.sh` against a live Serve URL and live gateway token:
  - HTTP `/tools/invoke` probe succeeded
  - `sessions_send` to `agent:main:main` succeeded
  - optional `team_lead_list_projects` probe warned cleanly when the extension was not loaded
