### PR TITLE
feat(scopelybot): ScopelyBot extension (28 tools) + passthrough runner

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -1,0 +1,100 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { registerAdminTools } from "./src/admin-tools.js";
+import { createAuditLogger } from "./src/audit.js";
+import { sendComfortMessage } from "./src/comfort.js";
+import { registerCorrelationTools } from "./src/correlation-tools.js";
+import { registerGhTools } from "./src/gh-tools.js";
+import { registerMonitoringTools } from "./src/monitoring-tools.js";
+import { runPassthroughCycle } from "./src/passthrough-runner-cycle.js";
+import { registerPassthroughTools } from "./src/passthrough-tools.js";
+import { registerScopelyTools } from "./src/scopely-tools.js";
+
+type PluginConfig = { scopelyRepos?: string[] };
+
+// Default 5 minutes; override with PASSTHROUGH_INTERVAL_MS
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+// Hard floor — never poll faster than 1 minute
+const MIN_INTERVAL_MS = 60 * 1000;
+
+let intervalHandle: NodeJS.Timeout | null = null;
+
+const plugin = {
+  id: "scopelybot",
+  name: "ScopelyBot",
+  description: "Scopely VIP observability and break/fix research agent tools",
+  configSchema: {
+    type: "object" as const,
+    additionalProperties: false,
+    properties: {
+      scopelyRepos: {
+        type: "array",
+        items: { type: "string" },
+        default: ["cloudwarriors-ai/scopely"],
+        description: "GitHub repos scoped for Scopely issue management",
+      },
+    },
+  },
+
+  register(api: OpenClawPluginApi, config?: PluginConfig) {
+    const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
+    const logger = createAuditLogger(workspaceDir);
+    const pluginConfig: PluginConfig = config ?? { scopelyRepos: ["cloudwarriors-ai/scopely"] };
+
+    registerScopelyTools(api, logger);
+    registerAdminTools(api, logger);
+    registerMonitoringTools(api, logger);
+    registerGhTools(api, logger, pluginConfig);
+    registerCorrelationTools(api, logger, pluginConfig);
+    registerPassthroughTools(api, logger, workspaceDir);
+
+    // Send comfort message when a message arrives in the scopelybot channel
+    api.on("message_received", async (event, ctx) => {
+      if (ctx.channelId === "zoom" && ctx.conversationId) {
+        const messageId =
+          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+        void sendComfortMessage(ctx.conversationId, messageId);
+      }
+    });
+
+    // Schedule recurring passthrough test runs.
+    // Disabled if PASSTHROUGH_RUNNER_ENABLED is not "1" or SCOPELY_REPO_PATH is unset.
+    const runnerEnabled = process.env.PASSTHROUGH_RUNNER_ENABLED === "1";
+    const repoPath = process.env.SCOPELY_REPO_PATH;
+    if (runnerEnabled && repoPath) {
+      const interval = Math.max(
+        MIN_INTERVAL_MS,
+        Number(process.env.PASSTHROUGH_INTERVAL_MS ?? DEFAULT_INTERVAL_MS),
+      );
+      api.registerHook("gateway:startup", () => {
+        // Run once at startup, then on the configured interval
+        void runPassthroughCycle(workspaceDir, { source: "scheduled" }).catch((err) => {
+          console.error("[scopelybot-passthrough] startup cycle failed:", err);
+        });
+        intervalHandle = setInterval(() => {
+          void runPassthroughCycle(workspaceDir, { source: "scheduled" }).catch((err) => {
+            console.error("[scopelybot-passthrough] scheduled cycle failed:", err);
+          });
+        }, interval);
+        // Don't keep the process alive solely for this timer
+        intervalHandle.unref?.();
+        console.log(`[scopelybot-passthrough] runner enabled, interval=${interval}ms`);
+      });
+      api.registerHook("gateway:shutdown", () => {
+        if (intervalHandle) {
+          clearInterval(intervalHandle);
+          intervalHandle = null;
+        }
+      });
+    } else {
+      console.log(
+        "[scopelybot-passthrough] runner disabled (set PASSTHROUGH_RUNNER_ENABLED=1 and SCOPELY_REPO_PATH to enable)",
+      );
+    }
+
+    console.log(
+      "[scopelybot] Registered 28 tools (10 observability + 5 admin + 4 monitoring + 6 GH + 1 correlation + 2 passthrough)",
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/scopelybot/openclaw.plugin.json
+++ b/extensions/scopelybot/openclaw.plugin.json
@@ -1,0 +1,17 @@
+{
+  "id": "scopelybot",
+  "name": "ScopelyBot",
+  "description": "Scopely VIP observability and break/fix agent tools",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "scopelyRepos": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["cloudwarriors-ai/scopely"],
+        "description": "GitHub repos scoped for Scopely issue management"
+      }
+    }
+  }
+}

--- a/extensions/scopelybot/src/admin-tools.ts
+++ b/extensions/scopelybot/src/admin-tools.ts
@@ -1,0 +1,178 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { scopelyFetch, jsonResult, errorResult, buildQuery } from "./scopely-api.js";
+
+export function registerAdminTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // scopely_dashboard_stats — "How is the platform doing?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_dashboard_stats",
+        description:
+          "Get Scopely VIP dashboard statistics. Returns total sessions, pipeline value, conversion rate, " +
+          "weekly trends, step drop-off funnel, vendor breakdown, and team performance. " +
+          "Use this for high-level observability: 'how many sessions this week', 'what is the pipeline value', " +
+          "'where are users dropping off'.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const result = await scopelyFetch("/api/v1/admin/stats/");
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_audit_logs — "Who changed what?" / "What happened recently?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_audit_logs",
+        description:
+          "Get Scopely VIP audit logs. Shows who changed what, when, with old/new value diffs. " +
+          "Covers vendor config changes, pricing updates, session modifications, user management. " +
+          "Use this to answer 'who changed the pricing', 'what configuration was modified', 'what happened today'.",
+        parameters: Type.Object({
+          resource_type: Type.Optional(
+            Type.String({
+              description:
+                "Filter by resource type (vendor, project_type, scoping_card, pricing_item, session, user)",
+            }),
+          ),
+          action: Type.Optional(
+            Type.String({ description: "Filter by action (create, update, delete)" }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, ["resource_type", "action", "limit"]);
+            const result = await scopelyFetch(`/api/v1/admin/audit-logs/${qs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_pending_approvals — "Are there sessions waiting for approval?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_pending_approvals",
+        description:
+          "Get Scopely VIP sessions pending manager approval. Shows sessions that need sign-off before proceeding.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const result = await scopelyFetch("/api/v1/admin/approvals/");
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_vendor_config — "What vendors are configured?" / "Show me the vendor setup"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_vendor_config",
+        description:
+          "List Scopely VIP vendor configurations. Shows all configured vendors with their project types and pricing. " +
+          "Use this to check if vendor config is correct or to understand the current setup.",
+        parameters: Type.Object({
+          vendor_key: Type.Optional(
+            Type.String({ description: "Get specific vendor by key (e.g. 'ringcentral', 'zoom')" }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const vendorKey = params.vendor_key as string | undefined;
+            const path = vendorKey
+              ? `/api/v1/admin/vendors/${encodeURIComponent(vendorKey)}/`
+              : "/api/v1/admin/vendors/";
+            const result = await scopelyFetch(path);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_session_pricing — "What is the pricing for session X?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_session_pricing",
+        description:
+          "Get pricing details for a specific Scopely VIP scoping session. " +
+          "Returns line items, discounts, totals, and pricing versions.",
+        parameters: Type.Object({
+          id: Type.String({ description: "Session ID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const result = await scopelyFetch(
+              `/api/v1/admin/sessions/${encodeURIComponent(params.id as string)}/pricing/`,
+            );
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/audit.ts
+++ b/extensions/scopelybot/src/audit.ts
@@ -1,0 +1,103 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface AuditEntry {
+  ts: string;
+  tool: string;
+  actor: string;
+  trigger?: string;
+  params?: Record<string, unknown>;
+  resultSummary?: string;
+  durationMs?: number;
+  error?: string;
+}
+
+export function createAuditLogger(workspaceDir: string) {
+  const auditDir = path.join(workspaceDir, "scopelybot");
+  const auditFile = path.join(auditDir, "audit.jsonl");
+
+  try {
+    fs.mkdirSync(auditDir, { recursive: true });
+  } catch {
+    // ignore if exists
+  }
+
+  return function logAudit(entry: AuditEntry) {
+    const line = JSON.stringify(entry) + "\n";
+    try {
+      fs.appendFileSync(auditFile, line);
+    } catch (err) {
+      console.error("[scopelybot-audit] Failed to write audit log:", err);
+    }
+  };
+}
+
+export type AuditLogger = ReturnType<typeof createAuditLogger>;
+
+export function wrapToolWithAudit(
+  toolDef: {
+    name: string;
+    description: string;
+    parameters: unknown;
+    execute: (
+      id: string,
+      params: Record<string, unknown>,
+    ) => Promise<{ content: { type: "text"; text: string }[] }>;
+  },
+  logger: AuditLogger,
+) {
+  const origExecute = toolDef.execute;
+  toolDef.execute = async (id: string, params: Record<string, unknown>) => {
+    const start = Date.now();
+    try {
+      const result = await origExecute(id, params);
+      const durationMs = Date.now() - start;
+      let resultSummary = "";
+      try {
+        const parsed = JSON.parse(result.content[0]?.text ?? "{}");
+        if (parsed.ok === false) {
+          resultSummary = `error: ${parsed.error ?? "unknown"}`;
+        } else if (Array.isArray(parsed.data)) {
+          resultSummary = `${parsed.data.length} items`;
+        } else {
+          resultSummary = "ok";
+        }
+      } catch {
+        resultSummary = "ok";
+      }
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "scopelybot",
+        params: sanitizeParams(params),
+        resultSummary,
+        durationMs,
+      });
+      return result;
+    } catch (err) {
+      const durationMs = Date.now() - start;
+      logger({
+        ts: new Date().toISOString(),
+        tool: toolDef.name,
+        actor: "scopelybot",
+        params: sanitizeParams(params),
+        error: err instanceof Error ? err.message : String(err),
+        durationMs,
+      });
+      throw err;
+    }
+  };
+  return toolDef;
+}
+
+function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(params)) {
+    if (typeof v === "string" && v.length > 200) {
+      clean[k] = v.slice(0, 200) + "...[truncated]";
+    } else {
+      clean[k] = v;
+    }
+  }
+  return clean;
+}

--- a/extensions/scopelybot/src/comfort.ts
+++ b/extensions/scopelybot/src/comfort.ts
@@ -1,0 +1,80 @@
+// ScopelyBot Zoom channel JID — update this after creating the channel in Zoom
+const SCOPELYBOT_CHANNEL = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getToken(): Promise<string> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+  const clientId = process.env.ZOOM_CLIENT_ID ?? "";
+  const clientSecret = process.env.ZOOM_CLIENT_SECRET ?? "";
+  const auth = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  const resp = await fetch("https://zoom.us/oauth/token?grant_type=client_credentials", {
+    method: "POST",
+    headers: { Authorization: `Basic ${auth}` },
+  });
+  if (!resp.ok) {
+    throw new Error(`Zoom token failed: ${resp.status}`);
+  }
+  const data = (await resp.json()) as { access_token: string; expires_in: number };
+  cachedToken = { token: data.access_token, expiresAt: Date.now() + data.expires_in * 1000 };
+  return cachedToken.token;
+}
+
+const COMFORT_MESSAGES = [
+  "On it — pulling up the details now...",
+  "Looking into that, one moment...",
+  "Checking Scopely VIP, hang tight...",
+  "Gathering the info now...",
+  "Let me dig into that...",
+];
+
+export async function sendComfortMessage(
+  channelJid: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  // Only send to the designated ScopelyBot channel
+  if (!SCOPELYBOT_CHANNEL || channelJid !== SCOPELYBOT_CHANNEL) {
+    return;
+  }
+
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!botJid || !accountId) {
+    return;
+  }
+
+  const text = COMFORT_MESSAGES[Math.floor(Math.random() * COMFORT_MESSAGES.length)];
+  const normalizedReplyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: {
+        head: { text: "ScopelyBot" },
+        body: [{ type: "message", text }],
+      },
+    };
+    if (normalizedReplyTo) {
+      body.reply_to = normalizedReplyTo;
+      body.reply_main_message_id = normalizedReplyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[scopelybot] comfort message failed:", err);
+  }
+}

--- a/extensions/scopelybot/src/correlation-tools.ts
+++ b/extensions/scopelybot/src/correlation-tools.ts
@@ -1,0 +1,111 @@
+import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./scopely-api.js";
+
+const DEVTOOLS_BASE = () => process.env.DEVTOOLS_API_URL ?? "https://devtools-api.cloudwarriors.ai";
+const DEVTOOLS_TOKEN = () => process.env.DEV_TOOLS_API ?? "";
+
+type PluginConfig = { scopelyRepos?: string[] };
+
+export function registerCorrelationTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  config: PluginConfig,
+) {
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_correlate_errors",
+        description:
+          "Correlate an error pattern across Scopely container logs and GitHub issues. " +
+          "Searches Docker logs via devtools API and GH issues for matching patterns, then returns correlated results. " +
+          "Use this to investigate an error across all data sources at once.",
+        parameters: Type.Object({
+          pattern: Type.String({ description: "Error pattern or message to search for" }),
+          container: Type.Optional(
+            Type.String({
+              description: "Container name to search logs in (default: scopely app container)",
+            }),
+          ),
+          since: Type.Optional(
+            Type.String({
+              description: "Log time range start (e.g. '1h', '2024-01-01T00:00:00Z')",
+            }),
+          ),
+          tail: Type.Optional(
+            Type.Number({ description: "Number of log lines to search (default 500)" }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const pattern = params.pattern as string;
+            const container = (params.container as string) || "dev-scopely";
+            const tail = (params.tail as number) || 500;
+            const since = params.since as string | undefined;
+
+            // 1. Search container logs via devtools API
+            let logMatches: string[] = [];
+            const token = DEVTOOLS_TOKEN();
+            if (token) {
+              const qs = new URLSearchParams({ tail: String(tail) });
+              if (since) {
+                qs.set("since", since);
+              }
+              try {
+                const resp = await fetch(
+                  `${DEVTOOLS_BASE()}/api/v1/containers/${encodeURIComponent(container)}/logs?${qs}`,
+                  { headers: { Authorization: `Bearer ${token}` } },
+                );
+                if (resp.ok) {
+                  const data = (await resp.json()) as { logs?: string };
+                  const logText =
+                    typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
+                  const lines = logText.split("\n");
+                  const lowerPattern = pattern.toLowerCase();
+                  logMatches = lines.filter((l: string) => l.toLowerCase().includes(lowerPattern));
+                }
+              } catch {
+                // devtools unavailable, continue with GH search
+              }
+            }
+
+            // 2. Search GitHub issues for similar patterns
+            let ghMatches: unknown = [];
+            try {
+              const repo = (config.scopelyRepos ?? ["cloudwarriors-ai/scopely"])[0];
+              const query = pattern.replace(/"/g, '\\"').slice(0, 100);
+              const result = execSync(
+                `gh search issues "${query}" --repo ${repo} --limit 10 --json number,title,state,labels,createdAt`,
+                {
+                  encoding: "utf-8",
+                  timeout: 15000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              ghMatches = JSON.parse(result);
+            } catch {
+              // gh search failed, continue
+            }
+
+            return jsonResult({
+              ok: true,
+              pattern,
+              container,
+              logMatches: {
+                count: logMatches.length,
+                lines: logMatches.slice(0, 50),
+              },
+              ghIssues: ghMatches,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/gh-tools.ts
+++ b/extensions/scopelybot/src/gh-tools.ts
@@ -1,0 +1,276 @@
+import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./scopely-api.js";
+
+type PluginConfig = { scopelyRepos?: string[] };
+
+function getAllowedRepos(config: PluginConfig): string[] {
+  return config.scopelyRepos ?? ["cloudwarriors-ai/scopely"];
+}
+
+function assertAllowedRepo(repo: string, config: PluginConfig) {
+  const allowed = getAllowedRepos(config);
+  if (!allowed.includes(repo)) {
+    throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
+  }
+}
+
+function gh(args: string): unknown {
+  const result = execSync(`gh ${args}`, {
+    encoding: "utf-8",
+    timeout: 30000,
+    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+  });
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result.trim();
+  }
+}
+
+export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+  // scopely_gh_list_issues
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_list_issues",
+        description:
+          "List GitHub issues from a Scopely repo. Returns title, number, state, labels, assignees.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
+          label: Type.Optional(Type.String({ description: "Filter by label" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const state = (params.state as string) || "open";
+            const limit = (params.limit as number) || 30;
+            const label = typeof params.label === "string" ? params.label : "";
+            const labelFlag = label ? ` --label "${label}"` : "";
+            const data = gh(
+              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_gh_get_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_get_issue",
+        description: "Get details of a specific GitHub issue including body and comments.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          number: Type.Number({ description: "Issue number" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const issueNumber = Number(params.number);
+            const data = gh(
+              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_gh_create_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_create_issue",
+        description: "Create a new GitHub issue in a Scopely repo for tracking bugs or tasks.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          title: Type.String({ description: "Issue title" }),
+          body: Type.String({ description: "Issue body (markdown)" }),
+          labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const labels = params.labels as string[] | undefined;
+            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+            const body = typeof params.body === "string" ? params.body : "";
+            const result = execSync(
+              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              {
+                encoding: "utf-8",
+                input: body,
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            return jsonResult({ ok: true, url: result.trim() });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_gh_add_comment
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_add_comment",
+        description: "Add a comment to an existing GitHub issue.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          number: Type.Number({ description: "Issue number" }),
+          body: Type.String({ description: "Comment body (markdown)" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const issueNumber = Number(params.number);
+            const body = typeof params.body === "string" ? params.body : "";
+            const result = execSync(
+              `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+              {
+                encoding: "utf-8",
+                input: body,
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            );
+            return jsonResult({ ok: true, url: result.trim() });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_gh_search_issues
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_search_issues",
+        description: "Search GitHub issues by keyword in Scopely repos.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const limit = (params.limit as number) || 20;
+            const query = (params.query as string).replace(/"/g, '\\"');
+            const data = gh(
+              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_gh_close_issue
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_gh_close_issue",
+        description: "Close a GitHub issue with an optional closing comment.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
+          ),
+          number: Type.Number({ description: "Issue number" }),
+          comment: Type.Optional(
+            Type.String({ description: "Closing comment to post before closing." }),
+          ),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const issueNumber = Number(params.number);
+            const reason =
+              typeof params.reason === "string" &&
+              params.reason.trim().toLowerCase() === "not_planned"
+                ? "not planned"
+                : "completed";
+            const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
+
+            if (closingComment) {
+              execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                encoding: "utf-8",
+                input: closingComment,
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              });
+            }
+
+            const closeOutput = execSync(
+              `gh issue close ${issueNumber} --repo ${repo} --reason "${reason}"`,
+              {
+                encoding: "utf-8",
+                timeout: 30000,
+                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+              },
+            ).trim();
+
+            return jsonResult({
+              ok: true,
+              number: issueNumber,
+              repo,
+              closeOutput,
+              closeReason: reason,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/monitoring-tools.ts
+++ b/extensions/scopelybot/src/monitoring-tools.ts
@@ -1,0 +1,147 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { scopelyFetch, jsonResult, errorResult, buildQuery } from "./scopely-api.js";
+
+export function registerMonitoringTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // scopely_extraction_metrics — "How are extractions performing?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_extraction_metrics",
+        description:
+          "Get Scopely VIP extraction metrics. Returns live active sessions, today's success/failure counts, " +
+          "average duration, and weekly breakdown by vendor and day. " +
+          "Use this for real-time health: 'how many extractions today', 'what is the success rate', 'any failures'.",
+        parameters: Type.Object({
+          vendor: Type.Optional(Type.String({ description: "Filter metrics by vendor" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, ["vendor"]);
+            const result = await scopelyFetch(`/api/v1/extraction-monitor/metrics/${qs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_extraction_sessions — "Show me recent extractions"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_extraction_sessions",
+        description:
+          "List Scopely VIP extraction sessions. Shows session status, user, vendor, frame counts, " +
+          "duration, and error messages. Use this to investigate extraction failures or see recent activity.",
+        parameters: Type.Object({
+          vendor: Type.Optional(Type.String({ description: "Filter by vendor" })),
+          status: Type.Optional(
+            Type.String({
+              description: "Filter: pending, streaming, completing, completed, failed, abandoned",
+            }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, ["vendor", "status", "limit"]);
+            const result = await scopelyFetch(`/api/v1/extraction-monitor/sessions/${qs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_extraction_detail — "What happened in extraction session X?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_extraction_detail",
+        description:
+          "Get detailed info about a specific extraction session including event timeline. " +
+          "Shows frame counts, latency, tokens captured, errors, and lifecycle events.",
+        parameters: Type.Object({
+          session_id: Type.String({ description: "Extraction session ID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const result = await scopelyFetch(
+              `/api/v1/extraction-monitor/sessions/${encodeURIComponent(params.session_id as string)}/`,
+            );
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_wizard_funnel — "Where are users dropping off in the wizard?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_wizard_funnel",
+        description:
+          "Get the Scopely VIP wizard step drop-off funnel. Shows how many sessions reached each step " +
+          "(company_info → project_type → source_vendor → ... → sow_generation) and where users abandon. " +
+          "Use this to identify UX problems or friction points in the scoping flow.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const result = await scopelyFetch("/api/v1/admin/stats/");
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            const stats = result.data as Record<string, unknown>;
+            return jsonResult({
+              ok: true,
+              step_dropoff: stats.step_dropoff ?? {},
+              total_sessions: stats.total_sessions ?? 0,
+              conversion_rate: stats.conversion_rate ?? 0,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/passthrough-alerts.ts
+++ b/extensions/scopelybot/src/passthrough-alerts.ts
@@ -1,0 +1,137 @@
+import type { PassthroughTestState } from "./passthrough-state.js";
+
+/**
+ * Posts structured passthrough alerts to the ScopelyBot Zoom channel.
+ * Reuses the same Zoom client-credentials OAuth pattern as comfort.ts.
+ */
+
+const ZOOM_API_BASE = "https://api.zoom.us";
+
+let cachedToken: { token: string; expiresAt: number } | null = null;
+
+async function getZoomToken(): Promise<string | null> {
+  if (cachedToken && Date.now() < cachedToken.expiresAt - 60_000) {
+    return cachedToken.token;
+  }
+  const clientId = process.env.ZOOM_CLIENT_ID ?? "";
+  const clientSecret = process.env.ZOOM_CLIENT_SECRET ?? "";
+  if (!clientId || !clientSecret) {
+    return null;
+  }
+
+  try {
+    const auth = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+    const resp = await fetch("https://zoom.us/oauth/token?grant_type=client_credentials", {
+      method: "POST",
+      headers: { Authorization: `Basic ${auth}` },
+    });
+    if (!resp.ok) {
+      console.error(`[scopelybot-passthrough] Zoom token failed: ${resp.status}`);
+      return null;
+    }
+    const data = (await resp.json()) as { access_token: string; expires_in: number };
+    cachedToken = { token: data.access_token, expiresAt: Date.now() + data.expires_in * 1000 };
+    return cachedToken.token;
+  } catch (err) {
+    console.error("[scopelybot-passthrough] Zoom token error:", err);
+    return null;
+  }
+}
+
+async function postToZoomChannel(headerText: string, lines: string[]): Promise<void> {
+  const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channel || !botJid || !accountId) {
+    console.warn("[scopelybot-passthrough] Zoom channel/bot config missing — skipping alert");
+    return;
+  }
+
+  const token = await getZoomToken();
+  if (!token) {
+    return;
+  }
+
+  const body = {
+    robot_jid: botJid,
+    to_jid: channel,
+    account_id: accountId,
+    content: {
+      head: { text: headerText },
+      body: lines.map((text) => ({ type: "message", text })),
+    },
+  };
+
+  try {
+    const resp = await fetch(`${ZOOM_API_BASE}/v2/im/chat/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    if (!resp.ok) {
+      console.error(`[scopelybot-passthrough] Zoom post failed: ${resp.status}`);
+    }
+  } catch (err) {
+    console.error("[scopelybot-passthrough] Zoom post error:", err);
+  }
+}
+
+function formatTestForAlert(test: PassthroughTestState): string {
+  const lines = [
+    `• [${test.passthrough}] failed ${test.consecutiveFailures}× in a row`,
+    `  ${test.testTitle}`,
+  ];
+  if (test.errorMessage) {
+    lines.push(`  Error: ${test.errorMessage.slice(0, 200)}`);
+  }
+  return lines.join("\n");
+}
+
+export async function postFailureAlert(failingTests: PassthroughTestState[]): Promise<void> {
+  if (failingTests.length === 0) {
+    return;
+  }
+
+  const header = `🚨 Scopely passthrough failure (${failingTests.length})`;
+  const body = [
+    `${failingTests.length} passthrough test${failingTests.length === 1 ? "" : "s"} crossed the failure threshold:`,
+    "",
+    ...failingTests.map(formatTestForAlert),
+    "",
+    `Run \`scopely_passthrough_status\` in chat for full state.`,
+  ];
+
+  await postToZoomChannel(header, body);
+}
+
+export async function postRecoveryAlert(recoveredTests: PassthroughTestState[]): Promise<void> {
+  if (recoveredTests.length === 0) {
+    return;
+  }
+
+  const header = `✅ Scopely passthrough recovered (${recoveredTests.length})`;
+  const body = [
+    `${recoveredTests.length} passthrough test${recoveredTests.length === 1 ? "" : "s"} recovered:`,
+    "",
+    ...recoveredTests.map((t) => `• [${t.passthrough}] ${t.testTitle}`),
+  ];
+
+  await postToZoomChannel(header, body);
+}
+
+export async function postRunnerErrorAlert(errorMessage: string): Promise<void> {
+  // Distinct from passthrough failures — this means the runner itself broke.
+  const header = `⚠️ Scopely passthrough runner error`;
+  const body = [
+    `The passthrough test runner could not execute:`,
+    "",
+    errorMessage.slice(0, 500),
+    "",
+    `Tests did not run this cycle. Check SCOPELY_REPO_PATH and Playwright installation.`,
+  ];
+
+  await postToZoomChannel(header, body);
+}

--- a/extensions/scopelybot/src/passthrough-runner-cycle.ts
+++ b/extensions/scopelybot/src/passthrough-runner-cycle.ts
@@ -1,0 +1,76 @@
+import { postFailureAlert, postRecoveryAlert, postRunnerErrorAlert } from "./passthrough-alerts.js";
+import { runPassthroughTests } from "./passthrough-runner.js";
+import { applyRunResults, getNewlyFailingTests, getRecoveredTests } from "./passthrough-state.js";
+
+export interface CycleSummary {
+  source: "scheduled" | "manual";
+  ran_successfully: boolean;
+  run_error?: string;
+  duration_ms: number;
+  total_tests: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+  newly_failing: number;
+  recovered: number;
+}
+
+const ALERT_THRESHOLD = Number(process.env.PASSTHROUGH_ALERT_THRESHOLD ?? 2);
+
+/**
+ * Single end-to-end cycle: run the tests, update state, fire alerts on
+ * threshold transitions. Used by both the scheduled hook and the manual
+ * chat tool so they behave identically.
+ */
+export async function runPassthroughCycle(
+  workspaceDir: string,
+  opts: { source: "scheduled" | "manual" },
+): Promise<CycleSummary> {
+  const summary = await runPassthroughTests();
+
+  if (!summary.ranSuccessfully) {
+    // Alert about the runner being broken — but only on scheduled runs to
+    // avoid spamming the channel when someone manually triggers it.
+    if (opts.source === "scheduled") {
+      await postRunnerErrorAlert(summary.runError ?? "unknown error");
+    }
+    return {
+      source: opts.source,
+      ran_successfully: false,
+      run_error: summary.runError,
+      duration_ms: summary.durationMs,
+      total_tests: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+      newly_failing: 0,
+      recovered: 0,
+    };
+  }
+
+  const { previous, current } = applyRunResults(
+    workspaceDir,
+    summary.results,
+    summary.startedAt,
+    summary.durationMs,
+  );
+
+  const newlyFailing = getNewlyFailingTests(previous, current, ALERT_THRESHOLD);
+  const recovered = getRecoveredTests(previous, current, ALERT_THRESHOLD);
+
+  // Fire alerts. These are best-effort (postX functions swallow errors).
+  await postFailureAlert(newlyFailing);
+  await postRecoveryAlert(recovered);
+
+  return {
+    source: opts.source,
+    ran_successfully: true,
+    duration_ms: summary.durationMs,
+    total_tests: summary.results.length,
+    passed: summary.results.filter((r) => r.status === "passed").length,
+    failed: summary.results.filter((r) => r.status === "failed").length,
+    skipped: summary.results.filter((r) => r.status === "skipped").length,
+    newly_failing: newlyFailing.length,
+    recovered: recovered.length,
+  };
+}

--- a/extensions/scopelybot/src/passthrough-runner.ts
+++ b/extensions/scopelybot/src/passthrough-runner.ts
@@ -1,0 +1,238 @@
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { PassthroughResult } from "./passthrough-state.js";
+
+/**
+ * Executes the Scopely passthrough test suite via Playwright and returns
+ * structured results. Designed to be invoked on a schedule by the OpenClaw
+ * runner hook.
+ *
+ * Requires the Scopely repo to be checked out somewhere reachable; the path
+ * is configured via the SCOPELY_REPO_PATH env var.
+ */
+
+export interface PassthroughRunResult {
+  passthrough: string; // extracted from [bracket] in test title
+  testTitle: string;
+  status: PassthroughResult;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+export interface PassthroughRunSummary {
+  startedAt: Date;
+  durationMs: number;
+  results: PassthroughRunResult[];
+  ranSuccessfully: boolean; // false if Playwright itself crashed
+  runError?: string; // populated when ranSuccessfully = false
+}
+
+const PASSTHROUGH_KEY_RE = /\[([a-z0-9-]+)\]/i;
+
+function extractPassthroughKey(testTitle: string): string {
+  const match = testTitle.match(PASSTHROUGH_KEY_RE);
+  return match ? match[1] : "unknown";
+}
+
+interface PlaywrightJsonResult {
+  status?: "passed" | "failed" | "timedOut" | "skipped" | "interrupted";
+  duration?: number;
+  errors?: Array<{ message?: string }>;
+  error?: { message?: string };
+}
+
+interface PlaywrightJsonTest {
+  title: string;
+  results?: PlaywrightJsonResult[];
+}
+
+interface PlaywrightJsonSpec {
+  title: string;
+  tests?: PlaywrightJsonTest[];
+}
+
+interface PlaywrightJsonSuite {
+  title?: string;
+  specs?: PlaywrightJsonSpec[];
+  suites?: PlaywrightJsonSuite[];
+}
+
+interface PlaywrightJsonReport {
+  suites?: PlaywrightJsonSuite[];
+}
+
+function flattenSuites(
+  suite: PlaywrightJsonSuite,
+  parentTitle = "",
+): Array<{ title: string; result: PlaywrightJsonResult | undefined }> {
+  const out: Array<{ title: string; result: PlaywrightJsonResult | undefined }> = [];
+  const fullTitle =
+    parentTitle && suite.title ? `${parentTitle} › ${suite.title}` : (suite.title ?? parentTitle);
+
+  for (const spec of suite.specs ?? []) {
+    const specTitle = fullTitle ? `${fullTitle} › ${spec.title}` : spec.title;
+    for (const test of spec.tests ?? []) {
+      const lastResult = test.results?.[test.results.length - 1];
+      out.push({ title: specTitle, result: lastResult });
+    }
+  }
+
+  for (const child of suite.suites ?? []) {
+    out.push(...flattenSuites(child, fullTitle));
+  }
+
+  return out;
+}
+
+function normalizeStatus(s: string | undefined): PassthroughResult {
+  if (s === "passed") {
+    return "passed";
+  }
+  if (s === "skipped") {
+    return "skipped";
+  }
+  return "failed";
+}
+
+function parsePlaywrightJson(json: string): PassthroughRunResult[] {
+  const report = JSON.parse(json) as PlaywrightJsonReport;
+  const flat: PassthroughRunResult[] = [];
+  for (const suite of report.suites ?? []) {
+    for (const item of flattenSuites(suite)) {
+      const status = normalizeStatus(item.result?.status);
+      const errMsg = item.result?.error?.message ?? item.result?.errors?.[0]?.message;
+      flat.push({
+        passthrough: extractPassthroughKey(item.title),
+        testTitle: item.title,
+        status,
+        durationMs: Math.round(item.result?.duration ?? 0),
+        errorMessage: errMsg ? String(errMsg).slice(0, 500) : undefined,
+      });
+    }
+  }
+  return flat;
+}
+
+/**
+ * Run the passthrough test suite. Returns structured results.
+ *
+ * Required env vars:
+ * - SCOPELY_REPO_PATH: absolute path to the Scopely repo (where playwright.config.ts lives)
+ *
+ * Optional env vars:
+ * - SCOPELY_URL, SCOPELY_EMAIL, SCOPELY_PASSWORD: passed through to the test process
+ *   (will become E2E_BACKEND_URL, E2E_FRONTEND_URL, E2E_EMAIL, E2E_PASSWORD)
+ * - PASSTHROUGH_TEST_TIMEOUT_MS: max wall time for the whole run (default 5 min)
+ */
+export async function runPassthroughTests(): Promise<PassthroughRunSummary> {
+  const startedAt = new Date();
+  const start = Date.now();
+
+  const repoPath = process.env.SCOPELY_REPO_PATH;
+  if (!repoPath || !fs.existsSync(repoPath)) {
+    return {
+      startedAt,
+      durationMs: 0,
+      results: [],
+      ranSuccessfully: false,
+      runError: `SCOPELY_REPO_PATH not set or directory does not exist: ${repoPath ?? "(unset)"}`,
+    };
+  }
+
+  const timeoutMs = Number(process.env.PASSTHROUGH_TEST_TIMEOUT_MS ?? 5 * 60 * 1000);
+  const tmpFile = path.join(os.tmpdir(), `passthrough-${Date.now()}.json`);
+
+  // Forward SCOPELY_* creds into the E2E_* env the tests expect
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    PLAYWRIGHT_JSON_OUTPUT_NAME: tmpFile,
+    E2E_BACKEND_URL: process.env.E2E_BACKEND_URL ?? process.env.SCOPELY_URL,
+    E2E_FRONTEND_URL: process.env.E2E_FRONTEND_URL ?? process.env.SCOPELY_URL,
+    E2E_EMAIL: process.env.E2E_EMAIL ?? process.env.SCOPELY_EMAIL,
+    E2E_PASSWORD: process.env.E2E_PASSWORD ?? process.env.SCOPELY_PASSWORD,
+  };
+
+  const args = ["playwright", "test", "--project=passthrough", "--reporter=json"];
+
+  const spawnResult = await new Promise<{ exitCode: number; stdout: string; stderr: string }>(
+    (resolve) => {
+      const child = spawn("npx", args, {
+        cwd: repoPath,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.on("data", (d) => (stdout += d.toString()));
+      child.stderr?.on("data", (d) => (stderr += d.toString()));
+
+      const killTimer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, timeoutMs);
+
+      child.on("close", (code) => {
+        clearTimeout(killTimer);
+        resolve({ exitCode: code ?? -1, stdout, stderr });
+      });
+      child.on("error", (err) => {
+        clearTimeout(killTimer);
+        resolve({ exitCode: -1, stdout, stderr: stderr + String(err) });
+      });
+    },
+  );
+
+  const durationMs = Date.now() - start;
+
+  // Playwright writes JSON to PLAYWRIGHT_JSON_OUTPUT_NAME if set, else stdout
+  let jsonContent = "";
+  if (fs.existsSync(tmpFile)) {
+    try {
+      jsonContent = fs.readFileSync(tmpFile, "utf-8");
+      fs.unlinkSync(tmpFile);
+    } catch {
+      // fall through to stdout
+    }
+  }
+  if (!jsonContent) {
+    // Playwright sometimes writes JSON to stdout — try to extract it
+    const jsonStart = spawnResult.stdout.indexOf("{");
+    if (jsonStart >= 0) {
+      jsonContent = spawnResult.stdout.slice(jsonStart);
+    }
+  }
+
+  if (!jsonContent) {
+    return {
+      startedAt,
+      durationMs,
+      results: [],
+      ranSuccessfully: false,
+      runError: `Playwright produced no JSON output. Exit code: ${spawnResult.exitCode}. Stderr: ${spawnResult.stderr.slice(0, 500)}`,
+    };
+  }
+
+  let results: PassthroughRunResult[];
+  try {
+    results = parsePlaywrightJson(jsonContent);
+  } catch (err) {
+    return {
+      startedAt,
+      durationMs,
+      results: [],
+      ranSuccessfully: false,
+      runError: `Failed to parse Playwright JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Playwright exits non-zero when tests fail — that's NOT a runner error,
+  // it's the expected signal. Only treat unexpected exits as runner errors.
+  // If we got results, the runner worked, regardless of pass/fail counts.
+  return {
+    startedAt,
+    durationMs,
+    results,
+    ranSuccessfully: true,
+  };
+}

--- a/extensions/scopelybot/src/passthrough-state.test.ts
+++ b/extensions/scopelybot/src/passthrough-state.test.ts
@@ -1,0 +1,158 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyRunResults,
+  getNewlyFailingTests,
+  getRecoveredTests,
+  readState,
+} from "./passthrough-state.js";
+
+describe("passthrough-state", () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "scopelybot-state-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("returns default empty state when no file exists", () => {
+    const state = readState(workspaceDir);
+    expect(state.lastRun).toBeNull();
+    expect(state.tests).toEqual({});
+  });
+
+  it("increments consecutiveFailures for a failing test", () => {
+    const startedAt = new Date();
+
+    // First run: fail
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    const state1 = readState(workspaceDir);
+    expect(state1.tests["[p1] test"].consecutiveFailures).toBe(1);
+
+    // Second run: still fail
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    const state2 = readState(workspaceDir);
+    expect(state2.tests["[p1] test"].consecutiveFailures).toBe(2);
+  });
+
+  it("resets consecutiveFailures when a previously-failing test passes", () => {
+    const startedAt = new Date();
+
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "passed", durationMs: 50 }],
+      startedAt,
+      50,
+    );
+
+    expect(readState(workspaceDir).tests["[p1] test"].consecutiveFailures).toBe(0);
+  });
+
+  it("getNewlyFailingTests returns tests crossing the threshold this run", () => {
+    const startedAt = new Date();
+
+    // Run 1: fail (count = 1, below threshold)
+    const r1 = applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    expect(getNewlyFailingTests(r1.previous, r1.current, 2)).toEqual([]);
+
+    // Run 2: fail again (count = 2, meets threshold) — should alert
+    const r2 = applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    const newlyFailing = getNewlyFailingTests(r2.previous, r2.current, 2);
+    expect(newlyFailing).toHaveLength(1);
+    expect(newlyFailing[0].passthrough).toBe("p1");
+
+    // Run 3: still failing (count = 3, already past threshold) — should NOT alert again
+    const r3 = applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    expect(getNewlyFailingTests(r3.previous, r3.current, 2)).toEqual([]);
+  });
+
+  it("getRecoveredTests returns tests that recovered from failing past threshold", () => {
+    const startedAt = new Date();
+
+    // Get to failing state past threshold
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+
+    // Now recover
+    const r = applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "passed", durationMs: 50 }],
+      startedAt,
+      50,
+    );
+    const recovered = getRecoveredTests(r.previous, r.current, 2);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].passthrough).toBe("p1");
+  });
+
+  it("does not report recovery for tests that never crossed the threshold", () => {
+    const startedAt = new Date();
+
+    // Single fail (below threshold), then pass — should NOT report recovery
+    applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "failed", durationMs: 100 }],
+      startedAt,
+      100,
+    );
+    const r = applyRunResults(
+      workspaceDir,
+      [{ passthrough: "p1", testTitle: "[p1] test", status: "passed", durationMs: 50 }],
+      startedAt,
+      50,
+    );
+    expect(getRecoveredTests(r.previous, r.current, 2)).toEqual([]);
+  });
+});

--- a/extensions/scopelybot/src/passthrough-state.ts
+++ b/extensions/scopelybot/src/passthrough-state.ts
@@ -1,0 +1,156 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Persistent state for passthrough test results.
+ * Stored at ~/.openclaw/workspace/scopelybot/passthrough-state.json so
+ * the OpenClaw runner can survive restarts and track consecutive failures.
+ */
+
+export type PassthroughResult = "passed" | "failed" | "skipped";
+
+export interface PassthroughTestState {
+  passthrough: string; // e.g. "bighead-launch"
+  testTitle: string; // full test title for context
+  status: PassthroughResult;
+  lastChecked: string; // ISO 8601
+  durationMs: number;
+  errorMessage?: string;
+  consecutiveFailures: number;
+}
+
+export interface PassthroughState {
+  lastRun: string | null; // ISO 8601 of most recent run
+  lastRunDurationMs: number;
+  tests: Record<string, PassthroughTestState>; // keyed by test title
+}
+
+const DEFAULT_STATE: PassthroughState = {
+  lastRun: null,
+  lastRunDurationMs: 0,
+  tests: {},
+};
+
+function getStateFilePath(workspaceDir: string): string {
+  return path.join(workspaceDir, "scopelybot", "passthrough-state.json");
+}
+
+export function readState(workspaceDir: string): PassthroughState {
+  const file = getStateFilePath(workspaceDir);
+  try {
+    if (!fs.existsSync(file)) {
+      return { ...DEFAULT_STATE };
+    }
+    const raw = fs.readFileSync(file, "utf-8");
+    const parsed = JSON.parse(raw) as PassthroughState;
+    // Defensive: ensure shape
+    return {
+      lastRun: parsed.lastRun ?? null,
+      lastRunDurationMs: parsed.lastRunDurationMs ?? 0,
+      tests: parsed.tests ?? {},
+    };
+  } catch (err) {
+    console.error("[scopelybot-passthrough] failed to read state, using defaults:", err);
+    return { ...DEFAULT_STATE };
+  }
+}
+
+export function writeState(workspaceDir: string, state: PassthroughState): void {
+  const file = getStateFilePath(workspaceDir);
+  try {
+    const dir = path.dirname(file);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error("[scopelybot-passthrough] failed to write state:", err);
+  }
+}
+
+/**
+ * Update state with the latest run results.
+ * - Increments consecutiveFailures for failing tests, resets to 0 on pass
+ * - Returns the previous state (so callers can detect transitions for alerting)
+ */
+export function applyRunResults(
+  workspaceDir: string,
+  results: Array<{
+    passthrough: string;
+    testTitle: string;
+    status: PassthroughResult;
+    durationMs: number;
+    errorMessage?: string;
+  }>,
+  runStartedAt: Date,
+  runDurationMs: number,
+): { previous: PassthroughState; current: PassthroughState } {
+  const previous = readState(workspaceDir);
+  const current: PassthroughState = {
+    lastRun: runStartedAt.toISOString(),
+    lastRunDurationMs: runDurationMs,
+    tests: { ...previous.tests },
+  };
+
+  for (const r of results) {
+    const prevTest = previous.tests[r.testTitle];
+    const consecutiveFailures =
+      r.status === "failed" ? (prevTest?.consecutiveFailures ?? 0) + 1 : 0;
+
+    current.tests[r.testTitle] = {
+      passthrough: r.passthrough,
+      testTitle: r.testTitle,
+      status: r.status,
+      lastChecked: runStartedAt.toISOString(),
+      durationMs: r.durationMs,
+      errorMessage: r.errorMessage,
+      consecutiveFailures,
+    };
+  }
+
+  writeState(workspaceDir, current);
+  return { previous, current };
+}
+
+/**
+ * Returns tests that crossed the alert threshold on this run.
+ * A test crosses the threshold when its consecutiveFailures becomes >= threshold
+ * AND it was below threshold (or absent) in the previous state — this prevents
+ * alerting on every run while a passthrough is broken.
+ */
+export function getNewlyFailingTests(
+  previous: PassthroughState,
+  current: PassthroughState,
+  threshold: number,
+): PassthroughTestState[] {
+  const newlyFailing: PassthroughTestState[] = [];
+  for (const [title, test] of Object.entries(current.tests)) {
+    if (test.consecutiveFailures < threshold) {
+      continue;
+    }
+    const prevFailures = previous.tests[title]?.consecutiveFailures ?? 0;
+    if (prevFailures < threshold) {
+      newlyFailing.push(test);
+    }
+  }
+  return newlyFailing;
+}
+
+/**
+ * Returns tests that recovered on this run (were failing >= threshold, now passing).
+ */
+export function getRecoveredTests(
+  previous: PassthroughState,
+  current: PassthroughState,
+  threshold: number,
+): PassthroughTestState[] {
+  const recovered: PassthroughTestState[] = [];
+  for (const [title, test] of Object.entries(current.tests)) {
+    if (test.status !== "passed") {
+      continue;
+    }
+    const prevFailures = previous.tests[title]?.consecutiveFailures ?? 0;
+    if (prevFailures >= threshold) {
+      recovered.push(test);
+    }
+  }
+  return recovered;
+}

--- a/extensions/scopelybot/src/passthrough-tools.ts
+++ b/extensions/scopelybot/src/passthrough-tools.ts
@@ -1,0 +1,90 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { runPassthroughCycle } from "./passthrough-runner-cycle.js";
+import { readState } from "./passthrough-state.js";
+import { jsonResult, errorResult } from "./scopely-api.js";
+
+export function registerPassthroughTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  workspaceDir: string,
+) {
+  // scopely_passthrough_status — "Are all the passthroughs healthy?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_passthrough_status",
+        description:
+          "Get the current health status of every Scopely passthrough being monitored. " +
+          "Shows last run timestamp, pass/fail status per passthrough, and consecutive failure counts. " +
+          "Use this to answer 'are the integrations healthy' or 'when did the last check run'.",
+        parameters: Type.Object({
+          only_failing: Type.Optional(
+            Type.Boolean({ description: "Only show currently failing passthroughs" }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const state = readState(workspaceDir);
+            const tests = Object.values(state.tests);
+            const filtered = params.only_failing
+              ? tests.filter((t) => t.status !== "passed")
+              : tests;
+
+            const summary = {
+              ok: true,
+              last_run: state.lastRun,
+              last_run_duration_ms: state.lastRunDurationMs,
+              total_tests: tests.length,
+              passing: tests.filter((t) => t.status === "passed").length,
+              failing: tests.filter((t) => t.status === "failed").length,
+              skipped: tests.filter((t) => t.status === "skipped").length,
+              tests: filtered.map((t) => ({
+                passthrough: t.passthrough,
+                test_title: t.testTitle,
+                status: t.status,
+                last_checked: t.lastChecked,
+                duration_ms: t.durationMs,
+                consecutive_failures: t.consecutiveFailures,
+                error_message: t.errorMessage,
+              })),
+            };
+
+            return jsonResult(summary);
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_passthrough_run_now — "Force a passthrough check right now"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_passthrough_run_now",
+        description:
+          "Trigger an immediate passthrough test run instead of waiting for the next scheduled cycle. " +
+          "Returns the run summary including pass/fail counts and any newly-failing passthroughs. " +
+          "Useful after a deploy or when investigating a reported issue.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const summary = await runPassthroughCycle(workspaceDir, { source: "manual" });
+            return jsonResult({
+              ok: true,
+              ...summary,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/scopely-api.ts
+++ b/extensions/scopelybot/src/scopely-api.ts
@@ -1,0 +1,74 @@
+import { scopelyGetAccessToken, scopelyClearSession } from "./scopely-auth.js";
+
+const SCOPELY_URL = () => process.env.SCOPELY_URL ?? "https://scopely.pscx.ai";
+
+export interface ScopelyFetchResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+}
+
+export async function scopelyFetch(
+  path: string,
+  opts?: RequestInit & { retried?: boolean },
+): Promise<ScopelyFetchResult> {
+  const token = await scopelyGetAccessToken();
+  const url = `${SCOPELY_URL()}${path}`;
+
+  const headers: Record<string, string> = {
+    ...(opts?.headers as Record<string, string> | undefined),
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts?.body) {
+    headers["Content-Type"] = "application/json";
+  }
+  const resp = await fetch(url, {
+    ...opts,
+    headers,
+  });
+
+  // If 401, refresh token and retry once
+  if (resp.status === 401 && !opts?.retried) {
+    scopelyClearSession();
+    return scopelyFetch(path, { ...opts, retried: true });
+  }
+
+  const data = resp.headers.get("content-type")?.includes("application/json")
+    ? await resp.json()
+    : await resp.text();
+
+  return { ok: resp.ok, status: resp.status, data };
+}
+
+export function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+export function errorResult(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
+}
+
+export function buildQuery(params: Record<string, unknown>, keys: string[]): string {
+  const qs = new URLSearchParams();
+  for (const key of keys) {
+    const value = params[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    // Only stringify primitives — skip objects/arrays so we don't emit "[object Object]"
+    if (typeof value === "string") {
+      qs.set(key, value);
+    } else if (
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      typeof value === "bigint"
+    ) {
+      qs.set(key, String(value));
+    }
+  }
+  const str = qs.toString();
+  return str ? `?${str}` : "";
+}

--- a/extensions/scopelybot/src/scopely-auth.ts
+++ b/extensions/scopelybot/src/scopely-auth.ts
@@ -1,0 +1,120 @@
+const SCOPELY_URL = () => process.env.SCOPELY_URL ?? "https://scopely.pscx.ai";
+const SCOPELY_EMAIL = () => process.env.SCOPELY_EMAIL ?? "";
+const SCOPELY_PASSWORD = () => process.env.SCOPELY_PASSWORD ?? "";
+
+interface TokenPair {
+  access: string;
+  refresh: string;
+  accessExpiry: number;
+  refreshExpiry: number;
+}
+
+let cachedTokens: TokenPair | null = null;
+
+// Access tokens last 1h, refresh 7d — refresh access 5 min before expiry
+const ACCESS_BUFFER_MS = 5 * 60 * 1000;
+
+export async function scopelyLogin(): Promise<TokenPair> {
+  const baseUrl = SCOPELY_URL();
+  const email = SCOPELY_EMAIL();
+  const password = SCOPELY_PASSWORD();
+
+  if (!email || !password) {
+    throw new Error("SCOPELY_EMAIL and SCOPELY_PASSWORD must be set");
+  }
+
+  const resp = await fetch(`${baseUrl}/api/v1/auth/login/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Scopely login failed (${resp.status}): ${body.slice(0, 300)}`);
+  }
+
+  const data = (await resp.json()) as {
+    access: string;
+    refresh: string;
+    access_expiration?: string;
+    refresh_expiration?: string;
+  };
+
+  if (!data.access || !data.refresh) {
+    throw new Error("Scopely login response missing access/refresh tokens");
+  }
+
+  const now = Date.now();
+  cachedTokens = {
+    access: data.access,
+    refresh: data.refresh,
+    // Default: access 1h, refresh 7d
+    accessExpiry: data.access_expiration
+      ? new Date(data.access_expiration).getTime()
+      : now + 60 * 60 * 1000,
+    refreshExpiry: data.refresh_expiration
+      ? new Date(data.refresh_expiration).getTime()
+      : now + 7 * 24 * 60 * 60 * 1000,
+  };
+
+  return cachedTokens;
+}
+
+export async function scopelyRefreshToken(): Promise<TokenPair> {
+  if (!cachedTokens?.refresh) {
+    return scopelyLogin();
+  }
+
+  // If refresh token itself is expired, do a full login
+  if (Date.now() >= cachedTokens.refreshExpiry - ACCESS_BUFFER_MS) {
+    return scopelyLogin();
+  }
+
+  const baseUrl = SCOPELY_URL();
+  const resp = await fetch(`${baseUrl}/api/v1/auth/refresh/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh: cachedTokens.refresh }),
+  });
+
+  if (!resp.ok) {
+    // Refresh failed, try full login
+    cachedTokens = null;
+    return scopelyLogin();
+  }
+
+  const data = (await resp.json()) as { access: string; access_expiration?: string };
+  if (!data.access) {
+    cachedTokens = null;
+    return scopelyLogin();
+  }
+
+  cachedTokens = {
+    ...cachedTokens,
+    access: data.access,
+    accessExpiry: data.access_expiration
+      ? new Date(data.access_expiration).getTime()
+      : Date.now() + 60 * 60 * 1000,
+  };
+
+  return cachedTokens;
+}
+
+export async function scopelyGetAccessToken(): Promise<string> {
+  if (cachedTokens && Date.now() < cachedTokens.accessExpiry - ACCESS_BUFFER_MS) {
+    return cachedTokens.access;
+  }
+
+  if (cachedTokens?.refresh) {
+    const tokens = await scopelyRefreshToken();
+    return tokens.access;
+  }
+
+  const tokens = await scopelyLogin();
+  return tokens.access;
+}
+
+export function scopelyClearSession(): void {
+  cachedTokens = null;
+}

--- a/extensions/scopelybot/src/scopely-tools.ts
+++ b/extensions/scopelybot/src/scopely-tools.ts
@@ -1,0 +1,430 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { scopelyFetch, jsonResult, errorResult, buildQuery } from "./scopely-api.js";
+
+export function registerScopelyTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // scopely_auth_status — "Are we connected?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_auth_status",
+        description:
+          "Check Scopely VIP authentication status. Returns current session and user info.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const result = await scopelyFetch("/api/v1/auth/me/");
+            if (!result.ok) {
+              return jsonResult({ ok: false, error: `HTTP ${result.status}` });
+            }
+            return jsonResult({ ok: true, user: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_health_check — "Is the service up?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_health_check",
+        description:
+          "Check Scopely VIP service health. Returns service status and database connectivity. " +
+          "Use this to determine if there is an immediate infrastructure problem.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const baseUrl = process.env.SCOPELY_URL ?? "https://scopely.pscx.ai";
+            const resp = await fetch(`${baseUrl}/health/`);
+            const data = resp.headers.get("content-type")?.includes("application/json")
+              ? await resp.json()
+              : await resp.text();
+            return jsonResult({ ok: resp.ok, status: resp.status, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_list_users — "Who are the users?" / "Who was the last person to login?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_list_users",
+        description:
+          "List Scopely VIP users. Returns user profiles with roles, organizations, last_login, and session count. " +
+          "Use this to answer 'who was the last person to login' or 'who are the active users'. " +
+          "Set ordering to '-last_login' to sort by most recent login.",
+        parameters: Type.Object({
+          role: Type.Optional(
+            Type.String({
+              description: "Filter by role (platform_admin, power_user, org_admin, user)",
+            }),
+          ),
+          search: Type.Optional(Type.String({ description: "Search by name or email" })),
+          ordering: Type.Optional(
+            Type.String({
+              description:
+                "Sort order: -last_login, last_login, -created_at, created_at (default: -created_at)",
+            }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, ["role", "search", "ordering"]);
+            const result = await scopelyFetch(`/api/v1/auth/users/${qs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_list_sessions — "What scoping sessions exist?" / "What are users working on?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_list_sessions",
+        description:
+          "List Scopely VIP scoping sessions. Shows wizard sessions with status, step, company, and creator. " +
+          "Use this to see what users are clicking on and what they are working on.",
+        parameters: Type.Object({
+          status: Type.Optional(
+            Type.String({ description: "Filter: in_progress, generated, cancelled, converted" }),
+          ),
+          vendor: Type.Optional(Type.String({ description: "Filter by destination vendor" })),
+          search: Type.Optional(Type.String({ description: "Search by company name or contact" })),
+          created_by: Type.Optional(Type.String({ description: "Filter by creator user ID" })),
+          date_from: Type.Optional(Type.String({ description: "Start date filter (YYYY-MM-DD)" })),
+          date_to: Type.Optional(Type.String({ description: "End date filter (YYYY-MM-DD)" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, [
+              "status",
+              "vendor",
+              "search",
+              "created_by",
+              "date_from",
+              "date_to",
+              "limit",
+            ]);
+            const result = await scopelyFetch(`/api/v1/admin/sessions/${qs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_get_session — "Tell me about session X"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_get_session",
+        description:
+          "Get detailed info about a specific Scopely VIP scoping session. " +
+          "Returns wizard state, answers, pricing, status, company info, and who created it.",
+        parameters: Type.Object({
+          id: Type.String({ description: "Session ID" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const result = await scopelyFetch(
+              `/api/v1/admin/sessions/${encodeURIComponent(params.id as string)}/`,
+            );
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_active_users — "Who is using the app right now?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_active_users",
+        description:
+          "Get count of currently active Scopely VIP users (active in last 5 minutes) and active extraction sessions. " +
+          "Use this to see if users are currently in the system.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            const result = await scopelyFetch("/api/v1/extraction-monitor/metrics/");
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            const metrics = result.data as Record<string, unknown>;
+            const live = metrics.live as Record<string, unknown> | undefined;
+            return jsonResult({
+              ok: true,
+              active_sessions: live?.active_sessions ?? 0,
+              wizard_users_online: live?.wizard_users_online ?? 0,
+              raw_metrics: metrics,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_recent_errors — "What was the last error produced?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_recent_errors",
+        description:
+          "Get recent errors from Scopely VIP. Queries the ActivityLog for exceptions, request failures, " +
+          "and failed extractions. Use this to answer 'what was the last error' or 'are there any problems right now'.",
+        parameters: Type.Object({
+          limit: Type.Optional(Type.Number({ description: "Max results (default 10)" })),
+          since: Type.Optional(
+            Type.String({ description: "Only errors after this time (ISO 8601)" }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const limit = (params.limit as number) || 10;
+
+            // Query real error/warning events from ActivityLog
+            const activityQs = new URLSearchParams({
+              event: "exception.unhandled",
+              limit: String(limit),
+            });
+            if (params.since) {
+              activityQs.set("since", params.since as string);
+            }
+            const errorResult_1 = await scopelyFetch(
+              `/api/v1/admin/activity/?${activityQs.toString()}&event=request.failed`,
+            );
+            const activityErrors = errorResult_1.ok ? errorResult_1.data : [];
+
+            // Also check 5xx request events
+            const requestQs = new URLSearchParams({
+              event: "request.completed",
+              level: "error",
+              limit: String(limit),
+            });
+            if (params.since) {
+              requestQs.set("since", params.since as string);
+            }
+            const requestResult = await scopelyFetch(
+              `/api/v1/admin/activity/?${requestQs.toString()}`,
+            );
+            const serverErrors = requestResult.ok ? requestResult.data : [];
+
+            // Check failed extraction sessions
+            const extractionResult = await scopelyFetch(
+              `/api/v1/extraction-monitor/sessions/?status=failed&limit=${limit}`,
+            );
+            const failedExtractions = extractionResult.ok ? extractionResult.data : [];
+
+            return jsonResult({
+              ok: true,
+              activity_errors: activityErrors,
+              server_errors: serverErrors,
+              failed_extractions: failedExtractions,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_search — "Find anything related to X"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_search",
+        description:
+          "Search across Scopely VIP sessions by company name, contact, or content. " +
+          "Useful for finding specific deals, companies, or user activity.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query (company name, email, keyword)" }),
+          status: Type.Optional(Type.String({ description: "Filter by status" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = buildQuery(params, ["search", "status", "limit"]);
+            // Map 'query' to 'search' param for the API
+            const searchQs = qs
+              ? `${qs}&search=${encodeURIComponent(params.query as string)}`
+              : `?search=${encodeURIComponent(params.query as string)}`;
+            const result = await scopelyFetch(`/api/v1/admin/sessions/${searchQs}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_user_activity — "What has user X been doing?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_user_activity",
+        description:
+          "Get a user's recent activity timeline from Scopely VIP. Shows logins, session operations, " +
+          "wizard steps, pricing calculations, SOW generation, and API requests. " +
+          "Use this to answer 'what has this user been doing' or 'show me their recent activity'.",
+        parameters: Type.Object({
+          user_id: Type.String({ description: "User ID to query activity for" }),
+          event: Type.Optional(
+            Type.String({
+              description: "Filter by event type (e.g. auth.login_success, wizard.step_completed)",
+            }),
+          ),
+          since: Type.Optional(
+            Type.String({ description: "Only activity after this time (ISO 8601)" }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const qs = new URLSearchParams({
+              user: String(params.user_id),
+              limit: String((params.limit as number) || 50),
+            });
+            if (params.event) {
+              qs.set("event", params.event as string);
+            }
+            if (params.since) {
+              qs.set("since", params.since as string);
+            }
+            const result = await scopelyFetch(`/api/v1/admin/activity/?${qs.toString()}`);
+            if (!result.ok) {
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            }
+            return jsonResult({ ok: true, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_recent_logins — "Who logged in today?" / "Any login failures?"
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_recent_logins",
+        description:
+          "Get recent login events from Scopely VIP. Shows successful and failed login attempts with user, IP, and timestamp. " +
+          "Use this to answer 'who logged in today' or 'were there any failed login attempts'.",
+        parameters: Type.Object({
+          include_failures: Type.Optional(
+            Type.Boolean({ description: "Include failed login attempts (default: true)" }),
+          ),
+          since: Type.Optional(
+            Type.String({ description: "Only logins after this time (ISO 8601)" }),
+          ),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const limit = String((params.limit as number) || 20);
+            const includeFail = params.include_failures !== false;
+
+            // Successful logins
+            const successQs = new URLSearchParams({ event: "auth.login_success", limit });
+            if (params.since) {
+              successQs.set("since", params.since as string);
+            }
+            const successResult = await scopelyFetch(
+              `/api/v1/admin/activity/?${successQs.toString()}`,
+            );
+            const successes = successResult.ok ? successResult.data : [];
+
+            // Failed logins (if requested)
+            let failures: unknown = [];
+            if (includeFail) {
+              const failQs = new URLSearchParams({ event: "auth.login_failure", limit });
+              if (params.since) {
+                failQs.set("since", params.since as string);
+              }
+              const failResult = await scopelyFetch(`/api/v1/admin/activity/?${failQs.toString()}`);
+              failures = failResult.ok ? failResult.data : [];
+            }
+
+            return jsonResult({
+              ok: true,
+              successful_logins: successes,
+              failed_logins: failures,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
Adds the ScopelyBot OpenClaw plugin — a Zoom Workplace chat bot that answers natural-language observability questions about Scopely VIP and runs the passthrough test suite on a schedule, alerting the channel when integrations break.

## Plugin contents (28 tools across 6 categories)
- **Observability (10):** `scopely_auth_status`, `scopely_health_check`, `scopely_list_users`, `scopely_list_sessions`, `scopely_get_session`, `scopely_active_users`, `scopely_recent_errors`, `scopely_search`, `scopely_user_activity`, `scopely_recent_logins`
- **Admin (5):** `scopely_dashboard_stats`, `scopely_audit_logs`, `scopely_pending_approvals`, `scopely_vendor_config`, `scopely_session_pricing`
- **Monitoring (4):** `scopely_extraction_metrics`, `scopely_extraction_sessions`, `scopely_extraction_detail`, `scopely_wizard_funnel`
- **GitHub (6):** `scopely_gh_list_issues`, `scopely_gh_get_issue`, `scopely_gh_create_issue`, `scopely_gh_add_comment`, `scopely_gh_search_issues`, `scopely_gh_close_issue`
- **Correlation (1):** `scopely_correlate_errors` — cross-references container logs with GitHub issues
- **Passthrough (2):** `scopely_passthrough_status`, `scopely_passthrough_run_now`

## Passthrough runner
- Shells out to `playwright test --project=passthrough --reporter=json` against the Scopely repo (path via `SCOPELY_REPO_PATH`)
- Parses JSON output, extracts passthrough keys from `[brackets]` in test titles
- Tracks consecutive failures in `~/.openclaw/workspace/scopelybot/passthrough-state.json`
- Posts structured Zoom alerts **after 2 consecutive failures**, with separate alerts for recoveries and runner errors
- Scheduled every 5 min (configurable via `PASSTHROUGH_INTERVAL_MS`, hard floor 60s) via a `gateway:startup` hook
- **Disabled by default** — enable with `PASSTHROUGH_RUNNER_ENABLED=1`

## Auth
JWT against the Scopely Django backend (`SCOPELY_EMAIL` / `SCOPELY_PASSWORD`) with auto-refresh on 401. Distinct from PulseBot's cookie-based auth.

## Architecture
Follows PulseBot's pattern exactly. All Scopely-specific logic stays inside `extensions/scopelybot/` — no core changes.

## Pairs with
- cloudwarriors-ai/scopely#420 — Phase 1 ActivityLog (provides the `/api/v1/admin/activity/` endpoint several observability tools query)
- cloudwarriors-ai/scopely#421 — passthrough test suite that this runner shells out to

## Test plan
- [ ] Unit tests pass: `npm test -- extensions/scopelybot/` (covers state-transition logic that drives alerting)
- [ ] With `PASSTHROUGH_RUNNER_ENABLED=0` (default), plugin loads and runner does not start — confirm via startup logs
- [ ] With `PASSTHROUGH_RUNNER_ENABLED=1` + a valid `SCOPELY_REPO_PATH`, runner fires at the configured interval and writes to `passthrough-state.json`
- [ ] Force a passthrough failure twice → Zoom alert posted; recovery → recovery alert posted
- [ ] Each of the 28 tools invoked via natural language in the channel returns a sensible response

🤖 Generated with [Claude Code](https://claude.com/claude-code)