### PR TITLE
fix(mesh-gateway): per-contact session on outbound mesh send

### DIFF
--- a/extensions/mesh-gateway/index.test.ts
+++ b/extensions/mesh-gateway/index.test.ts
@@ -232,7 +232,11 @@ function createApi(pluginConfigOverrides: Record<string, unknown> = {}) {
       allowedUsers: ["chad.simon@cloudwarriors.ai"],
       ...pluginConfigOverrides,
     },
-    runtime: {},
+    runtime: {
+      subagent: {
+        run: vi.fn(async () => ({ runId: "mock-run-id" })),
+      },
+    },
     logger: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/extensions/mesh-gateway/index.ts
+++ b/extensions/mesh-gateway/index.ts
@@ -720,6 +720,16 @@ const plugin = {
             status: res.payload?.["status"] ?? "accepted",
             agent: agent_name,
           };
+
+          // Record outbound in per-contact mesh session
+          const contactIdentity = agent.expected_identity ?? agent_name;
+          const sessionKey = `mesh:${contactIdentity}`;
+          void api.runtime.subagent.run({
+            sessionKey,
+            message: `[Outbound mesh task to ${agent_name}] ${message}`,
+            lane: "mesh",
+          }).catch(() => {});
+
           return {
             content: [{ type: "text" as const, text: JSON.stringify(result) }],
             details: result,
@@ -813,6 +823,16 @@ const plugin = {
             response: final.payload?.["details"] ?? final.payload?.["summary"],
             agent: agent_name,
           };
+
+          // Record outbound in per-contact mesh session
+          const contactIdentity = agent.expected_identity ?? agent_name;
+          const sessionKey = `mesh:${contactIdentity}`;
+          void api.runtime.subagent.run({
+            sessionKey,
+            message: `[Outbound mesh message to ${agent_name}] ${message}\n\n[Response] ${result.response ?? "(no response)"}`,
+            lane: "mesh",
+          }).catch(() => {});
+
           return {
             content: [{ type: "text" as const, text: JSON.stringify(result) }],
             details: result,


### PR DESCRIPTION
## Summary
- After successful `mesh_send_task` or `mesh_send_message`, spawns a subagent run in the `mesh:<identity>` session to record the outbound message
- Both inbound and outbound messages for a contact now land in the same per-contact session

## Test plan
- [x] All 16 tests pass
- [ ] Send task to teammate, verify `mesh:<identity>` session appears in session list

🤖 Generated with [Claude Code](https://claude.com/claude-code)