### PR TITLE
ci: dev-image build workflow — stop building images on deployment hosts

### DIFF
--- a/.github/workflows/docker-dev-build.yml
+++ b/.github/workflows/docker-dev-build.yml
@@ -1,0 +1,87 @@
+name: Docker Dev Build
+
+# Builds a dev image for branch testing and pushes it to GHCR, so dev images
+# are never built on shared deployment hosts (noob-root wedged twice on
+# 2026-06-03/04 from on-box 10.6GB image builds exhausting RAM/CPU).
+#
+# Trigger: push to `development`, or manual dispatch for any ref.
+# Output tags:
+#   ghcr.io/<org>/cw-openclaw:dev-<branch-slug>-<short-sha>   (pinned, for deploys)
+#   ghcr.io/<org>/cw-openclaw:dev-<branch-slug>               (moving, for quick local pulls)
+#
+# amd64 only — dev deploys target the amd64 deployment box. Release images
+# (multi-arch, versioned) remain owned by docker-release.yml.
+
+on:
+  push:
+    branches:
+      - development
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
+      - ".agents/**"
+      - "skills/**"
+  workflow_dispatch:
+
+concurrency:
+  group: docker-dev-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build_dev_amd64:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # The image is ~10GB; hosted runners have ~14GB free. Drop preinstalled
+      # toolchains we don't use before building.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache /usr/local/lib/android /usr/share/dotnet /opt/ghc
+          df -h /
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute tags
+        id: tags
+        run: |
+          set -euo pipefail
+          BRANCH_SLUG=$(echo "${GITHUB_REF_NAME}" | tr '/_' '--' | tr -cd 'a-zA-Z0-9-' | cut -c1-40)
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
+          IMAGE="${REGISTRY}/${IMAGE_NAME,,}"
+          echo "value=${IMAGE}:dev-${BRANCH_SLUG}-${SHORT_SHA},${IMAGE}:dev-${BRANCH_SLUG}" >> "$GITHUB_OUTPUT"
+          echo "pinned=${IMAGE}:dev-${BRANCH_SLUG}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          tags: ${{ steps.tags.outputs.value }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache:amd64
+          push: true
+
+      - name: Report pinned tag
+        run: |
+          echo "### Dev image published" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.tags.outputs.pinned }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "Deploy: docker pull <tag> && update compose image pin. Do NOT build on the deployment host." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why
noob-root went down twice (2026-06-03 22:18 UTC, 2026-06-04 13:02 UTC) because 10.6GB openclaw dev images were built **on the deployment box** (moltbot fastrebuild via buildx), exhausting aggregate RAM/CPU next to ~200 prod containers. RCA evidence: buildkit memcg OOM at 12:21, load1=43 with 1GB available at 12:47, journald SIGABRT, box unreachable.

## What
- New `docker-dev-build.yml`: builds **amd64 dev images in CI** on push to `development` (or `workflow_dispatch`), pushes `ghcr.io/cloudwarriors-ai/cw-openclaw:dev-<branch>-<sha>` (pinned) + `dev-<branch>` (moving) tags.
- Reuses docker-release.yml conventions (buildx, GHCR login, registry cache read).
- Frees runner disk before build (image is ~10GB vs ~14GB free on hosted runners).

## Deploy-side changes (done out-of-band on noob-root)
- buildx builders removed; earlyoom + swap + guard caps installed.
- `/root/web/moltbot/docker-compose.dev.yml` should switch from `build:` to the pinned GHCR tag once this merges (follow-up on the box).

## Notes
- Release images (multi-arch, versioned) remain owned by `docker-release.yml` — untouched.
- No new secrets: GITHUB_TOKEN with `packages: write`. The `NGROK_AUTH_TOKEN` build arg in the box compose is dead — the Dockerfile never declared it.