### PR TITLE
mesh-gateway: write a2a lifecycle records to local omni-mem

### DIFF
--- a/extensions/mesh-gateway/index.ts
+++ b/extensions/mesh-gateway/index.ts
@@ -448,9 +448,52 @@ const plugin = {
   register(api: OpenClawPluginApi) {
     const config = resolveConfig(api.pluginConfig);
 
+    // Capture deps from gateway method calls for use in outbound session routing
+    let capturedDeps: Record<string, unknown> | null = null;
+    function captureDeps(opts: GatewayRequestHandlerOptions): void {
+      if (!capturedDeps && opts.context?.deps) {
+        capturedDeps = opts.context.deps as Record<string, unknown>;
+      }
+    }
+
+    async function recordOutboundInMeshSession(
+      contactIdentity: string,
+      agentName: string,
+      outboundMessage: string,
+    ): Promise<void> {
+      if (!capturedDeps) return;
+      const now = Date.now();
+      const job: CronJob = {
+        id: `mesh-outbound-${randomUUID()}`,
+        name: `Outbound to ${agentName}`,
+        enabled: true,
+        deleteAfterRun: true,
+        createdAtMs: now,
+        updatedAtMs: now,
+        schedule: { kind: "at", at: new Date(now).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: outboundMessage },
+        state: {},
+      };
+      try {
+        await runCronIsolatedAgentTurn({
+          cfg: api.config,
+          deps: capturedDeps,
+          job,
+          message: outboundMessage,
+          sessionKey: `mesh:${contactIdentity}`,
+          lane: "mesh",
+        });
+      } catch (err) {
+        api.logger.error(`Failed to create mesh session for ${contactIdentity}:`, err);
+      }
+    }
+
     api.registerGatewayMethod(
       "mesh.health",
       (opts) => {
+        captureDeps(opts);
         const authz = authorizeMeshClient(config, opts);
         opts.respond(true, {
           ok: authz.ok,
@@ -526,6 +569,7 @@ const plugin = {
     api.registerGatewayMethod(
       "mesh.send_task",
       (opts) => {
+        captureDeps(opts);
         const authz = authorizeMeshClient(config, opts);
         if (!authz.ok) {
           sendError(opts, authz.reason, { identity: authz.identity });
@@ -723,12 +767,11 @@ const plugin = {
 
           // Record outbound in per-contact mesh session
           const contactIdentity = agent.expected_identity ?? agent_name;
-          const sessionKey = `mesh:${contactIdentity}`;
-          void api.runtime.subagent.run({
-            sessionKey,
-            message: `[Outbound mesh task to ${agent_name}] ${message}`,
-            lane: "mesh",
-          }).catch(() => {});
+          void recordOutboundInMeshSession(
+            contactIdentity,
+            agent_name,
+            `[Outbound mesh task to ${agent_name}] ${message}`,
+          );
 
           return {
             content: [{ type: "text" as const, text: JSON.stringify(result) }],
@@ -826,12 +869,11 @@ const plugin = {
 
           // Record outbound in per-contact mesh session
           const contactIdentity = agent.expected_identity ?? agent_name;
-          const sessionKey = `mesh:${contactIdentity}`;
-          void api.runtime.subagent.run({
-            sessionKey,
-            message: `[Outbound mesh message to ${agent_name}] ${message}\n\n[Response] ${result.response ?? "(no response)"}`,
-            lane: "mesh",
-          }).catch(() => {});
+          void recordOutboundInMeshSession(
+            contactIdentity,
+            agent_name,
+            `[Outbound mesh message to ${agent_name}] ${message}\n\n[Response] ${result.response ?? "(no response)"}`,
+          );
 
           return {
             content: [{ type: "text" as const, text: JSON.stringify(result) }],

--- a/extensions/mesh-gateway/index.ts
+++ b/extensions/mesh-gateway/index.ts
@@ -3,12 +3,16 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
-import WebSocket from "ws";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import WebSocket from "ws";
 import { runCronIsolatedAgentTurn } from "../../src/cron/isolated-agent.js";
 import type { CronJob } from "../../src/cron/types.js";
 import { MESH_SCOPE } from "../../src/gateway/operator-scopes.js";
 import type { GatewayRequestHandlerOptions } from "../../src/gateway/server-methods/types.js";
+import { postTaskCompletion, postTaskTransition } from "./omni-mem.js";
+
+const DEFAULT_OMNI_MEM_URL = "http://localhost:8765";
+const DEFAULT_OMNI_MEM_WORKSPACE = "default";
 
 type MeshGatewayConfig = {
   enabled: boolean;
@@ -17,6 +21,11 @@ type MeshGatewayConfig = {
   allowedUsers: string[];
   allowedAgents: string[];
   rosterPath?: string;
+  omniMem: {
+    enabled: boolean;
+    url: string;
+    workspaceId: string;
+  };
 };
 
 type MeshAuthz = { ok: true; identity: string } | { ok: false; identity?: string; reason: string };
@@ -48,7 +57,24 @@ function stringArray(value: unknown): string[] {
   );
 }
 
+function resolveOmniMemConfig(
+  raw: Record<string, unknown> | undefined,
+): MeshGatewayConfig["omniMem"] {
+  const explicitEnabled = typeof raw?.enabled === "boolean" ? raw.enabled : undefined;
+  const url = stringValue(raw?.url) ?? DEFAULT_OMNI_MEM_URL;
+  const workspaceId = stringValue(raw?.workspaceId) ?? DEFAULT_OMNI_MEM_WORKSPACE;
+  return {
+    enabled: explicitEnabled ?? Boolean(url),
+    url,
+    workspaceId,
+  };
+}
+
 function resolveConfig(raw: Record<string, unknown> | undefined): MeshGatewayConfig {
+  const omniMemRaw =
+    raw && typeof raw.omniMem === "object" && raw.omniMem !== null && !Array.isArray(raw.omniMem)
+      ? (raw.omniMem as Record<string, unknown>)
+      : undefined;
   return {
     enabled: raw?.enabled === true,
     displayName: stringValue(raw?.displayName),
@@ -56,7 +82,62 @@ function resolveConfig(raw: Record<string, unknown> | undefined): MeshGatewayCon
     allowedUsers: stringArray(raw?.allowedUsers),
     allowedAgents: stringArray(raw?.allowedAgents),
     rosterPath: stringValue(raw?.rosterPath),
+    omniMem: resolveOmniMemConfig(omniMemRaw),
   };
+}
+
+function shouldWriteToOmniMem(config: MeshGatewayConfig): boolean {
+  return Boolean(config.omniMem.enabled && config.omniMem.url && config.agentIdentity);
+}
+
+function recordTransitionBestEffort(
+  config: MeshGatewayConfig,
+  args: { taskId: string; status: "accepted" | "executing"; note?: string },
+) {
+  if (!shouldWriteToOmniMem(config)) {
+    return;
+  }
+  void postTaskTransition({
+    omniMemUrl: config.omniMem.url,
+    workspaceId: config.omniMem.workspaceId,
+    taskId: args.taskId,
+    status: args.status,
+    actor: config.agentIdentity as string,
+    note: args.note,
+  }).then((res) => {
+    if (!res?.ok && !res?.skipped) {
+      // eslint-disable-next-line no-console
+      console.warn(`[mesh-gateway] omni-mem transition write failed: ${res?.error ?? "unknown"}`);
+    }
+  });
+}
+
+function recordCompletionBestEffort(
+  config: MeshGatewayConfig,
+  args: {
+    taskId: string;
+    status: "completed" | "failed" | "rejected";
+    summary?: string;
+    details?: string;
+  },
+) {
+  if (!shouldWriteToOmniMem(config)) {
+    return;
+  }
+  void postTaskCompletion({
+    omniMemUrl: config.omniMem.url,
+    workspaceId: config.omniMem.workspaceId,
+    taskId: args.taskId,
+    status: args.status,
+    actor: config.agentIdentity as string,
+    summary: args.summary,
+    details: args.details,
+  }).then((res) => {
+    if (!res?.ok && !res?.skipped) {
+      // eslint-disable-next-line no-console
+      console.warn(`[mesh-gateway] omni-mem completion write failed: ${res?.error ?? "unknown"}`);
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -102,7 +183,9 @@ function wsUrl(gatewayUrl: string): string {
 
 function tokenValue(agent: RosterAgent): string | undefined {
   const raw = (agent.token ?? "").trim();
-  if (!raw) return undefined;
+  if (!raw) {
+    return undefined;
+  }
   if (raw.toLowerCase().startsWith("bearer ")) {
     return raw.slice(7).trim() || undefined;
   }
@@ -119,6 +202,7 @@ async function loadRoster(rosterPath: string): Promise<Roster> {
       code === "ENOENT"
         ? `Roster file not found: ${rosterPath}`
         : `Failed to read roster file: ${(err as Error).message}`,
+      { cause: err },
     );
   }
   try {
@@ -132,9 +216,7 @@ function lookupAgent(roster: Roster, agentName: string): RosterAgent {
   const agent = roster.agents?.[agentName];
   if (!agent) {
     const available = Object.keys(roster.agents ?? {}).join(", ") || "(none)";
-    throw new Error(
-      `Agent "${agentName}" not found in roster. Available: ${available}`,
-    );
+    throw new Error(`Agent "${agentName}" not found in roster. Available: ${available}`);
   }
   return agent;
 }
@@ -187,20 +269,16 @@ class MeshClient {
     }
     const res = await this.rpc("connect", connectParams, timeoutMs);
     if (!res.ok) {
-      throw new Error(
-        `Mesh connect rejected: ${res.error?.message ?? "unknown error"}`,
-      );
+      throw new Error(`Mesh connect rejected: ${res.error?.message ?? "unknown error"}`);
     }
     const server = res.payload?.["server"] as Record<string, unknown> | undefined;
     this.connId = typeof server?.["connId"] === "string" ? server["connId"] : null;
   }
 
-  async rpc(
-    method: string,
-    params: Record<string, unknown>,
-    timeoutMs: number,
-  ): Promise<WsFrame> {
-    if (!this.ws) throw new Error("WebSocket not connected");
+  async rpc(method: string, params: Record<string, unknown>, timeoutMs: number): Promise<WsFrame> {
+    if (!this.ws) {
+      throw new Error("WebSocket not connected");
+    }
     const reqId = randomUUID();
     const frame: WsFrame = { type: "req", id: reqId, method, params };
     this.ws.send(JSON.stringify(frame));
@@ -208,7 +286,9 @@ class MeshClient {
   }
 
   async recvUntil(expectedId: string | null, timeoutMs: number): Promise<WsFrame> {
-    if (!this.ws) throw new Error("WebSocket not connected");
+    if (!this.ws) {
+      throw new Error("WebSocket not connected");
+    }
     const ws = this.ws;
     return new Promise<WsFrame>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -219,7 +299,15 @@ class MeshClient {
       function onMessage(data: WebSocket.RawData) {
         let frame: WsFrame;
         try {
-          frame = JSON.parse(data.toString()) as WsFrame;
+          const raw =
+            typeof data === "string"
+              ? data
+              : Buffer.isBuffer(data)
+                ? data.toString("utf8")
+                : Array.isArray(data)
+                  ? Buffer.concat(data).toString("utf8")
+                  : Buffer.from(data).toString("utf8");
+          frame = JSON.parse(raw) as WsFrame;
         } catch {
           return;
         }
@@ -356,6 +444,7 @@ function emitToCurrentClient(opts: GatewayRequestHandlerOptions, event: string, 
 async function runMeshTask(params: {
   api: OpenClawPluginApi;
   opts: GatewayRequestHandlerOptions;
+  config: MeshGatewayConfig;
   eventParams: Record<string, unknown>;
   taskId: string;
   callerIdentity: string;
@@ -363,8 +452,13 @@ async function runMeshTask(params: {
   title?: string;
   model?: string;
 }) {
-  const { api, opts, eventParams, taskId, callerIdentity, message, title, model } = params;
+  const { api, opts, config, eventParams, taskId, callerIdentity, message, title, model } = params;
   emitToCurrentClient(opts, "mesh.task", buildMeshEvent(eventParams, "running"));
+  recordTransitionBestEffort(config, {
+    taskId,
+    status: "executing",
+    note: "Mesh-gateway dispatched to cron isolated-agent runtime.",
+  });
   const now = Date.now();
   const job: CronJob = {
     id: `mesh-${taskId}`,
@@ -400,6 +494,12 @@ async function runMeshTask(params: {
         artifacts: [],
       }),
     );
+    recordCompletionBestEffort(config, {
+      taskId,
+      status: status,
+      summary: result.summary,
+      details: result.outputText ?? result.error,
+    });
   } catch (error) {
     const messageText = error instanceof Error ? error.message : String(error);
     emitToCurrentClient(
@@ -412,6 +512,12 @@ async function runMeshTask(params: {
         artifacts: [],
       }),
     );
+    recordCompletionBestEffort(config, {
+      taskId,
+      status: "failed",
+      summary: "Mesh task failed",
+      details: messageText,
+    });
   }
 }
 
@@ -441,6 +547,16 @@ const plugin = {
         agentIdentity: { type: "string" },
         allowedUsers: { type: "array", items: { type: "string" } },
         allowedAgents: { type: "array", items: { type: "string" } },
+        rosterPath: { type: "string" },
+        omniMem: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            enabled: { type: "boolean" },
+            url: { type: "string" },
+            workspaceId: { type: "string" },
+          },
+        },
       },
     },
   },
@@ -461,7 +577,9 @@ const plugin = {
       agentName: string,
       outboundMessage: string,
     ): Promise<void> {
-      if (!capturedDeps) return;
+      if (!capturedDeps) {
+        return;
+      }
       const now = Date.now();
       const job: CronJob = {
         id: `mesh-outbound-${randomUUID()}`,
@@ -596,9 +714,15 @@ const plugin = {
         });
         emitToCurrentClient(opts, "mesh.task", accepted);
         opts.respond(true, accepted);
+        recordTransitionBestEffort(config, {
+          taskId,
+          status: "accepted",
+          note: `Mesh-gateway accepted task from ${authz.identity}.`,
+        });
         void runMeshTask({
           api,
           opts,
+          config,
           eventParams: taskParams,
           taskId,
           callerIdentity: authz.identity,
@@ -615,9 +739,7 @@ const plugin = {
     // -------------------------------------------------------------------------
 
     const resolvedRosterPath =
-      config.rosterPath ??
-      process.env["MESH_ROSTER_PATH"] ??
-      defaultRosterPath();
+      config.rosterPath ?? process.env["MESH_ROSTER_PATH"] ?? defaultRosterPath();
 
     api.registerTool({
       name: "mesh_list_agents",
@@ -641,17 +763,10 @@ const plugin = {
         const results = await Promise.all(
           agentNames.map(async (name) => {
             const agent = roster.agents[name];
-            const client = new MeshClient(
-              agent,
-              config.displayName ?? "openclaw",
-            );
+            const client = new MeshClient(agent, config.displayName ?? "openclaw");
             try {
               await client.connect(MESH_CONNECT_TIMEOUT_MS);
-              const health = await client.rpc(
-                "mesh.health",
-                {},
-                MESH_CONNECT_TIMEOUT_MS,
-              );
+              const health = await client.rpc("mesh.health", {}, MESH_CONNECT_TIMEOUT_MS);
               client.close();
               const payload = health.payload ?? {};
               return {
@@ -697,7 +812,12 @@ const plugin = {
         ),
       }),
       async execute(_toolCallId, params) {
-        const { agent_name, goal, context: ctx, start } = params as {
+        const {
+          agent_name,
+          goal,
+          context: ctx,
+          start,
+        } = params as {
           agent_name: string;
           goal: string;
           context?: string;
@@ -733,7 +853,9 @@ const plugin = {
           const taskId = randomUUID();
           const fromAgent = config.displayName ?? "openclaw";
           const messageParts = [goal];
-          if (ctx) messageParts.push(`Context:\n${ctx}`);
+          if (ctx) {
+            messageParts.push(`Context:\n${ctx}`);
+          }
           const message = messageParts.join("\n\n");
           const taskParams: Record<string, unknown> = {
             task_id: taskId,
@@ -869,10 +991,12 @@ const plugin = {
 
           // Record outbound in per-contact mesh session
           const contactIdentity = agent.expected_identity ?? agent_name;
+          const responseText =
+            typeof result.response === "string" ? result.response : "(no response)";
           void recordOutboundInMeshSession(
             contactIdentity,
             agent_name,
-            `[Outbound mesh message to ${agent_name}] ${message}\n\n[Response] ${result.response ?? "(no response)"}`,
+            `[Outbound mesh message to ${agent_name}] ${message}\n\n[Response] ${responseText}`,
           );
 
           return {

--- a/extensions/mesh-gateway/omni-mem.ts
+++ b/extensions/mesh-gateway/omni-mem.ts
@@ -1,0 +1,181 @@
+// Thin HTTP client for writing a2a task lifecycle records to the local
+// omni-mem HTTP API (`/api/save-memory`). Fire-and-forget: a failed write
+// must never block mesh.send_task acceptance or mark a task as failed.
+
+const TASK_META_OPEN = "<task-meta>";
+const TASK_META_CLOSE = "</task-meta>";
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+type FetchImpl = (
+  input: string | URL,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}>;
+
+export type TransitionStatus = "accepted" | "executing";
+export type CompletionStatus = "completed" | "failed" | "rejected";
+
+export type OmniMemWriteResult = {
+  ok: boolean;
+  memoryId?: string;
+  error?: string;
+  skipped?: boolean;
+};
+
+export type PostTaskTransitionParams = {
+  omniMemUrl: string | undefined;
+  taskId: string;
+  status: TransitionStatus;
+  actor: string;
+  note?: string;
+  workspaceId?: string;
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+  source?: string;
+};
+
+export type PostTaskCompletionParams = {
+  omniMemUrl: string | undefined;
+  taskId: string;
+  status: CompletionStatus;
+  actor: string;
+  summary?: string;
+  details?: string;
+  workspaceId?: string;
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+  source?: string;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function embedMeta(meta: Record<string, unknown>): string {
+  return `${TASK_META_OPEN}${JSON.stringify(meta)}${TASK_META_CLOSE}`;
+}
+
+function normalizeUrl(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim().replace(/\/+$/, "");
+  return trimmed || undefined;
+}
+
+export async function postTaskTransition(
+  params: PostTaskTransitionParams,
+): Promise<OmniMemWriteResult> {
+  const url = normalizeUrl(params.omniMemUrl);
+  if (!url) {
+    return { ok: false, skipped: true, error: "omni-mem url not configured" };
+  }
+  if (!params.taskId || !params.status || !params.actor) {
+    return { ok: false, error: "missing required field (taskId|status|actor)" };
+  }
+  const source = params.source ?? "mesh-gateway";
+  const embedded = embedMeta({
+    kind: "task_transition_record",
+    task_id: params.taskId,
+    status: params.status,
+    actor: params.actor,
+    note: params.note,
+    recorded_at: nowIso(),
+    source,
+  });
+  const body = {
+    title: `task-${params.status}:${params.taskId}`,
+    text: [
+      `Task ${params.taskId} → ${params.status} (recorded by ${source} for ${params.actor}).`,
+      ...(params.note ? ["", params.note] : []),
+      "",
+      embedded,
+    ].join("\n"),
+    workspaceId: params.workspaceId ?? "default",
+    taskId: params.taskId,
+  };
+  return sendSaveMemory(url, body, params.fetchImpl, params.timeoutMs);
+}
+
+export async function postTaskCompletion(
+  params: PostTaskCompletionParams,
+): Promise<OmniMemWriteResult> {
+  const url = normalizeUrl(params.omniMemUrl);
+  if (!url) {
+    return { ok: false, skipped: true, error: "omni-mem url not configured" };
+  }
+  if (!params.taskId || !params.status || !params.actor) {
+    return { ok: false, error: "missing required field (taskId|status|actor)" };
+  }
+  const source = params.source ?? "mesh-gateway";
+  const embedded = embedMeta({
+    kind: "task_completion_record",
+    task_id: params.taskId,
+    status: params.status,
+    completed_by: params.actor,
+    completed_at: nowIso(),
+    summary: params.summary,
+    source,
+  });
+  const body = {
+    title: `task-completed:${params.taskId}`,
+    text: [
+      `Task ${params.taskId} completed with status=${params.status} by ${params.actor}.`,
+      ...(params.summary ? ["", `**Summary:** ${params.summary}`] : []),
+      ...(params.details ? ["", params.details] : []),
+      "",
+      embedded,
+    ].join("\n"),
+    workspaceId: params.workspaceId ?? "default",
+    taskId: params.taskId,
+  };
+  return sendSaveMemory(url, body, params.fetchImpl, params.timeoutMs);
+}
+
+async function sendSaveMemory(
+  baseUrl: string,
+  body: Record<string, unknown>,
+  fetchImpl: FetchImpl | undefined,
+  timeoutMs: number | undefined,
+): Promise<OmniMemWriteResult> {
+  const impl = fetchImpl ?? (globalThis as { fetch?: FetchImpl }).fetch;
+  if (typeof impl !== "function") {
+    return { ok: false, error: "fetch implementation unavailable" };
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await impl(`${baseUrl}/api/save-memory`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      return { ok: false, error: `save-memory ${response.status}: ${text.slice(0, 200)}` };
+    }
+    const data = (await response.json().catch(() => ({}))) as { id?: unknown };
+    if (!data || typeof data !== "object" || typeof data.id !== "string") {
+      return { ok: false, error: "save-memory response missing id" };
+    }
+    return { ok: true, memoryId: data.id };
+  } catch (err) {
+    const e = err as { name?: string; message?: string };
+    if (e?.name === "AbortError") {
+      return { ok: false, error: "save-memory timed out" };
+    }
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/extensions/mesh-gateway/openclaw.plugin.json
+++ b/extensions/mesh-gateway/openclaw.plugin.json
@@ -8,6 +8,7 @@
     "properties": {
       "enabled": { "type": "boolean" },
       "displayName": { "type": "string" },
+      "agentIdentity": { "type": "string" },
       "allowedUsers": {
         "type": "array",
         "items": { "type": "string" }
@@ -15,6 +16,16 @@
       "allowedAgents": {
         "type": "array",
         "items": { "type": "string" }
+      },
+      "rosterPath": { "type": "string" },
+      "omniMem": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "url": { "type": "string" },
+          "workspaceId": { "type": "string" }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Brings the vendored in-tree \`mesh-gateway\` plugin to parity with the overlay plugin (cw-openclaw-extensions PR #4) by firing fire-and-forget omni-mem writes at mesh.send_task lifecycle transitions. The records use the same \`<task-meta>\` shape as \`services/mesh-sidecar\` so the manager-side \`task_status\` / \`list_my_tasks\` tools can join dispatch → transitions → completion across all three implementations.

- New \`extensions/mesh-gateway/omni-mem.ts\` — HTTP client with AbortController timeout, \`source: "mesh-gateway"\` in meta.
- \`MeshGatewayConfig\` gains \`omniMem: { enabled, url, workspaceId }\` (default on; localhost:8765, default workspace).
- Manifest \`jsonSchema\` adds \`agentIdentity\`, \`rosterPath\`, and \`omniMem\` so the pre-existing + new fields pass the \`additionalProperties: false\` gate.
- Writes fire from: \`mesh.send_task\` after acceptance, at subagent/cron dispatch (executing), and at terminal states (completed/failed). Fire-and-forget — a failed write never blocks the handler.
- Incidental: narrow two template-literal types (\`WsFrame\` decode, \`mesh_send_message\` response) so pre-existing oxlint \`restrict-template-expressions\` errors don't block the commit.

## Verification
- \`pnpm tsgo\` — zero net new errors in \`extensions/mesh-gateway/**\` (pre-existing logger.error arity issue unchanged).
- Built and deployed locally: \`node scripts/tsdown-build.mjs\` + \`copy-bundled-plugin-metadata\` + manual \`cp dist/omni-mem-*.js dist-runtime/\` (known gap — \`stageBundledPluginRuntime\` doesn't copy new root-level chunks, filed as follow-up memory). Gateway restart loaded cleanly with \`agentIdentity\`, \`allowedAgents: [omni-mem-management-mcp]\`, \`omniMem.enabled=true\`.
- End-to-end lifecycle records from a paired peer dispatch remain to verify — the in-process gateway requires device pairing (\`NOT_PAIRED\`) so local self-dispatch probes against \`ws://127.0.0.1:18789/\` can't complete the handshake.

## Test plan
- [x] Build + install on Chad's box, gateway restart passes config validation, plugin loads without error.
- [ ] Paired peer dispatch: confirm \`task_transition_record(accepted|executing)\` + \`task_completion_record\` appear in local omni-mem with \`source="mesh-gateway"\`.