### PR TITLE
fix(claude-mem): point bundled-extension entry at committed source

### DIFF
--- a/extensions/claude-mem/package.json
+++ b/extensions/claude-mem/package.json
@@ -12,7 +12,7 @@
   },
   "openclaw": {
     "extensions": [
-      "./dist/index.js"
+      "./src/index.ts"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Why
Clean Docker builds of main fail: `[UNRESOLVED_ENTRY] Cannot resolve entry module extensions/claude-mem/dist/index.js` (caught by the first run of docker-dev-build.yml, run 26967754278). Unnoticed until now because docker-release.yml hasn't completed since claude-mem landed (last 3 runs cancelled), and on-box dev builds were grafting onto old images.

## What
One line: `openclaw.extensions: ["./dist/index.js"]` → `["./src/index.ts"]` — the convention used by catfish, diagnostics-otel, copilot-proxy, imessage, irc, llm-task, lobster. tsdown compiles the source; copy-bundled-plugin-metadata.mjs rewrites the staged manifest to .js for runtime (scripts/lib/bundled-plugin-build-entries.mjs:137-142 normalizes the entry).

## Verification
- `listBundledPluginBuildEntries()`: all entries resolve to existing files (was: claude-mem missing).
- E2E: docker-dev-build dispatch on this branch — link in comments when green.

Note: Blacksmith-runner checks will sit queued (runner outage, repo-wide).