### PR TITLE
mesh: write task-completed memory to close omni-mem task_status loop

### DIFF
--- a/extensions/mesh-gateway/README.md
+++ b/extensions/mesh-gateway/README.md
@@ -36,3 +36,15 @@ Authorization is explicit allowlist only:
 - If `allowedAgents` is set, inbound `from_agent` must also match that list.
 
 `mesh.send_task` is async-first. It returns `accepted`, then emits `running` and terminal `completed`, `failed`, or `rejected` callbacks as `mesh.task` events on the same gateway connection.
+
+## Task completion memory (for manager-side `task_status`)
+
+After each mesh task reaches a terminal state, the extension POSTs a `task-completed:<task_id>` memory to the local omni-mem HTTP API. The memory body includes a `<task-meta>JSON</task-meta>` block with `{ kind: "task_completion_record", task_id, status, completed_by, ... }` so that the manager-side [`task_status` MCP tool](https://github.com/Chaddacus/omni-mem) can close the loop by correlating dispatch records with completion records by `task_id`.
+
+| Config key                    | Default                 | Purpose                                                     |
+| ----------------------------- | ----------------------- | ----------------------------------------------------------- |
+| `completionMemoryEnabled`     | `true`                  | Set to `false` to skip the POST entirely (legacy behavior). |
+| `localOmniMemUrl`             | `http://localhost:8765` | Base URL of the local omni-mem HTTP server.                 |
+| `completionMemoryWorkspaceId` | `"default"`             | `workspaceId` field on the saved memory.                    |
+
+The POST is best-effort — failures are logged via the plugin logger and do not change the `mesh.task` event stream.

--- a/extensions/mesh-gateway/index.test.ts
+++ b/extensions/mesh-gateway/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCronIsolatedAgentTurn } from "../../src/cron/isolated-agent.js";
 import type {
   GatewayRequestHandler,
@@ -16,8 +16,9 @@ vi.mock("../../src/cron/isolated-agent.js", () => ({
   })),
 }));
 
-function createApi() {
+function createApi(pluginConfigOverrides: Record<string, unknown> = {}) {
   const handlers = new Map<string, GatewayRequestHandler>();
+  const warn = vi.fn();
   const api = {
     id: "mesh-gateway",
     name: "Mesh Gateway",
@@ -27,11 +28,12 @@ function createApi() {
       enabled: true,
       displayName: "Chad Agent",
       allowedUsers: ["chad.simon@cloudwarriors.ai"],
+      ...pluginConfigOverrides,
     },
     runtime: {},
     logger: {
       info: vi.fn(),
-      warn: vi.fn(),
+      warn,
       error: vi.fn(),
     },
     registerGatewayMethod(method: string, handler: GatewayRequestHandler) {
@@ -50,7 +52,7 @@ function createApi() {
     on: vi.fn(),
   } as unknown as OpenClawPluginApi;
   plugin.register(api);
-  return { api, handlers };
+  return { api, handlers, warn };
 }
 
 function createOptions(
@@ -83,8 +85,20 @@ function createOptions(
 }
 
 describe("mesh-gateway plugin", () => {
+  const originalFetch = globalThis.fetch;
+  let fetchMock: ReturnType<typeof vi.fn>;
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no-op fetch mock so the completion-memory POST never touches
+    // a real network. Individual tests can capture calls by inspecting
+    // `fetchMock.mock.calls` or by replacing the implementation.
+    fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ id: "mem-test" }), { status: 200 }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   it("registers the mesh RPC surface", () => {
@@ -182,5 +196,104 @@ describe("mesh-gateway plugin", () => {
       expect.objectContaining({ task_id: "task-1", status: "running" }),
       new Set(["conn-1"]),
     );
+  });
+
+  it("posts a task-completed memory with a <task-meta> block after a successful run", async () => {
+    const { handlers } = createApi({ localOmniMemUrl: "http://127.0.0.1:9999" });
+    const opts = createOptions({
+      task_id: "task-completion-1",
+      from_agent: "daniel",
+      dispatched_by: "chad.simon@cloudwarriors.ai",
+      title: "mesh test",
+      message: "run it",
+    });
+
+    handlers.get("mesh.send_task")?.(opts);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://127.0.0.1:9999/api/save-memory");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.title).toBe("task-completed:task-completion-1");
+    expect(body.workspaceId).toBe("default");
+    expect(body.text).toContain("<task-meta>");
+    expect(body.text).toContain("</task-meta>");
+    const metaMatch = (body.text as string).match(/<task-meta>(.*)<\/task-meta>/s);
+    expect(metaMatch).toBeTruthy();
+    const meta = JSON.parse(metaMatch![1]!);
+    expect(meta).toMatchObject({
+      kind: "task_completion_record",
+      task_id: "task-completion-1",
+      status: "completed",
+      completed_by: "chad.simon@cloudwarriors.ai",
+      from_agent: "daniel",
+      dispatched_by: "chad.simon@cloudwarriors.ai",
+      simulated: false,
+    });
+    expect(meta.completed_at).toBeTruthy();
+  });
+
+  it("records a failure completion when the isolated agent errors", async () => {
+    const mocked = vi.mocked(runCronIsolatedAgentTurn);
+    mocked.mockRejectedValueOnce(new Error("isolated boom"));
+    const { handlers } = createApi();
+    const opts = createOptions({
+      task_id: "task-failure-1",
+      from_agent: "daniel",
+      dispatched_by: "chad@test",
+      message: "run it",
+    });
+
+    handlers.get("mesh.send_task")?.(opts);
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    const meta = JSON.parse((body.text as string).match(/<task-meta>(.*)<\/task-meta>/s)![1]!);
+    expect(meta.status).toBe("failed");
+    expect(meta.task_id).toBe("task-failure-1");
+  });
+
+  it("skips completion-memory POST when completionMemoryEnabled=false", async () => {
+    const { handlers } = createApi({ completionMemoryEnabled: false });
+    const opts = createOptions({
+      task_id: "task-opt-out",
+      from_agent: "daniel",
+      message: "run",
+    });
+
+    handlers.get("mesh.send_task")?.(opts);
+
+    await vi.waitFor(() => {
+      expect(opts.context.broadcastToConnIds).toHaveBeenCalledWith(
+        "mesh.task",
+        expect.objectContaining({ task_id: "task-opt-out", status: "completed" }),
+        new Set(["conn-1"]),
+      );
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("logs and swallows completion-memory save failures", async () => {
+    const { handlers, warn } = createApi();
+    fetchMock.mockResolvedValueOnce(new Response("boom", { status: 500 }));
+    const opts = createOptions({
+      task_id: "task-save-fail",
+      from_agent: "daniel",
+      message: "run",
+    });
+
+    handlers.get("mesh.send_task")?.(opts);
+
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalled();
+    });
+    const warnMessage = String(warn.mock.calls[0]![0]);
+    expect(warnMessage).toContain("task-save-fail");
+    expect(warnMessage).toContain("500");
   });
 });

--- a/extensions/mesh-gateway/index.ts
+++ b/extensions/mesh-gateway/index.ts
@@ -9,6 +9,18 @@ type MeshGatewayConfig = {
   displayName?: string;
   allowedUsers: string[];
   allowedAgents: string[];
+  /**
+   * If true, after each mesh task finishes the gateway POSTs a
+   * `task-completed:<task_id>` memory to the local omni-mem HTTP API
+   * (at {@link MeshGatewayConfig.localOmniMemUrl}). The memory embeds a
+   * `<task-meta>JSON</task-meta>` block so the manager-side `task_status`
+   * tool can join dispatch records with completion records by task_id.
+   * Best-effort: POST failures are logged and do NOT alter the mesh.task
+   * event stream returned to the caller.
+   */
+  completionMemoryEnabled: boolean;
+  localOmniMemUrl: string;
+  completionMemoryWorkspaceId: string;
 };
 
 type MeshAuthz = { ok: true; identity: string } | { ok: false; identity?: string; reason: string };
@@ -41,12 +53,104 @@ function stringArray(value: unknown): string[] {
 }
 
 function resolveConfig(raw: Record<string, unknown> | undefined): MeshGatewayConfig {
+  const completionMemoryEnabled = raw?.completionMemoryEnabled !== false;
   return {
     enabled: raw?.enabled === true,
     displayName: stringValue(raw?.displayName),
     allowedUsers: stringArray(raw?.allowedUsers),
     allowedAgents: stringArray(raw?.allowedAgents),
+    completionMemoryEnabled,
+    localOmniMemUrl: (stringValue(raw?.localOmniMemUrl) ?? "http://localhost:8765").replace(
+      /\/+$/,
+      "",
+    ),
+    completionMemoryWorkspaceId: stringValue(raw?.completionMemoryWorkspaceId) ?? "default",
   };
+}
+
+// Sentinel markers for the embedded structured metadata block. Matches the
+// convention used by omni-mem's management-mcp/src/tools.ts and
+// scripts/dev-mesh-stub.ts — the body is the only field that survives the
+// save-memory → sync-daemon → cloud progress API round trip, so task
+// correlation metadata lives inside the memory text.
+const TASK_META_OPEN = "<task-meta>";
+const TASK_META_CLOSE = "</task-meta>";
+
+function embedTaskMeta(meta: Record<string, unknown>): string {
+  return `${TASK_META_OPEN}${JSON.stringify(meta)}${TASK_META_CLOSE}`;
+}
+
+interface CompletionMemoryParams {
+  readonly api: OpenClawPluginApi;
+  readonly config: MeshGatewayConfig;
+  readonly taskId: string;
+  readonly status: "completed" | "failed" | "rejected";
+  readonly completedBy?: string;
+  readonly fromAgent?: string;
+  readonly dispatchedBy?: string;
+  readonly originalTitle?: string;
+  readonly summary?: string;
+  readonly details?: string;
+  readonly error?: string;
+}
+
+// Records a task-completion memory in the local omni-mem HTTP API so the
+// manager-side `task_status` MCP tool can close the loop by correlating the
+// dispatch record (on the manager's progress) with this completion record
+// (on the receiving agent's progress) via task_id. Best-effort — any failure
+// is logged and swallowed; the mesh.task event stream is already emitted by
+// the caller before this runs.
+async function writeCompletionMemory(params: CompletionMemoryParams): Promise<void> {
+  if (!params.config.completionMemoryEnabled) {
+    return;
+  }
+  const url = `${params.config.localOmniMemUrl}/api/save-memory`;
+  const meta: Record<string, unknown> = {
+    kind: "task_completion_record",
+    task_id: params.taskId,
+    status: params.status,
+    completed_by: params.completedBy,
+    completed_at: new Date().toISOString(),
+    summary:
+      params.summary ?? (params.status === "completed" ? "mesh task completed" : params.error),
+    original_title: params.originalTitle,
+    from_agent: params.fromAgent,
+    dispatched_by: params.dispatchedBy,
+    simulated: false,
+  };
+  const payload = {
+    title: `task-completed:${params.taskId}`,
+    text: [
+      `Mesh task ${params.taskId} finished with status=${params.status}.`,
+      "",
+      params.originalTitle ? `**Original title:** ${params.originalTitle}` : "",
+      params.summary ? `**Summary:** ${params.summary}` : "",
+      params.details ? `\n${params.details}` : "",
+      params.error ? `\n**Error:** ${params.error}` : "",
+      "",
+      embedTaskMeta(meta),
+    ]
+      .filter((l) => l !== "")
+      .join("\n"),
+    workspaceId: params.config.completionMemoryWorkspaceId,
+  };
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      params.api.logger.warn(
+        `mesh-gateway: completion-memory save-memory ${response.status} for task ${params.taskId}: ${text.slice(0, 200)}`,
+      );
+    }
+  } catch (err) {
+    params.api.logger.warn(
+      `mesh-gateway: completion-memory POST failed for task ${params.taskId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }
 
 function authorizeMeshClient(
@@ -113,6 +217,7 @@ function emitToCurrentClient(opts: GatewayRequestHandlerOptions, event: string, 
 
 async function runMeshTask(params: {
   api: OpenClawPluginApi;
+  config: MeshGatewayConfig;
   opts: GatewayRequestHandlerOptions;
   eventParams: Record<string, unknown>;
   taskId: string;
@@ -120,7 +225,7 @@ async function runMeshTask(params: {
   title?: string;
   model?: string;
 }) {
-  const { api, opts, eventParams, taskId, message, title, model } = params;
+  const { api, config, opts, eventParams, taskId, message, title, model } = params;
   emitToCurrentClient(opts, "mesh.task", buildMeshEvent(eventParams, "running"));
   const now = Date.now();
   const job: CronJob = {
@@ -136,6 +241,9 @@ async function runMeshTask(params: {
     payload: { kind: "agentTurn", message, model },
     state: {},
   };
+  const completedBy = stringValue(eventParams.from_identity);
+  const fromAgent = stringValue(eventParams.from_agent);
+  const dispatchedBy = stringValue(eventParams.dispatched_by);
   try {
     const result = await runCronIsolatedAgentTurn({
       cfg: api.config,
@@ -157,6 +265,19 @@ async function runMeshTask(params: {
         artifacts: [],
       }),
     );
+    await writeCompletionMemory({
+      api,
+      config,
+      taskId,
+      status,
+      completedBy,
+      fromAgent,
+      dispatchedBy,
+      originalTitle: title,
+      summary: result.summary,
+      details: result.outputText,
+      error: result.error,
+    });
   } catch (error) {
     const messageText = error instanceof Error ? error.message : String(error);
     emitToCurrentClient(
@@ -169,6 +290,19 @@ async function runMeshTask(params: {
         artifacts: [],
       }),
     );
+    await writeCompletionMemory({
+      api,
+      config,
+      taskId,
+      status: "failed",
+      completedBy,
+      fromAgent,
+      dispatchedBy,
+      originalTitle: title,
+      summary: "Mesh task failed",
+      details: messageText,
+      error: messageText,
+    });
   }
 }
 
@@ -197,6 +331,9 @@ const plugin = {
         displayName: { type: "string" },
         allowedUsers: { type: "array", items: { type: "string" } },
         allowedAgents: { type: "array", items: { type: "string" } },
+        completionMemoryEnabled: { type: "boolean" },
+        localOmniMemUrl: { type: "string" },
+        completionMemoryWorkspaceId: { type: "string" },
       },
     },
   },
@@ -288,6 +425,7 @@ const plugin = {
       opts.respond(true, accepted);
       void runMeshTask({
         api,
+        config,
         opts,
         eventParams: taskParams,
         taskId,

--- a/extensions/mesh-gateway/openclaw.plugin.json
+++ b/extensions/mesh-gateway/openclaw.plugin.json
@@ -15,7 +15,10 @@
       "allowedAgents": {
         "type": "array",
         "items": { "type": "string" }
-      }
+      },
+      "completionMemoryEnabled": { "type": "boolean" },
+      "localOmniMemUrl": { "type": "string" },
+      "completionMemoryWorkspaceId": { "type": "string" }
     }
   }
 }


### PR DESCRIPTION
## Summary

S3 of the omni-mem agent-to-agent task pipeline. Pairs with [omni-mem PR #8](https://github.com/Chaddacus/omni-mem/pull/8) and [PR #9](https://github.com/Chaddacus/omni-mem/pull/9).

After `runMeshTask` emits its terminal `mesh.task` event, the extension now POSTs a `task-completed:<task_id>` memory to the local omni-mem HTTP API (default `http://localhost:8765`). The memory body embeds a `<task-meta>JSON</task-meta>` block that the manager-side `task_status` MCP tool uses to correlate dispatch records with completion records by `task_id`.

This is the real-agent analogue of what `omni-mem/scripts/dev-mesh-stub.ts` already does in test. Wire shape is identical.

## New config keys (all optional)

| Key | Default | Behavior |
|---|---|---|
| `completionMemoryEnabled` | `true` | Set `false` to restore legacy behavior (no POST). |
| `localOmniMemUrl` | `http://localhost:8765` | Base URL of the local omni-mem HTTP server. |
| `completionMemoryWorkspaceId` | `"default"` | `workspaceId` field on the saved memory. |

## Safety

- POST is best-effort; failures log via `api.logger.warn` and do NOT alter the `mesh.task` event stream.
- No changes to the mesh wire protocol, `mesh.send_task` response shape, or any other RPC method.
- 9/9 vitest passing (5 existing + 4 new covering success POST, failure POST, opt-out, and save-failure logging).
- `pnpm tsgo` introduces no new type errors beyond the 228 pre-existing ones on this branch.

## Test plan

- [x] `pnpm exec vitest run extensions/mesh-gateway` — 9/9 pass
- [x] `pnpm exec vitest run src/gateway/method-scopes.test.ts` — 8/8 pass (adjacent)
- [x] `pnpm tsgo` — no new errors from these changes
- [ ] End-to-end verification against a real receiving dev once the extension is deployed alongside a local omni-mem