### PR TITLE
Hub-and-spoke for scopelybot: confirm-gate fix, test harness, reusable pattern docs

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,7 @@ services:
     container_name: openclaw
     user: root
     environment:
+    - OPENCLAW_TEST_CAPTURE=${OPENCLAW_TEST_CAPTURE:-0}
     - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
     - ZOOM_PREFILTER_MODEL=${ZOOM_PREFILTER_MODEL}

--- a/docs/reference/agent-test-harness-design.md
+++ b/docs/reference/agent-test-harness-design.md
@@ -1,0 +1,196 @@
+---
+title: "Agent Test Harness — Noise-Free Intake/Output + Hub-and-Spoke Verification"
+summary: "A modular, agent-agnostic harness that drives a Zoom-bound agent's real intake→coordinator→spoke→output pipeline, captures and SUPPRESSES all channel egress (no writes to the live channel), and records the internal routing/tool trace so hub-and-spoke delegation can be asserted. Built on existing primitives (signed webhook intake, an env-gated undici egress interceptor, the before_tool_call hook, and the proxy-capture SQLite store)."
+status: exploratory
+---
+
+# Agent Test Harness — Noise-Free Intake/Output + Hub-and-Spoke Verification
+
+> **Status.** Design intent, not an approved spec. Decisions marked **[chosen]** are settled with
+> the requester; items under "Open questions" must be verified before building. Nothing here is
+> implemented yet.
+
+## Goal
+
+Drive a Zoom-bound agent's **real** pipeline — webhook intake → coordinator routing →
+spoke execution → outbound reply — and:
+
+1. **Capture every outbound message** the bot would send (final reply, comfort message, confirm
+   prompt) **without any of it reaching the live Zoom channel**.
+2. **Observe the internal hub-and-spoke behavior** — which spoke the coordinator routed to, which
+   tools each agent called — so routing/delegation correctness is assertable, not just final text.
+3. Be **modular / agent-agnostic**: testing pulsebot vs scopelybot vs bigheadbot is a different
+   *profile*, not different code. Test-only; inert in production.
+
+## Why the obvious seams don't work (the finding that shapes this)
+
+Every bot ships the **same duplicated raw-POST pattern**: `extensions/<bot>/src/comfort.ts` and
+`zoom-dm.ts` call `fetch("https://api.zoom.us/v2/...messages")` **directly, bypassing core
+outbound**. The coordinator's *final reply* goes through core (and fires the `message_sending`
+hook), but the comfort message and the confirm prompt — the two messages a confirm-gate test most
+needs — do not.
+
+> A `message_sending` hook can't be the capture seam: it misses the raw POSTs for **every** bot.
+> The only point all outbound shares is the **HTTP egress to `api.zoom.us`**. Interception lives
+> there.
+
+Likewise, the channel output alone can't prove hub-and-spoke routing — that requires the
+**tool-call trace** (which spoke ran, which tools), observed via the `before_tool_call` hook.
+
+## Solution ladder
+
+- **L1 — per-bot dry-run flag** in each `comfort.ts`/`zoom-dm.ts`: 7+ bots × 2 files, high churn,
+  not modular. Rejected.
+- **L2 — one env-gated egress interceptor (undici) + a tool-trace hook + thin external harness.**
+  Single interception point per concern, agent-agnostic, surgical, test-only. **[chosen]**
+- **L3 — first-class "loopback channel transport"** simulating all channels: a new runtime surface;
+  overkill for the need. Revisit only if multi-channel simulation is later required.
+
+### Reuse-first record
+- `src/proxy-capture/` — MITM capture **proxy**; it *forwards* traffic, so it can't satisfy "don't
+  write to channel". **Reuse its SQLite store/schema** (`CaptureDirection: "outbound"`) as the
+  record sink. **[chosen]**
+- `message_sending` hook — core-only, misses raw POSTs. Rejected as the egress seam.
+- `before_tool_call` hook (`src/plugins/hook-types.ts:517`) — generic, fires for every tool call
+  incl. `sessions_spawn`; reuse for the routing/tool trace.
+- `src/infra/net/undici-runtime.ts` — repo already owns the global dispatcher; **compose with it**
+  (wrap, don't clobber its custom Agent).
+- The synthetic signed-webhook injector from the 2026-06-05 debug session already works; formalize.
+
+## Decisions [chosen]
+
+- **Isolation model: real bot, egress-suppressed.** Inject to the bot's real channel; the
+  interceptor captures + suppresses outbound **scoped to the profile's `channelJid`**, so other
+  bots stay live. Caveat: a human messaging that same channel mid-run would also be suppressed —
+  runs are short / use an idle window. (No per-bot Zoom or agent setup → fully modular.)
+- **Capture sink: reuse proxy-capture SQLite.** Synthetic outbound + tool-trace records persist to
+  the existing capture store/schema; the harness queries it. SQLite-only compliant, reuse-first.
+
+## Architecture — components
+
+```
+  [1 injector CLI]                gateway process (in container)
+  signed webhook  ───────────────►  :4000 /zoom/webhook
+  (channelJid, msg)                      │  REAL dispatch: coordinator → sessions_spawn → spoke → outbound
+                                         │
+              [3 tool-trace hook] ◄──────┤  before_tool_call fires for EVERY tool call
+              records {runId, agent,     │  (coordinator's sessions_spawn + each spoke's domain tools)
+               toolName, params} ──┐     │
+                                   │     ▼
+            [2 egress interceptor] │  if to_jid ∈ capture-set:  record outbound → [proxy-capture SQLite] + synthetic 200 (NO send)
+            (undici dispatcher,    │  else:                     forward to real dispatcher (other bots unaffected)
+             env-gated)            │
+                                   ▼
+                         [proxy-capture SQLite store]
+                                   ▲
+  [5 assertion runner] ◄───────────┘   reads outbound records + tool-trace records
+  [4 session reset]: /reset target agent's session before the run (anti-contamination)
+```
+
+### 1. Intake injector (external CLI)
+Posts a signed `team_chat.channel_message_posted` to `:4000/zoom/webhook`. Signature =
+`v0=HMAC_SHA256(ZOOM_WEBHOOK_SECRET_TOKEN, "v0:<ts>:<rawBody>")`, headers `x-zm-signature` +
+`x-zm-request-timestamp`. Parameterized by `channelJid` (routes to whichever bot is bound),
+message text, operator. One injector → any bot.
+
+### 2. Egress interceptor (the one in-process, test-only piece)
+Env-gated (`OPENCLAW_ZOOM_CAPTURE_CHANNELS=<jid,jid>`). Installed at gateway bootstrap; **wraps**
+the existing `undici-runtime` global dispatcher. For requests to `api.zoom.us` message endpoints
+(`/v2/im/chat/messages`, `/v2/chat/users/*/messages`):
+- `to_jid` (or DM target) ∈ capture-set → **record outbound + return synthetic `200
+  {status:"ok", message_id:"<fake>"}`**; no real send.
+- otherwise → **forward to the real dispatcher** (production bots in other channels keep working).
+- all non-Zoom traffic (openrouter model calls, Scopely BFF reads, Zoom token/history) →
+  untouched passthrough.
+
+Catches core sends **and** every bot's raw POSTs in one place, scoped so only the channel(s) under
+test go silent.
+
+### 3. Tool-trace hook (the hub-and-spoke observability piece)
+A `before_tool_call` hook (same test env gate) records each call: `{runId, toolName, params,
+toolCallId, agentAttribution}`. Because it fires for `sessions_spawn` too, the trace shows exactly
+which spoke the coordinator chose (`sessions_spawn` `params.agentId`) and which domain tools each
+spoke then called. Records go to the same capture store, correlated by `runId`.
+
+> Agent attribution: derive which agent made a call from the hook context (`sessionKey`/`agentId`)
+> if exposed, else from `sessions_spawn` params + the per-spoke `agents.<spoke>.tools.allow`
+> tool-policy boundary. **Open question** — confirm the cleanest attribution source.
+
+### 4. Session reset (external step)
+Before each run, `/reset` the target agent's channel session (parameterized by `sessionKey`) so
+prior-turn contamination cannot poison results. (This is the documented non-channel lever; it also
+prevented the 2026-06-05 "fixated on resetting Matt Keuning" failure mode from recurring.)
+
+### 5. Assertion runner (external)
+Reads outbound + tool-trace records for the run from the capture store and asserts. All assertions
+are payload/trace-level — no screenshots needed.
+
+## What this lets you assert
+
+**Output fidelity (per-bot, e.g. scopelybot confirm-gate):**
+- Confirm prompt was posted to the channel and **contains a real `CONFIRM <code>`**.
+- Coordinator's reply is **code-free** (regex: no `CONFIRM \d{4}`).
+- Result is **in-thread** (`reply_to`/`reply_main_message_id` set to the originating message).
+- Wrong-code CONFIRM is a no-op (fail-closed).
+
+**Hub-and-spoke routing (any bot):**
+- **Routing discrimination** — request X spawned spoke Y (assert the `sessions_spawn`
+  `params.agentId`); a different-domain request spawns a different spoke.
+- **Router-only coordinator** — the coordinator's tool calls ⊆ `{sessions_spawn, subagents,
+  liveness reads}`; it never calls a domain tool directly.
+- **Per-spoke tool use** — spoke Y called the expected tools (e.g. `scopely_list_users`), and only
+  from its own allowlist.
+- **No cross-spoke reach** — a single in-domain task completed without the spoke needing a tool
+  that lives in another spoke (the Track 2 partitioning invariant).
+- **Safety guard** — a **read** request triggered **no write/staging tool** (would have caught the
+  2026-06-05 "list users → staged password reset" contamination directly).
+
+## Modularity model
+An **agent profile** = `{ agentId, channelJid, sessionKey }`. The harness takes a profile + a test
+message + expected assertions. The capture-set is the profile's `channelJid`, so only that bot's
+channel is silenced. Testing another bot = another profile, zero code change. Profiles can live in
+a small test fixture (one entry per bot) or be passed inline.
+
+## Test flow (one run)
+1. Ensure the gateway is running with the interceptor armed (`OPENCLAW_ZOOM_CAPTURE_CHANNELS`
+   includes the profile's `channelJid`).
+2. `/reset` the profile's `sessionKey`.
+3. Inject the test message (signed webhook) to `channelJid`.
+4. Await completion (capture-count stable for the `runId`, or an `agent_end`/log marker — see open
+   questions), with a timeout.
+5. Read the run's outbound + tool-trace records; run assertions.
+6. Nothing reached the real channel.
+
+## Where the in-process pieces live
+A small **bundled test-capture extension** (`extensions/test-capture/`, or a test-helper module)
+that on `gateway:startup`, **only when the env flag is set**:
+- installs the egress interceptor by composing with `undici-runtime`, and
+- registers the `before_tool_call` trace hook.
+Inert when the flag is unset → safe to ship disabled. This keeps the harness in the
+`extensions/`/test boundary and touches no bot code.
+
+## Open questions to resolve before building
+1. **undici composition point** — confirm `src/infra/net/undici-runtime.ts` exposes a clean way to
+   wrap the existing dispatcher (capture-or-forward) without clobbering its custom Agent
+   (timeouts/proxy).
+2. **No per-request dispatcher bypass** — `comfort.ts`/`send.ts` use bare global `fetch` (good), but
+   verify no Zoom egress path passes a per-request `dispatcher` that slips past the global intercept
+   (a contract test referenced `requestInit.dispatcher`).
+3. **Agent attribution in `before_tool_call`** — confirm the hook context carries `agentId`/
+   `sessionKey`, else attribute via `sessions_spawn` params + tool-policy boundary.
+4. **Capture-store reuse** — confirm proxy-capture's SQLite store can be a writer-only sink for
+   synthetic outbound + tool-trace records, or add a small dedicated table (still SQLite).
+5. **Completion signal** — pick a deterministic "turn done" signal (stable capture count for the
+   `runId`, or an `agent_end` hook) instead of a fixed sleep.
+
+## Estimated scope
+~300–400 LOC, almost entirely **test infrastructure**: the test-capture extension (interceptor +
+trace hook + store writer), the injector CLI, and the assertion runner. Net **production-runtime**
+change ≈ the env-gated interceptor/hook install only (off by default).
+
+## Worthwhile follow-on (not required by this design)
+The duplicated `comfort.ts`/`zoom-dm.ts` raw POSTs across 7 bots are the reason a clean hook-level
+egress seam doesn't already exist — they violate the repo's "channels are transport-only; product
+code shouldn't raw-send" guidance. Routing them through core outbound (or a shared SDK send helper)
+would make `message_sending` a sufficient egress seam, shrink duplicated code, and simplify this
+harness. Separate refactor; the egress-interceptor design works today without it.

--- a/docs/reference/hub-and-spoke-implementation-guide.md
+++ b/docs/reference/hub-and-spoke-implementation-guide.md
@@ -1,0 +1,381 @@
+---
+title: "Hub-and-Spoke for Support Bots — Comprehensive Implementation Guide"
+summary: "The canonical, end-to-end guide to splitting an overloaded OpenClaw support bot into a router coordinator + single-domain specialist spokes: when it's worth doing, the exact native primitives and config, confirm-gated writes, deploy, noise-free validation with the test-capture harness, and every failure mode we hit in production. Supersedes hub-spoke-pattern-playbook.md and folds in the scopelybot as-built record, confirm-gate fidelity, and test-harness docs."
+status: reference
+---
+
+# Hub-and-Spoke for Support Bots — Comprehensive Implementation Guide
+
+> **Scope.** A reusable, copy-this guide for applying the hub-and-spoke pattern to *any* OpenClaw
+> support bot (scopelybot, pulsebot, bigheadbot, zoomwarriorssupportbot, …). First proven on
+> `scopelybot` (86 tools → router + 8 spokes, live-validated). This is the single canonical
+> reference; it supersedes `hub-spoke-pattern-playbook.md` and absorbs the lessons from
+> `scopelybot-hub-spoke-recommendation.md`, `scopelybot-confirm-gate-fidelity.md`, and
+> `agent-test-harness-design.md`. Read those only for deeper history.
+
+---
+
+## 1. What it is
+
+One user-facing **coordinator** agent (bound to the channel) that owns *no domain tools* — it
+classifies each request into one domain and delegates to a single-domain **specialist spoke** via
+`sessions_spawn(runtime=subagent)`. Each spoke sees only its own small toolset; the coordinator
+composes/relays the reply.
+
+```
+ user (channel) ─▶ coordinator (router; ~4 tools, no domain data)
+                        │  sessions_spawn(runtime="subagent", agentId="<spoke>", task="…")
+                        ▼
+                   spoke (small exclusive toolset) ── runs tools, returns data ──┐
+                        ▲                                                          │
+ coordinator relays the spoke's result into the originating thread ◀──────────────┘
+```
+
+Built entirely on native OpenClaw primitives — **no custom orchestration**:
+`sessions_spawn` + per-agent `tools.allow` allowlists + `subagents.allowAgents` + channel bindings.
+
+---
+
+## 2. When to use it (decision framework — read this BEFORE building)
+
+Hub-and-spoke is **not free**: every delegated call costs a full subagent spawn round-trip
+(latency + 2–3× model tokens), it needs a capable-enough coordinator model, and it adds deploy and
+session-management complexity. Apply it only when the payoff is real.
+
+**The trigger is confusable-tool density and *measured* misrouting — NOT raw tool count.**
+A model selects reliably among 40–50 *distinct, well-known* tools (`read`, `exec`, `gh_create_issue`,
+`zoom_send`, …). It fails among dozens of *near-synonym domain* tools in one menu (scopelybot's
+`list_users` vs `active_users` vs `list_invites`; CRUD across orgs/pricing/vendors/deploy). Count the
+**confusable domain surface**, not the menu size.
+
+Decision checklist for a candidate bot:
+1. **Measure first.** Use the test-capture harness (§8) to inject representative domain requests and
+   inspect tool selection / routing. Only act on demonstrated misrouting.
+2. **Is the confusable domain surface large (≈30+ same-domain tools with overlapping names)?** If no,
+   prefer cheaper fixes: sharpen tool descriptions, consolidate thin CRUD wrappers, or split the
+   *menu* with a shared tool bundle (§10) — not a full coordinator/spoke split.
+3. **Is the bot unscoped (no `tools.allow`)?** Then its real problem is *missing scoping*, not
+   confusability — give it an allowlist first (an unscoped agent sees every non-optional plugin tool
+   across all bots; see §3). That alone may resolve it.
+4. **Is the per-call spawn cost acceptable?** Hub-and-spoke doubles model turns per request. Fine for
+   a research/admin bot; reconsider for a latency-sensitive, high-frequency bot.
+
+If 1–4 say yes, proceed. Otherwise stop — the pattern will cost more than it saves.
+
+---
+
+## 3. How tool scoping actually works (the mechanism you must understand)
+
+Source of truth: `src/plugins/tools.ts` (filtering at lines ~828–845; `isOptionalToolAllowed` ~277).
+
+- A **non-optional** plugin tool is included for an agent iff its name is in that agent's resolved
+  available set (derived from its `tools.allow` / profile). An agent with **no allowlist** gets the
+  default profile = **every non-optional plugin tool across all loaded plugins** (this is why an
+  unscoped bound agent like `customer-support`/`main` can silently see 150+ tools).
+- An **optional** plugin tool (registered `optional: true`) is included **only if explicitly allowed**
+  (by tool name, plugin id, `group:plugins`, or `*`). If the allowlist doesn't name it, it's hidden —
+  even from unscoped agents.
+
+**Consequence for hub-and-spoke:** register the bot's tools `optional: true` so per-agent allowlists
+actually scope them and they don't leak into other agents' default profiles. Then the coordinator's
+tiny allowlist and each spoke's exclusive allowlist do real work.
+
+```ts
+// extensions/<bot>/index.ts — wrap registerTool so every tool is optional.
+const optionalApi: OpenClawPluginApi = {
+  ...api,
+  registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+};
+registerXxxTools(optionalApi, logger); // ...register all the bot's tools through optionalApi
+```
+
+> **Verify after wiring:** the tool-policy log line `tool policy removed N tool(s) via
+> agents.<id>.tools.allow: …` shows the allowlist filtering. Model self-reports about "which tools do
+> you have" are unreliable — trust the gateway log / the harness trace, not the agent.
+
+---
+
+## 4. Prerequisites (channel-level; shared, mostly already shipped)
+
+For a Zoom bot these already exist (landed during the scopelybot build) and a new hub-and-spoke bot
+inherits them for free:
+1. **Subagent spawn unblock** — `sessions_spawn` ignores acp-only `streamTo` for `runtime=subagent`.
+2. **Inbound threading** — `channels.zoom.threading.inheritParent: true` routes threaded replies to
+   the channel-bound agent with parent context.
+3. **Outbound in-thread delivery** — the Zoom `subagent_delivery_target` hook lands spoke results in
+   the originating thread, not channel root.
+
+For a **non-Zoom** channel, verify the equivalent `subagent_delivery_target` hook exists (discord/
+feishu ship one; others may need it).
+
+---
+
+## 5. Per-bot implementation recipe
+
+### 5a. Define the spokes (one unbound agent per domain)
+Each spoke is an entry in `agents.list[]` in `~/.openclaw/openclaw.json`
+(`.data/openclaw/openclaw.json` in the dev container):
+
+```jsonc
+{
+  "id": "scopely-users",
+  "model": { "primary": "openrouter/openai/gpt-5.4-mini",
+             "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"] },
+  "tools": { "allow": [            // EXCLUSIVE allowlist = exactly this domain's tools
+    "scopely_list_users", "scopely_get_user", "scopely_reset_user_password",
+    "scopely_set_user_active", "scopely_update_user", "scopely_create_invite",
+    "scopely_list_invites", "scopely_list_access_requests",
+    "scopely_approve_access_request", "scopely_reject_access_request"
+  ] }
+}
+```
+Each spoke gets a `workspace-<spoke>/IDENTITY.md` worker prompt (template in §11). Same model as the
+coordinator is fine. Spokes are **unbound** (no `bindings` entry) — only the coordinator is bound.
+
+### 5b. Make the coordinator router-only
+Shrink the coordinator's `tools.allow` to *just* routing + at most 1–2 trivial liveness reads, and
+set `subagents.allowAgents` to the spoke ids:
+
+```jsonc
+{
+  "id": "scopelybot",
+  "model": { "primary": "openrouter/openai/gpt-5.4-mini",
+             "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"] },
+  "tools": { "allow": ["sessions_spawn", "subagents",
+                       "scopely_health_check", "scopely_auth_status"] },
+  "subagents": { "allowAgents": ["scopely-observe","scopely-admin","scopely-users","scopely-orgs",
+                                 "scopely-pricing","scopely-vendors","scopely-deploy","scopely-github"] }
+}
+```
+
+> ### THE critical lesson (cost 4 failed live tests on scopelybot)
+> The coordinator must have **NO general tools** — no `read`, `memory_search`, `memory_get`,
+> `web_*`, `exec`. If it can read anything, a weak model uses that to answer domain questions from
+> its own memory/history instead of delegating, and tends to ask permission instead of acting.
+> `sessions_spawn` must be its **only** path to domain data. **Prompt hardening alone is not enough —
+> remove the tools.**
+
+### 5c. Enable the bot in discovery
+An extension only loads if its id is in `plugins.entries` in `openclaw.json` — having the dir +
+manifest + `OPENCLAW_BUNDLED_PLUGINS_DIR` is **not** enough, and discovery skips unlisted plugins
+*silently* (no log, no error):
+```jsonc
+"plugins": { "entries": { "<bot>": { "enabled": true }, /* … */ } }
+```
+
+### 5d. Bind the coordinator to the channel
+```jsonc
+"bindings": [ { "agentId": "<bot>",
+  "match": { "channel": "zoom", "peer": { "kind": "channel", "id": "<channelJid>" } } } ]
+```
+
+---
+
+## 6. Spoke partitioning rules
+
+The recurring failure mode (documented in `scopelybot-spoke-partitioning-problem.md`) is splitting
+tools by **action-class** (list / summary / CRUD / telemetry) instead of by the **domain noun the
+coordinator routes on**. Get this right:
+
+- **Routing axis == partitioning axis.** A request classified to a domain noun ("users", "pricing")
+  must land on a spoke holding the *full* surface to answer it — reads **and** writes **and** the
+  lookups those depend on. The coordinator must never need to know which sibling holds a dependency.
+- **Each spoke owns its full CRUD.** Don't split "read pricing" and "edit pricing" across spokes.
+- **No cross-domain dependency reaches.** If a write needs an id from a lookup, that lookup lives in
+  the *same* spoke (scopelybot bug: scoping cards needed `list_project_types`, which lived in a
+  different spoke → the deploy spoke brute-forced ids 0–10 and gave up).
+- **Cross-cutting reads** (telemetry, dashboards, audit) get a dedicated `observe`/`admin` spoke —
+  but keep their charter crisp, or you reintroduce routing ambiguity ("active users" → users *or*
+  observe?).
+- **Keep each spoke ≲ 30 tools.** Merge thin wrappers / sharpen descriptions first if a single domain
+  is still too big.
+- **One spoke = one unambiguous intent.** If a request could plausibly route to two spokes, the split
+  is wrong.
+
+There is no shared source of truth between the coordinator's routing table (prose in `IDENTITY.md`)
+and the spoke allowlists (`openclaw.json`) — they drift. After any change, **prove with the harness
+(§8) that every representative intent the table routes to spoke S is answerable by S's tools.**
+
+---
+
+## 7. Confirm-gated writes (deterministic, LLM-out-of-the-loop)
+
+Any destructive write must be confirm-gated, and — critically — the confirmation code must **never
+pass through the LLM** (a small coordinator model fabricates, rewrites, re-relays, and duplicates
+codes; observed live). The proven pattern (scopelybot `gated.ts` + `index.ts`):
+
+1. **Single staging chokepoint.** Every write tool calls one `stageWrite(summary, run)` helper that:
+   generates the code, `putPending({code, summary, run})` (in-memory, single-use, 5-min TTL), and
+   **delivers the `⚠️ Confirm … CONFIRM <code>` prompt to the channel itself** (threaded), returning
+   a **code-free** `{staged, awaiting_confirmation}` result to the model. The model never sees a code.
+2. **Execution in `before_dispatch`, not an observe hook.** A `before_dispatch` hook matches
+   `^CONFIRM\s+\d{4}` and runs the staged action, returning `{handled: true, text: <result>}`.
+   `handled:true` **suppresses the coordinator** (so the CONFIRM can't re-stage) and the result is
+   delivered threaded by core. (`message_received` is fire-and-forget and runs *before*
+   `before_dispatch` — do **not** execute there, or it consumes the pending first.)
+3. **Persona guard (defense-in-depth).** Coordinator `IDENTITY.md`: "never emit/relay/invent a
+   `CONFIRM <code>`; on `awaiting_confirmation` reply `NO_REPLY`; if a message is `CONFIRM <code>`,
+   reply `NO_REPLY`."
+
+Invariants: fail-closed (single-use, TTL, human-typed; the LLM cannot fabricate the inbound CONFIRM),
+and the **whole write class** routes through the one chokepoint so no tool relies on LLM relay.
+
+Key source: `before_dispatch` fires at `src/auto-reply/reply/dispatch-from-config.ts:~2082`
+(`handled` → threaded `sendFinalPayload` + early return); `message_received` is fire-and-forget at
+`~1893`; void/early-return hooks are safe (`src/plugins/hooks.ts` `runClaimingHooksList ~737`).
+
+---
+
+## 8. Validation — noise-free, with the test-capture harness
+
+Use `extensions/test-capture/` (see `agent-test-harness-design.md`) to drive the bot's **real**
+pipeline and capture+suppress all channel egress — **no writes to the live channel** — while
+recording the routing/tool trace. To onboard a new bot:
+
+1. Add a profile to `extensions/test-capture/harness/profiles.mjs`:
+   `{ agentId, channelIdRaw, channelJid, sessionKey, operator, routerTools }`.
+2. Enable capture: `OPENCLAW_TEST_CAPTURE=1` (dev compose) + the bot is in `plugins.entries`.
+3. Run in-container (host Node 20 can't open the `node:sqlite` capture DB):
+   `docker exec openclaw sh -lc 'cd /app && node extensions/test-capture/harness/cases.mjs'`
+
+Assertions the harness makes possible (all payload/trace-level, no screenshots):
+- **Routing discrimination** — request X spawned spoke Y (`sessions_spawn` `params.agentId`).
+- **Router-only coordinator** — coordinator's tool calls ⊆ `{sessions_spawn, subagents, liveness}`.
+- **Per-spoke tool use / no cross-spoke reach** — spoke Y answered with only its own tools.
+- **Confirm-gate fidelity** — confirm prompt posted *with* a code; coordinator reply code-free;
+  in-thread; wrong code = no-op (fail-closed).
+- **Safety guard** — a *read* request triggered *no* write/staging tool (catches the contamination
+  class directly).
+
+Validation gates to run in order: spawn round-trip → routing discrimination → in-thread delivery →
+confirm-gate. The harness covers all four.
+
+---
+
+## 9. Deploy model + gotchas
+
+- **Extensions are jiti-live** from the `./extensions` bind-mount: edit `extensions/<bot>/**`, then
+  restart the container. **Core `src/**` changes need a `docker build`** (the container runs baked
+  `dist/`). A full `pnpm build` can OOM the box — avoid unless necessary.
+- **NEVER `rm -rf /tmp/jiti/*`** — it forces a cold re-transpile of *every* extension on the next
+  message (~70s + a memory spike to critical). jiti re-transpiles only changed files by mtime; just
+  restart. (Wiping the whole cache caused a self-inflicted "bot hung" stall.)
+- **First message after a restart is slow** (~70s cold load of all extensions); subsequent messages
+  are fast. Tooling/timeouts must tolerate this.
+- **Spoke/coordinator config + IDENTITY.md live in gitignored runtime state** (`.data/openclaw/…`).
+  Back up before/after (`.bak-*`); that's the rollback.
+- **`plugins.entries` and `tools.allow`/`subagents` changes need a container restart** (tool policy
+  loads at start). Moving a tool between spokes = edit the spoke's `tools.allow` + restart.
+
+---
+
+## 10. Shared bundles vs shared spokes (modularization guidance)
+
+Support bots heavily duplicate shared capabilities — `gh-tools.ts` is copy-pasted across **7**
+extensions (already drifting: 401 vs 223 lines), `comfort.ts` ×6, `zoom-dm.ts` ×5, `correlation` ×4,
+`devtools` ×3. Two different reuse units solve two different problems — don't conflate them:
+
+| | **Shared bundle** (shared *code*) | **Shared spoke** (shared *agent*) |
+|---|---|---|
+| What | one `registerGithubTools(api,{prefix})` imported by all bots | a `github` agent the coordinator spawns |
+| Per-call cost | zero (in-process, direct) | a full spawn round-trip (latency + tokens) |
+| Reduces coordinator menu | no | yes |
+| Best for | **frequent, distinct** shared tools (GH, devtools) | **infrequent, large/confusable** shared clusters |
+
+- Fix duplication with a **shared bundle** (prefix-parameterized so `bh_gh_*` / `gh_*` /
+  `scopely_gh_*` still work). This is the plug-and-play win at the *code* layer; no spawn cost.
+- Promote a shared capability to a **shared spoke** only when a bot is *both* demonstrably overloaded
+  *and* uses that capability infrequently enough to absorb the spawn. The bundle is the prerequisite
+  either way (a shared spoke also needs one implementation).
+- Deciding factor per capability: **frequency × confusability.** Frequent+distinct → bundle.
+  Infrequent+large/confusable → spoke.
+
+---
+
+## 11. Templates
+
+### Coordinator `IDENTITY.md` (router)
+```markdown
+# IDENTITY.md — <Bot> Coordinator
+- Role: router for <product> administration in this channel. You are a ROUTER, not a doer.
+- You own NO domain tools (only liveness checks). For every real request, classify into ONE
+  domain and delegate to that domain's spoke.
+
+## Never answer from memory — always route, never ask
+History/notes/memory may be stale. Never answer a domain question from recall/`read`/`memory_*`/
+assumption. For ANY domain question, immediately spawn the relevant spoke and relay its fresh result.
+Do not ask permission ("would you like me to…"); just spawn and answer.
+
+## How to delegate
+1. Pick the single best spoke from the routing table.
+2. sessions_spawn(runtime="subagent", agentId="<spoke>", task="<full restatement incl. every
+   id/name/value the spoke needs — it cannot see the channel or history>").
+3. On the SPAWN turn, reply exactly `NO_REPLY` (no summary/preview).
+4. Wait — the spoke's result is auto-delivered back (push-based). Do NOT poll.
+5. On the result turn, relay the spoke's fresh result clearly.
+
+## Routing table
+| Spoke | Use when the request is about… |
+|---|---|
+| <spoke-a> | … |
+
+## Confirm-gate (writes)
+Writes are confirm-gated; the code is handled entirely by the system. A staging spoke returns
+`awaiting_confirmation` and NO code (the system posts the `CONFIRM <code>` prompt directly). On that
+turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a message is just
+`CONFIRM <code>`, reply `NO_REPLY`.
+```
+
+### Spoke `IDENTITY.md` (worker)
+```markdown
+# IDENTITY.md — <Bot> <Domain> Specialist
+- You run only your domain's tools and return the result to your coordinator.
+- You NEVER address the channel directly; the coordinator owns all user-facing replies.
+- Writes are confirm-gated: stage via the write tool (which posts the CONFIRM prompt) and return its
+  result. Never execute a mutation directly; never fabricate a code.
+- If you lack a tool to answer, say so plainly — do not guess ids or approximate from proxy data.
+```
+
+---
+
+## 12. Quick-start checklist
+1. **Measure** the candidate bot with the harness; confirm real confusable-domain misrouting (§2).
+2. Make the bot's tools `optional: true` (§3).
+3. Partition tools into domain spokes by the **routing noun**, full CRUD per spoke (§6).
+4. Add spoke agents (`agents.list[]`, exclusive `tools.allow`, worker `IDENTITY.md`) (§5a).
+5. Make the coordinator router-only (`tools.allow` = routing only; `subagents.allowAgents`; router
+   `IDENTITY.md`) — **remove all general tools** (§5b).
+6. Confirm-gate writes through one `stageWrite` chokepoint + `before_dispatch` execution (§7).
+7. Add the bot to `plugins.entries`; bind the coordinator to the channel (§5c–d).
+8. Deploy (restart; don't wipe jiti) (§9).
+9. Validate with the harness: routing, in-thread, confirm-gate, safety guard — zero channel writes (§8).
+10. If the bot also duplicates shared tools, consolidate into shared **bundles** (§10).
+
+---
+
+## 13. Failure modes we actually hit (and the fix)
+- **Coordinator answers from memory instead of routing** → it still had general tools. Remove them (§5b).
+- **Weak coordinator fabricates/relays confirm codes** → deterministic confirm delivery; code never
+  through the LLM (§7).
+- **Read request stages a write** (model fixates on recent write history) → context contamination;
+  clear with a session `/reset`; the harness safety-guard assertion catches it (§8). Root cause is the
+  weak model + co-located read/write tools — a reason to keep spokes small and consider splitting
+  destructive tools out.
+- **Bot "hung" / no model request after tool-policy** → bloated coordinator session (context-build
+  stalls). Reset the session: `docker exec openclaw node dist/entry.js agent --session-key
+  '<key>' --message '/reset'` (CLI times out on teardown but the reset completes server-side).
+- **Extension silently not loaded** → missing from `plugins.entries` (§5c).
+- **Self-inflicted ~70s stall + memory spike** → someone wiped `/tmp/jiti/*`. Don't (§9).
+- **Spoke can't answer an in-domain question** → a needed lookup/read tool lives in another spoke;
+  re-partition by domain noun, not action class (§6).
+
+---
+
+## 14. References
+- As-built record: `scopelybot-hub-spoke-recommendation.md`
+- Confirm-gate detail: `scopelybot-confirm-gate-fidelity.md`
+- Partitioning problem: `scopelybot-spoke-partitioning-problem.md`
+- Test harness: `agent-test-harness-design.md`
+- Source anchors: `src/plugins/tools.ts` (scoping ~828–845, `isOptionalToolAllowed` ~277),
+  `src/auto-reply/reply/dispatch-from-config.ts` (`before_dispatch` ~2082, `message_received` ~1893),
+  `src/plugins/hook-types.ts` (`PluginHookToolContext` ~501), `extensions/scopelybot/` (reference impl).

--- a/docs/reference/hub-spoke-pattern-playbook.md
+++ b/docs/reference/hub-spoke-pattern-playbook.md
@@ -6,6 +6,11 @@ status: reference
 
 # Hub-and-Spoke Agent Pattern — Reuse Playbook
 
+> **Superseded.** The canonical, comprehensive guide is now
+> [Hub-and-Spoke for Support Bots — Implementation Guide](/reference/hub-and-spoke-implementation-guide)
+> (decision framework, full recipe, confirm-gated writes, deploy, noise-free validation, failure
+> modes). This page is kept for history; start with the implementation guide.
+
 When one agent accumulates too many tools (degradation starts ~30-50; selection gets worse beyond
 that), split it into a small **router coordinator** that delegates to single-domain **specialist
 subagents ("spokes")**, each seeing only its own small toolset. First proven on `scopelybot` (86

--- a/docs/reference/scopelybot-confirm-gate-fidelity.md
+++ b/docs/reference/scopelybot-confirm-gate-fidelity.md
@@ -1,0 +1,151 @@
+---
+title: "ScopelyBot Confirm-Gate — Fidelity & Delivery Problem"
+summary: "The confirm-gate's code and result currently pass through the LLM coordinator and an un-suppressed observe hook. This causes fabricated codes, stale/duplicate prompts, spurious re-staging, and out-of-thread delivery. Records the problem with live evidence and the deterministic round-trip the fix must achieve."
+status: exploratory
+---
+
+# ScopelyBot Confirm-Gate — Fidelity & Delivery Problem
+
+> **Read this first.** This documents observed defects in the write-action confirm gate, backed
+> by live logs from 2026-06-05, plus the design principle a fix must satisfy. It is an _intent_
+> document, not an approved spec. The "what a fix must guarantee" section is the contract; the
+> sketched mechanism is one way to meet it, not the only way. Re-verify the hook behavior noted in
+> "Open questions" before building.
+
+## Background — how the gate works today
+
+Write tools in `extensions/scopelybot/` (password reset, activate/deactivate, update user, create
+invite, pricing/org/vendor/deploy mutations) are **confirm-gated**:
+
+1. The spoke calls a write tool (e.g. `scopely_reset_user_password`). The tool does **not** mutate.
+   It calls `putPending({ code, summary, run })` (`src/pending-confirm.ts`) — an in-memory,
+   single-use, 5-minute-TTL store keyed by a 4-digit `code` — and returns a staged message:
+   `⚠️ Confirm: <summary> on PROD. Reply CONFIRM <code> within 5 minutes…`.
+2. That message travels **back to the coordinator** as a subagent announce, and the **coordinator
+   relays it to the Zoom channel** as its turn reply.
+3. The human types `CONFIRM <code>` in the channel. A `message_received` hook
+   (`extensions/scopelybot/index.ts:74`) calls `tryExecuteConfirm`, which `takePending(code)` and
+   runs the staged closure — a single deterministic API call. The LLM is not in the execution
+   decision (it cannot fabricate the inbound `CONFIRM` message).
+
+The **intent** is sound: the model stages, a human confirms, the system executes. The **defects
+are in the delivery plumbing around it** — specifically that exact-fidelity strings (the codes)
+and the confirm round-trip pass through the LLM and through an observe-only hook.
+
+## The defects (with live evidence, 2026-06-05)
+
+Comparing what was **actually staged** (spoke → `putPending`) against what the **coordinator
+relayed to the channel** (what the user sees):
+
+```
+REAL stagings (spoke putPending)     RELAYED to channel (coordinator reply)
+18:29:48  9042                        18:29:52  9042   ok
+                                      18:39:41  9042   ← STALE re-relay (no staging occurred at 18:39)
+18:45:08  7961                        18:45:12  7961   ok
+18:45:30  6880                        18:45:31  6880   ok
+19:04:02  5799                        19:04:00  7951   ← FABRICATED (never staged; relayed BEFORE the real staging)
+                                      19:04:06  5799   ok
+```
+
+### D1 — Coordinator fabricates confirm codes (highest severity)
+At 19:04:00 the coordinator relayed `CONFIRM 7951`, a code that was **never staged** (the real
+code `5799` did not exist until 19:04:02). `gpt-5.4-mini` invented a plausible 4-digit code, in
+direct violation of its own persona (`IDENTITY.md`: *"Relay the CONFIRM code exactly,
+character-for-character… never invent a code"*). It also **re-relayed a stale code** (`9042` at
+18:39 with no staging behind it).
+
+- **Why it matters:** the user cannot tell the real code from the invented one. A fabricated code
+  *fails closed* (it matches no pending action, so nothing executes) — so this is not a
+  security hole — but it is a **trust and usability hole**: it directly caused the operator to type
+  wrong codes (`1001`, `9042`-expired) and conclude the gate was broken.
+- **Root cause:** the exact code passes **through the LLM** on its way to the channel. Any model —
+  especially a small one — can mangle, re-emit, or invent it.
+
+### D2 — Duplicate confirm prompt
+The same real code is relayed twice for one staging (`9042` at 18:29:48 & :52; `5799`-class double
+relays observed). This is the coordinator double-delivering a reply — the same intermittent
+double-reply pattern that the `NO_REPLY`-on-spawn persona rule reduced for normal answers but does
+not fully eliminate under `gpt-5.4-mini`.
+
+### D3 — `CONFIRM` message re-triggers the coordinator → spurious re-stage
+The `message_received` confirm hook is **observe-only**: it executes the confirm but does **not**
+suppress the message from reaching the coordinator. So `CONFIRM <code>` is *also* dispatched to the
+coordinator, which sometimes interprets it as a new request and **re-stages**:
+
+```
+18:44:58  user: "reset Matt Keuning's password"   → staged 7961
+18:45:23  user: "CONFIRM 7961"                     → confirm-gate executes 7961  (ok)
+          (same message also routed to coordinator → re-spawned the users spoke)
+18:45:30  → staged 6880                            ← spurious second code from the CONFIRM message
+```
+
+- **Why it matters:** every confirmation can spawn an orphan staged write action. Harmless today
+  (the orphan expires) but it is real write-path churn and more confusing codes. Intermittent —
+  it depends on whether the mini model decides to act on the `CONFIRM` text.
+
+### D4 — Confirm result delivered out-of-thread
+The confirm execution result (and the `No pending action…` errors) are sent via `sendScopelyText`
+(`src/comfort.ts:84`), which POSTs to the channel JID with **no `reply_to`** — unlike
+`sendComfortMessage`, which supports threading. So results land at **channel root**, detached from
+the conversation thread. (Separate from, but compounding, the general threading work already fixed
+in `extensions/zoom/src/outbound.ts`.)
+
+## Root cause, stated once
+
+> The confirm round-trip — the prompt carrying the code **out**, and the result coming **back** —
+> currently passes through the **LLM coordinator** and through an **observe-only hook**. Exact
+> strings (codes) and control flow (execute / suppress / thread) must not depend on a language
+> model relaying them faithfully or on a hook that cannot stop dispatch.
+
+D1/D2 come from the **prompt** being LLM-relayed. D3/D4 come from the **execution** path being an
+observe hook with a non-threaded sender.
+
+## What a fix must guarantee (the contract)
+
+1. **Codes never pass through the LLM.** The exact `⚠️ Confirm … CONFIRM <code>` prompt is
+   delivered to the channel **deterministically** from the staging tool/runtime, not relayed by the
+   coordinator. The coordinator returns `NO_REPLY` for the staging turn.
+2. **The `CONFIRM <code>` message never reaches the coordinator.** It is claimed/suppressed before
+   agent dispatch, so it cannot re-stage.
+3. **Both prompt and result are delivered in-thread**, anchored to the originating conversation.
+4. **Fail-closed is preserved.** No change weakens the in-memory, single-use, TTL, human-typed
+   confirm guarantee. The LLM stays out of the execution decision.
+5. **Applies to the whole class.** Every confirm-gated write tool (not just password reset) must
+   use the deterministic path — no tool may rely on LLM relay of its code.
+
+## Sketched mechanism (one way to meet the contract — not the spec)
+
+- **Deterministic prompt delivery:** when a write tool stages, deliver the confirm prompt straight
+  to the channel (threaded), and have the staging turn resolve to `NO_REPLY`. The code is generated
+  and rendered by code, sent by code — the model never sees or repeats it.
+- **`before_dispatch` for execution:** move `tryExecuteConfirm` from the observe `message_received`
+  hook to a `before_dispatch` hook returning `{ handled: true, text: <result> }`. `handled:true`
+  suppresses the coordinator (fixes D3); `text` is delivered via the core's threaded
+  `sendFinalPayload` (fixes D4). Remove `tryExecuteConfirm` from `message_received` to avoid
+  double-consuming the single-use code.
+- **Defense-in-depth:** persona line — *"never emit a `CONFIRM <code>` line yourself; if a message
+  is `CONFIRM <code>`, reply `NO_REPLY`."* Covers any path the deterministic delivery misses.
+
+## Open questions / to verify before building
+
+- Does `before_dispatch` actually fire for the scopelybot **channel-bound agent dispatch** path?
+  (No extension uses it yet — confirm with a temporary probe before relying on it; fallback is
+  `inbound_claim`, which is the other documented pre-dispatch suppression seam.)
+- What is the cleanest deterministic channel-send seam for the **prompt** that threads correctly
+  and is reusable by all write tools? (`sendComfortMessage` already threads via `reply_to` /
+  `reply_main_message_id` — `sendScopelyText` needs the same, or the staging path should use the
+  core delivery rather than a raw Zoom POST.)
+- Inventory: confirm that **all** confirm-gated write tools route their prompt the same way, so the
+  fix covers the class rather than one tool. (`scopely_set_user_active`, `scopely_update_user`,
+  `scopely_create_invite`, approve/reject access request, and the pricing/org/vendor/deploy
+  mutations all use `putPending`.)
+
+## Severity / priority
+
+- D1 (fabricated codes): **high** — breaks operator trust in the gate; root of the reported
+  "two different codes back to back." Fails closed, so not a security breach.
+- D3 (re-stage): **medium** — write-path churn, intermittent.
+- D2 (duplicate prompt) / D4 (out-of-thread): **low/cosmetic** — confusing, not harmful.
+
+All four are resolved by the single principle: take the LLM and the observe-only hook out of the
+confirm round-trip.

--- a/docs/reference/scopelybot-hub-spoke-recommendation.md
+++ b/docs/reference/scopelybot-hub-spoke-recommendation.md
@@ -204,3 +204,75 @@ and silently undoes all scoping work for threaded conversations. Note the audit 
 - Tool catalog / admin surface: `docs/reference/scopely-admin-config-roadmap.md`,
   `docs/reference/scopely-user-maintenance-roadmap.md`
 - ScopelyBot extension: `extensions/scopelybot/`
+
+---
+
+## Appendix — As-deployed configuration snapshot (2026-06-08)
+
+> **Why this is here.** The hub-and-spoke *wiring* (agent definitions, allowlists, router/worker
+> personas, plugin enablement) lives in **gitignored runtime state** — `~/.openclaw/openclaw.json`
+> (`agents.list[]`, `plugins.entries`, `bindings`) and `~/.openclaw/workspace-*/IDENTITY.md` — so it
+> is **not otherwise reviewable from this branch**. This appendix snapshots the live config verbatim
+> for review/reproducibility. It is a record only; the running environment is unchanged.
+
+### Agents (coordinator + 8 spokes), all `model.primary = openrouter/openai/gpt-5.4-mini`, fallback `openrouter/anthropic/claude-haiku-4.5`
+
+```
+scopelybot (COORDINATOR, router-only)  tools.allow(4): sessions_spawn, subagents,
+                                       scopely_health_check, scopely_auth_status
+  subagents.allowAgents: scopely-observe, scopely-admin, scopely-users, scopely-orgs,
+                         scopely-pricing, scopely-vendors, scopely-deploy, scopely-github
+
+scopely-observe  (15) active_users, auth_status, get_session, health_check, list_sessions,
+                      list_users, recent_errors, recent_logins, search, user_activity,
+                      extraction_detail, extraction_metrics, extraction_sessions,
+                      wizard_funnel, correlate_errors
+scopely-admin    (7)  audit_logs, dashboard_stats, pending_approvals, session_pricing,
+                      vendor_config, passthrough_run_now, passthrough_status
+scopely-users    (10) approve_access_request, create_invite, list_users, get_user,
+                      list_access_requests, list_invites, reject_access_request,
+                      reset_user_password, set_user_active, update_user
+scopely-orgs     (8)  add_org_domain, create_org, delete_org, get_org, list_org_domains,
+                      list_orgs, remove_org_domain, update_org
+scopely-pricing  (15) create/update/delete {currency, pricing_default, pricing_item},
+                      get_pricing_default, get_session_pricing_config, list_currencies,
+                      list_pricing_defaults, list_pricing_items, update_session_pricing_config
+scopely-vendors  (13) create/update/delete {vendor, project_type, vendor_term},
+                      get_vendor, list_project_types, list_vendors, list_vendor_terms
+scopely-deploy   (14) create/update/delete {deployment_type, deployment_type_template,
+                      scoping_card}, get_scoping_card, list_deployment_types,
+                      list_deployment_type_templates, list_project_types, list_scoping_cards
+scopely-github   (6)  gh_add_comment, gh_close_issue, gh_create_issue, gh_get_issue,
+                      gh_list_issues, gh_search_issues
+```
+(All tool names carry the `scopely_` prefix. Spokes are **unbound**; only the coordinator is bound.)
+
+### Plugin enablement + binding
+```
+plugins.entries.scopelybot = { "enabled": true, "config": { "scopelyRepos": ["cloudwarriors-ai/scopely"] } }
+binding: scopelybot <- zoom channel 575b23671d6b4b7f8c22b1924b6177fa@conference.xmpp.zoom.us
+```
+
+### Coordinator persona (`workspace-scopelybot/IDENTITY.md`) — router prompt
+Key clauses (full text in runtime state):
+- "You are a **router**, not a doer ... only liveness checks (`scopely_health_check`,
+  `scopely_auth_status`). Classify into **one** domain and delegate to that domain's spoke."
+- "**NEVER answer domain questions from memory** ... immediately spawn the relevant spoke and relay
+  its fresh result." / "**Do not ask permission to route.** Just spawn and answer."
+- Delegation: `sessions_spawn(runtime="subagent", agentId="<spoke>", task="<full restatement>")`;
+  reply **exactly `NO_REPLY`** on the spawn turn; relay only on the result turn; never poll.
+- A routing table (domain -> spoke).
+- Confirm-gate: "the confirmation code is handled **entirely by the system - never by you** ... a
+  spoke returns `awaiting_confirmation: true` and **no code** ... reply `NO_REPLY` ... never write a
+  `CONFIRM <code>` line yourself."
+
+### Spoke persona (`workspace-scopely-users/IDENTITY.md`) — worker prompt (representative)
+- "You are a **worker subagent** ... do exactly that task using only your tools, then return the
+  result. You do **not** talk to the channel."
+- "If you lack an id/value ... look it up with your read tools first; ... rather than guessing."
+- WARNING **known drift (cleanup item):** the spoke persona still says "Return that
+  `Reply CONFIRM <code>` message **verbatim**." That predates the deterministic confirm-gate fix
+  (`a8eb400b39`), where `stageWrite()` now posts the prompt itself and returns a **code-free**
+  result — so the spoke no longer relays a code regardless of this line. The text is obsolete and
+  should be reconciled with the coordinator's "no code" contract. Functionally harmless (the code
+  path is deterministic), but worth cleaning up.

--- a/docs/reference/scopelybot-spoke-partitioning-problem.md
+++ b/docs/reference/scopelybot-spoke-partitioning-problem.md
@@ -1,0 +1,123 @@
+---
+title: "ScopelyBot Spoke Tool-Partitioning — Problem Statement"
+summary: "The 86 tools were split across 8 spokes by action-class, not by the domain the coordinator routes on. Read/dependency tools end up siloed away from the spoke that fields their questions, and the routing table and allowlists drift independently. This doc describes the problem and what a good split must achieve — it does NOT prescribe a solution."
+status: exploratory
+---
+
+# ScopelyBot Spoke Tool-Partitioning — Problem Statement
+
+> **Scope of this doc.** This describes a recurring class of failure in how scopelybot's tools are
+> divided among spokes, with concrete evidence. It deliberately does **not** propose a fix — only
+> the problem, why it keeps happening, and the criteria any future rework must satisfy. A separate
+> design doc will own the solution.
+
+## Context
+
+`scopelybot` is a router **coordinator** plus 8 single-domain **specialist spokes** (see
+`scopelybot-hub-spoke-design.md`). The coordinator owns no domain tools; it classifies each user
+request into one domain and delegates to that domain's spoke via `sessions_spawn`. Each spoke has a
+small `tools.allow` allowlist. The 86 Scopely tools were partitioned across the spokes:
+
+```
+scopely-observe   telemetry/read       (~15 tools)
+scopely-admin     summaries/queues     (~7)
+scopely-users     user mutations       (10)
+scopely-orgs      orgs/domains         (8)
+scopely-pricing   pricing/currency     (15)
+scopely-vendors   vendors/project-types(13)
+scopely-deploy    deployment/scoping   (14)
+scopely-github    GitHub issues        (6)
+```
+
+## The problem
+
+**Tools were grouped by action-class (listing, summaries, CRUD, telemetry) instead of by the
+domain noun the coordinator actually routes on.** The coordinator routes on the noun in the request
+("users", "vendors", "scoping cards"). When a *read* or *dependency-resolution* tool for that noun
+lives in a different spoke, the spoke that receives the question cannot answer it.
+
+This is not a one-off; it is a **structural mismatch** between the routing axis (domain noun) and
+the partitioning axis (action class). It produces a steady trickle of "the bot can't do X" reports
+that are each individually "just add a tool" but collectively signal the split is wrong.
+
+### Evidence — three instances of the same failure
+
+1. **Scoping cards (resolved 2026-06-05).** `scopely-deploy` owns `scopely_list_scoping_cards` but
+   the cards endpoint needs a numeric `project_type_id`, and the resolver
+   `scopely_list_project_types` lived only in `scopely-vendors`. Asked for "8x8 UCaaS scoping
+   cards," the deploy spoke could not resolve `ucaas → 66`, **brute-forced `project_type_id` 0–10
+   (all 404), and gave up**. Fixed by adding the resolver to `scopely-deploy`.
+
+2. **List users (resolved 2026-06-05).** `scopely_list_users`, `scopely_active_users`,
+   `scopely_user_activity` were all assigned to `scopely-observe`. "List users in CloudWarriors"
+   routes to `scopely-users` (per the routing table), which had only `scopely_get_user` + user
+   mutations — **no way to enumerate users**. The spoke **approximated from access-requests/invites
+   and honestly reported it could not produce an authoritative list**. Fixed by adding
+   `scopely_list_users` to `scopely-users`.
+
+3. **Cross-cutting overlap (open).** `scopely-admin` ("summaries") and `scopely-observe`
+   ("telemetry") cut **across every domain**: `scopely_session_pricing` and `scopely_vendor_config`
+   live in `admin`; `scopely_active_users`/`scopely_user_activity` live in `observe`. So
+   "vendor config" could plausibly route to `vendors` *or* `admin`; "active users" to `users` *or*
+   `observe`. This is **routing ambiguity by construction** — the coordinator has to guess which
+   spoke owns a tool, and a weak model guesses wrong.
+
+### Symptoms this produces
+- Spokes that **cannot answer in-domain questions** because a needed read/lookup tool is elsewhere.
+- Spokes **brute-forcing or approximating** (guessing ids, deriving counts from proxy data) instead
+  of calling the right tool — which then looks like a model failure but is a missing-tool failure.
+- **Routing ambiguity** for cross-cutting spokes (admin/observe), worsened by the weak coordinator
+  model.
+- Each gap is discovered **one user complaint at a time**, in production, rather than caught up front.
+
+## Secondary problem: routing table and allowlists drift independently
+
+The coordinator's routing table lives in prose in `IDENTITY.md`; each spoke's tools live in
+`tools.allow` in `openclaw.json`. **They are maintained separately and have no shared source of
+truth.** This is literally how the `list_users` gap shipped: the routing table sent user questions
+to `scopely-users`, but `scopely-users`'s allowlist did not contain `scopely_list_users`. There is
+no check that "every question the table routes to spoke S can be answered by the tools S actually
+has." Nothing prevents the table and the allowlists from disagreeing.
+
+## Why it keeps happening (root cause)
+
+- **Wrong partitioning axis.** Splitting by action-class (list/summary/CRUD/telemetry) cuts across
+  the domain nouns the router reasons about. A domain's read + write + dependency-resolution tools
+  get scattered across spokes.
+- **No coverage contract.** There is no artifact asserting that the routing target for an intent
+  actually holds the tools to satisfy it.
+- **Thin tool descriptions.** Even when a tool is in the right spoke, the spoke's own model picks
+  and sequences tools from names + descriptions. Where descriptions omit how to obtain a required
+  parameter (e.g. "`project_type_id` comes from `scopely_list_project_types`"), the model
+  brute-forces (observed: 0–10 id guessing). Description quality compounds the partitioning
+  problem, especially under `gpt-5.4-mini`.
+
+## What a good split must achieve (success criteria, not a design)
+
+Any future rework should be judged against these — the *how* is out of scope for this doc:
+
+1. **Routing axis == partitioning axis.** A request classified to a domain noun must land on a
+   spoke that holds the full surface needed to answer it (read + write + the lookups those depend
+   on), so the coordinator never has to know which sibling holds a dependency tool.
+2. **No cross-domain dependency reaches.** A spoke should not need to have called a tool that lives
+   in another spoke to complete a single in-domain task.
+3. **Unambiguous routing.** For any user intent there should be one obviously-correct spoke. Where
+   cross-cutting concerns (telemetry, summaries) genuinely exist, their charter must be crisp enough
+   that the coordinator applies it mechanically.
+4. **Single source of truth / coverage guarantee.** The routing table and the spoke allowlists must
+   not be able to drift — a representative intent should be provably answerable by the spoke it
+   routes to.
+5. **Right-sized, well-described spokes.** Small enough that the spoke's model selects tools
+   reliably; descriptions that name how to obtain required parameters so the model resolves instead
+   of guessing.
+6. **Lower the reasoning bar.** Better grouping + descriptions should make correct routing and tool
+   use achievable even by a weak coordinator model — reducing dependence on a model upgrade.
+
+## Out of scope (intentionally)
+
+- The mechanism for grouping (re-partition, merge cross-cutting spokes, generate config from a
+  declarative map, etc.).
+- The model question (`gpt-5.4-mini` vs a stronger coordinator) — relevant, but a separate lever.
+- Tool-description rewriting specifics.
+
+These belong in a follow-up design doc once the problem framing here is agreed.

--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -1,7 +1,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { registerAdminTools } from "./src/admin-tools.js";
 import { createAuditLogger } from "./src/audit.js";
-import { sendComfortMessage, sendScopelyText } from "./src/comfort.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDeploymentConfigTools } from "./src/deployment-config-tools.js";
 import { registerGhTools } from "./src/gh-tools.js";
@@ -16,6 +16,10 @@ import { registerUserMaintenanceTools, tryExecuteConfirm } from "./src/user-main
 import { registerVendorConfigTools } from "./src/vendor-config-tools.js";
 
 type PluginConfig = { scopelyRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 // Default 5 minutes; override with PASSTHROUGH_INTERVAL_MS
 const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
@@ -70,20 +74,36 @@ const plugin = {
     registerDeploymentConfigTools(optionalApi, logger);
     registerScopingCardTools(optionalApi, logger);
 
-    // Send comfort message when a message arrives in the scopelybot channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator), and it runs before before_dispatch — if
+    // it consumed the pending action the before_dispatch handler would find
+    // nothing. So here we only (a) skip comfort for a CONFIRM reply and (b) stash
+    // the inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        // User-maintenance confirm gate: a human `CONFIRM <code>` reply executes a staged action.
-        const text = typeof event.content === "string" ? event.content : "";
-        const confirmReply = await tryExecuteConfirm({ text, actor: event.from ?? "", logger });
-        if (confirmReply) {
-          await sendScopelyText(ctx.conversationId, confirmReply);
-          return;
-        }
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
+    });
+
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered by core threaded into the conversation. The
+    // LLM is never in the execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return;
+      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      // `handled: true` suppresses the coordinator so the CONFIRM cannot re-stage; the
+      // result string (executed / "no pending action") is delivered threaded by core.
+      console.log("[scopelybot] before_dispatch claimed CONFIRM (coordinator suppressed)");
+      return { handled: true, text: result ?? undefined };
     });
 
     // Schedule recurring passthrough test runs.

--- a/extensions/scopelybot/src/comfort.ts
+++ b/extensions/scopelybot/src/comfort.ts
@@ -80,24 +80,64 @@ export async function sendComfortMessage(
 }
 
 // Generic text send to a Zoom channel (reuses the bot token). Used by the
-// user-maintenance confirm gate to post execution results.
-export async function sendScopelyText(channelJid: string, text: string): Promise<void> {
+// confirm gate to deterministically post the CONFIRM prompt (with the code).
+// Pass replyToMessageId to thread the message under the originating request.
+export async function sendScopelyText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
   const botJid = process.env.ZOOM_BOT_JID ?? "";
   const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
   if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
   try {
     const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "ScopelyBot" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
     await fetch("https://api.zoom.us/v2/im/chat/messages", {
       method: "POST",
       headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-      body: JSON.stringify({
-        robot_jid: botJid,
-        to_jid: channelJid,
-        account_id: accountId,
-        content: { head: { text: "ScopelyBot" }, body: [{ type: "message", text }] },
-      }),
+      body: JSON.stringify(body),
     });
   } catch (err) {
     console.error("[scopelybot] sendScopelyText failed:", err);
   }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside a spoke subagent, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -1,12 +1,13 @@
 // Shared confirm-gate staging helper for scopelybot write tools.
 //
 // THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
-// (which registers a pending action and returns a CONFIRM prompt) and never calls
-// scopelyFetch with a mutating method directly. The real mutation lives in the `run`
-// closure, fired ONLY by tryExecuteConfirm() (user-maintenance-tools.ts) when a human
-// replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the bot
-// cannot self-mutate. Each slice's test asserts scopelyFetch is not called during execute().
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never calls scopelyFetch with a mutating method directly. The real mutation
+// lives in the `run` closure, fired ONLY by tryExecuteConfirm() (user-maintenance-tools.ts)
+// when a human replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message,
+// so the bot cannot self-mutate. Tests assert scopelyFetch is not called during execute().
 
+import { getChannelThreadAnchor, sendScopelyText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./scopely-api.js";
 
@@ -14,16 +15,38 @@ let codeSeed = 1;
 
 type FetchResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
-// Stage a gated mutation and return the confirm prompt. Does NOT execute.
-export function stageWrite(summary: string, run: () => FetchResult) {
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live 2026-06-05). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => FetchResult) {
   const code = makeCode(codeSeed++ * 7919 + summary.length);
   putPending({ code, summary, run });
-  return jsonResult({
-    staged: true,
-    message:
-      `⚠️ Confirm: ${summary} on PROD.\n` +
-      `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-  });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly.
+  const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+  if (channel) {
+    await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
 }
 
 // Build a request body from only the fields the caller actually supplied, so we

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the prod HTTP layer so no real network call is ever made and we can
 // assert exactly which path/method each tool would hit.
@@ -12,6 +12,17 @@ vi.mock("./scopely-api.js", () => ({
   buildQuery: () => "",
 }));
 
+// Mock the channel sender so staging delivers the confirm prompt to a spy instead
+// of hitting Zoom. This is where the real code now lives — never in the tool's
+// LLM-facing return value.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+}));
+
 import { registerUserMaintenanceTools, tryExecuteConfirm } from "./user-maintenance-tools.js";
 
 type ToolDef = {
@@ -23,6 +34,7 @@ type ToolDef = {
 };
 
 const noopLogger = () => {};
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
 
 function buildTools(): Record<string, ToolDef> {
   const tools: Record<string, ToolDef> = {};
@@ -42,9 +54,22 @@ function parse(res: { content: { text: string }[] }) {
   return JSON.parse(res.content[0].text);
 }
 
+// The confirm code now travels ONLY through the deterministic channel send, never
+// through the tool's return value. Pull it from the latest sendScopelyText call.
+function codeFromDelivery(): string | undefined {
+  // sendScopelyText(channel, text, replyTo) — the prompt text is arg index 1.
+  const text = sendScopelyTextMock.mock.calls.at(-1)?.[1];
+  return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
+}
+
 describe("user-maintenance-tools", () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
   });
 
   it("read-only tools execute immediately against the correct BFF paths", async () => {
@@ -61,6 +86,33 @@ describe("user-maintenance-tools", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/auth/access-requests/");
   });
 
+  it("staging delivers the code to the channel (threaded) and returns NO code to the model", async () => {
+    const tools = buildTools();
+
+    const staged = parse(
+      await tools.scopely_reset_user_password.execute("t", {
+        user_id: 123,
+        email: "matt@example.com",
+      }),
+    );
+
+    // The model-facing result is code-free — it cannot fabricate/relay/duplicate it.
+    expect(staged.staged).toBe(true);
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(JSON.stringify(staged)).not.toMatch(/\b\d{4}\b/);
+
+    // The real prompt — with the code — was posted to the channel, threaded.
+    expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
+    const [channel, text, replyTo] = sendScopelyTextMock.mock.calls[0];
+    expect(channel).toBe(CHANNEL);
+    expect(text).toMatch(/CONFIRM \d{4}/);
+    expect(replyTo).toBe("MSG-ANCHOR");
+
+    // Staging must not touch prod until confirmed.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("scopely_update_user stages only the supplied fields and does NOT execute until confirmed", async () => {
     const tools = buildTools();
 
@@ -70,7 +122,7 @@ describe("user-maintenance-tools", () => {
     expect(staged.staged).toBe(true);
     expect(fetchMock).not.toHaveBeenCalled(); // staging must not touch prod
 
-    const code = staged.message.match(/CONFIRM (\d{4})/)?.[1];
+    const code = codeFromDelivery();
     expect(code).toBeTruthy();
 
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
@@ -92,17 +144,16 @@ describe("user-maintenance-tools", () => {
     const res = parse(await tools.scopely_update_user.execute("t", { user_id: 7 }));
     expect(res.ok).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(sendScopelyTextMock).not.toHaveBeenCalled();
   });
 
   it("scopely_create_invite stages email+role and posts to the invite endpoint on confirm", async () => {
     const tools = buildTools();
-    const staged = parse(
-      await tools.scopely_create_invite.execute("t", {
-        email: "new@example.com",
-        role: "org_admin",
-      }),
-    );
-    const code = staged.message.match(/CONFIRM (\d{4})/)?.[1];
+    await tools.scopely_create_invite.execute("t", {
+      email: "new@example.com",
+      role: "org_admin",
+    });
+    const code = codeFromDelivery();
 
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
     await tryExecuteConfirm({
@@ -120,10 +171,8 @@ describe("user-maintenance-tools", () => {
   it("access-request approve/reject stage and hit the right endpoints on confirm", async () => {
     const tools = buildTools();
 
-    const approve = parse(
-      await tools.scopely_approve_access_request.execute("t", { request_id: 3, organization: 9 }),
-    );
-    const approveCode = approve.message.match(/CONFIRM (\d{4})/)?.[1];
+    await tools.scopely_approve_access_request.execute("t", { request_id: 3, organization: 9 });
+    const approveCode = codeFromDelivery();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
     await tryExecuteConfirm({
       text: `CONFIRM ${approveCode}`,
@@ -139,8 +188,8 @@ describe("user-maintenance-tools", () => {
       role: "user",
     });
 
-    const reject = parse(await tools.scopely_reject_access_request.execute("t", { request_id: 4 }));
-    const rejectCode = reject.message.match(/CONFIRM (\d{4})/)?.[1];
+    await tools.scopely_reject_access_request.execute("t", { request_id: 4 });
+    const rejectCode = codeFromDelivery();
     await tryExecuteConfirm({
       text: `CONFIRM ${rejectCode}`,
       actor: "t",
@@ -150,5 +199,17 @@ describe("user-maintenance-tools", () => {
       "/api/auth/access-requests/4/reject/",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "t",
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/scopelybot/src/user-maintenance-tools.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.ts
@@ -2,14 +2,14 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
-import { makeCode, putPending, takePending } from "./pending-confirm.js";
+import { stageWrite } from "./gated.js";
+import { takePending } from "./pending-confirm.js";
 import { scopelyFetch, jsonResult, errorResult } from "./scopely-api.js";
 
-let codeSeed = 1;
-
-// Each gated tool resolves a target, stages a pending action, and returns the
-// confirm prompt. It does NOT execute — execution happens in tryExecuteConfirm()
-// when a human replies `CONFIRM <code>` in the channel.
+// Each gated tool resolves a target and stages a pending action via stageWrite(),
+// which posts the confirm prompt (with code) to the channel deterministically. It
+// does NOT execute — execution happens in tryExecuteConfirm() when a human replies
+// `CONFIRM <code>`, consumed in the before_dispatch hook (extensions/scopelybot/index.ts).
 export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: AuditLogger) {
   // 1) Admin password reset
   api.registerTool(() =>
@@ -33,23 +33,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
           try {
             const userId = params.user_id as number;
             const email = (params.email as string) || `id ${userId}`;
-            const code = makeCode(codeSeed++ * 7919 + userId);
             const summary = `reset password for ${email} (id ${userId})`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/users/${userId}/reset-password/`, {
-                  method: "POST",
-                  body: "{}",
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/users/${userId}/reset-password/`, {
+                method: "POST",
+                body: "{}",
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -81,23 +71,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
             const userId = params.user_id as number;
             const isActive = params.is_active as boolean;
             const email = (params.email as string) || `id ${userId}`;
-            const code = makeCode(codeSeed++ * 7919 + userId);
             const summary = `${isActive ? "ACTIVATE" : "DEACTIVATE"} ${email} (id ${userId})`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/users/${userId}/`, {
-                  method: "PATCH",
-                  body: JSON.stringify({ is_active: isActive }),
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/users/${userId}/`, {
+                method: "PATCH",
+                body: JSON.stringify({ is_active: isActive }),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -237,23 +217,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
             const changes = Object.entries(body)
               .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
               .join(", ");
-            const code = makeCode(codeSeed++ * 7919 + userId);
             const summary = `update user id ${userId}: ${changes}`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/users/${userId}/`, {
-                  method: "PATCH",
-                  body: JSON.stringify(body),
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/users/${userId}/`, {
+                method: "PATCH",
+                body: JSON.stringify(body),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -297,23 +267,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
             }
             const orgPart =
               params.organization !== undefined ? ` into org ${params.organization}` : "";
-            const code = makeCode(codeSeed++ * 7919 + email.length);
             const summary = `invite ${email} as ${role}${orgPart}`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/invites/create/`, {
-                  method: "POST",
-                  body: JSON.stringify(body),
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/invites/create/`, {
+                method: "POST",
+                body: JSON.stringify(body),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -348,23 +308,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
             const requestId = params.request_id as number;
             const organization = params.organization as number;
             const role = (params.role as string) || "user";
-            const code = makeCode(codeSeed++ * 7919 + requestId);
             const summary = `APPROVE access request ${requestId} → org ${organization} as ${role}`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/access-requests/${requestId}/approve/`, {
-                  method: "POST",
-                  body: JSON.stringify({ organization, role }),
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/access-requests/${requestId}/approve/`, {
+                method: "POST",
+                body: JSON.stringify({ organization, role }),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -392,23 +342,13 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const requestId = params.request_id as number;
-            const code = makeCode(codeSeed++ * 7919 + requestId);
             const summary = `REJECT access request ${requestId}`;
-            putPending({
-              code,
-              summary,
-              run: () =>
-                scopelyFetch(`/api/auth/access-requests/${requestId}/reject/`, {
-                  method: "POST",
-                  body: "{}",
-                }),
-            });
-            return jsonResult({
-              staged: true,
-              message:
-                `⚠️ Confirm: ${summary} on PROD.\n` +
-                `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`,
-            });
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/auth/access-requests/${requestId}/reject/`, {
+                method: "POST",
+                body: "{}",
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }

--- a/extensions/test-capture/harness/cases-scopely-reads.mjs
+++ b/extensions/test-capture/harness/cases-scopely-reads.mjs
@@ -1,0 +1,103 @@
+// Scopely READ-ONLY genie-prompt test matrix.
+// Natural, vague, user-style phrasing ("magic genie") — NOT exact tool instructions —
+// to test whether a normal human's request reaches the right spoke and tool.
+// READ-ONLY: every prompt here resolves to read endpoints (GET). No write is staged;
+// we assert mutatingToolsCalled is empty as a safety guard. Nothing is confirmed,
+// nothing reaches the channel (harness captures + suppresses egress).
+//
+// Run in-container:  node extensions/test-capture/harness/cases-scopely-reads.mjs
+import { runScenario, resetSession } from "./harness.mjs";
+import { getProfile } from "./profiles.mjs";
+
+// Each row: { spoke (expected, informational), prompt (genie phrasing), expectTool (the
+// read tool we expect in the trace; multi-step prompts may also call helper reads) }.
+const MATRIX = [
+  // --- scopely-observe (telemetry / read) ---
+  { spoke: "scopely-observe", prompt: "are the scopely systems healthy right now?", expectTool: "scopely_health_check" },
+  { spoke: "scopely-observe", prompt: "is your scopely connection still authenticated?", expectTool: "scopely_auth_status" },
+  { spoke: "scopely-observe", prompt: "how many users are active at the moment?", expectTool: "scopely_active_users" },
+  { spoke: "scopely-observe", prompt: "have there been any errors recently?", expectTool: "scopely_recent_errors" },
+  { spoke: "scopely-observe", prompt: "who has logged in recently?", expectTool: "scopely_recent_logins" },
+  { spoke: "scopely-observe", prompt: "show me the recent sessions", expectTool: "scopely_list_sessions" },
+  { spoke: "scopely-observe", prompt: "what's matt keuning been up to lately?", expectTool: "scopely_user_activity" },
+  { spoke: "scopely-observe", prompt: "search scopely for anything about cloudwarriors", expectTool: "scopely_search" },
+  { spoke: "scopely-observe", prompt: "how are the extraction metrics looking?", expectTool: "scopely_extraction_metrics" },
+  { spoke: "scopely-observe", prompt: "list the extraction sessions", expectTool: "scopely_extraction_sessions" },
+  { spoke: "scopely-observe", prompt: "what does the wizard funnel look like?", expectTool: "scopely_wizard_funnel" },
+  { spoke: "scopely-observe", prompt: "can you correlate the recent errors for me?", expectTool: "scopely_correlate_errors" },
+
+  // --- scopely-admin (summaries / queues) ---
+  { spoke: "scopely-admin", prompt: "show me the dashboard stats", expectTool: "scopely_dashboard_stats" },
+  { spoke: "scopely-admin", prompt: "pull up the recent audit logs", expectTool: "scopely_audit_logs" },
+  { spoke: "scopely-admin", prompt: "are there any pending approvals?", expectTool: "scopely_pending_approvals" },
+  { spoke: "scopely-admin", prompt: "give me the session pricing summary", expectTool: "scopely_session_pricing" },
+  { spoke: "scopely-admin", prompt: "show me the vendor config summary", expectTool: "scopely_vendor_config" },
+  { spoke: "scopely-admin", prompt: "what's the status of the passthrough test runner?", expectTool: "scopely_passthrough_status" },
+
+  // --- scopely-users (reads) ---
+  { spoke: "scopely-users", prompt: "list the users in cloudwarriors", expectTool: "scopely_list_users" },
+  { spoke: "scopely-users", prompt: "look up matt keuning's account", expectTool: "scopely_get_user" }, // search → get
+  { spoke: "scopely-users", prompt: "have we sent any invites out?", expectTool: "scopely_list_invites" },
+  { spoke: "scopely-users", prompt: "show me the pending access requests", expectTool: "scopely_list_access_requests" },
+
+  // --- scopely-orgs (reads) ---
+  { spoke: "scopely-orgs", prompt: "what organizations do we have?", expectTool: "scopely_list_orgs" },
+  { spoke: "scopely-orgs", prompt: "show me the details on the cloudwarriors org", expectTool: "scopely_get_org" }, // list → get
+  { spoke: "scopely-orgs", prompt: "what domains are attached to the cloudwarriors org?", expectTool: "scopely_list_org_domains" },
+
+  // --- scopely-pricing (reads) ---
+  { spoke: "scopely-pricing", prompt: "what currencies do we support?", expectTool: "scopely_list_currencies" },
+  { spoke: "scopely-pricing", prompt: "show me the pricing defaults", expectTool: "scopely_list_pricing_defaults" },
+  { spoke: "scopely-pricing", prompt: "list the pricing items", expectTool: "scopely_list_pricing_items" },
+  { spoke: "scopely-pricing", prompt: "what's the session pricing configuration?", expectTool: "scopely_get_session_pricing_config" },
+
+  // --- scopely-vendors (reads) ---
+  { spoke: "scopely-vendors", prompt: "list our vendors", expectTool: "scopely_list_vendors" },
+  { spoke: "scopely-vendors", prompt: "show me the 8x8 vendor", expectTool: "scopely_get_vendor" }, // list → get
+  { spoke: "scopely-vendors", prompt: "what project types does 8x8 have?", expectTool: "scopely_list_project_types" },
+  { spoke: "scopely-vendors", prompt: "show me the vendor terms for 8x8", expectTool: "scopely_list_vendor_terms" },
+
+  // --- scopely-deploy (reads) ---
+  { spoke: "scopely-deploy", prompt: "what deployment types exist?", expectTool: "scopely_list_deployment_types" },
+  { spoke: "scopely-deploy", prompt: "show me the deployment type templates", expectTool: "scopely_list_deployment_type_templates" },
+  { spoke: "scopely-deploy", prompt: "list the scoping cards", expectTool: "scopely_list_scoping_cards" },
+
+  // --- scopely-github (reads) ---
+  { spoke: "scopely-github", prompt: "list the open scopely github issues", expectTool: "scopely_gh_list_issues" },
+  { spoke: "scopely-github", prompt: "search the scopely issues for anything about login", expectTool: "scopely_gh_search_issues" },
+];
+
+const profile = getProfile("scopelybot");
+console.log(`\n=== Scopely READ matrix: ${MATRIX.length} genie prompts (read-only, no confirm) ===\n`);
+
+// Reset the session ONCE up front (clean context), then run reads without per-case reset.
+await resetSession(profile.sessionKey);
+
+const results = [];
+let pass = 0, fail = 0;
+for (const c of MATRIX) {
+  let r;
+  try {
+    r = await runScenario({ profileName: "scopelybot", message: c.prompt, reset: false });
+  } catch (e) {
+    console.log(`✗ ${c.expectTool.padEnd(38)} threw: ${e.message}`);
+    fail++; results.push({ ...c, ok: false, err: e.message }); continue;
+  }
+  const calledTools = r.trace.filter((t) => t.kind === "tool_call").map((t) => t.tool_name);
+  const toolHit = calledTools.includes(c.expectTool);
+  const answered = r.summary.outboundCount >= 1;
+  const noWrite = r.summary.mutatingToolsCalled.length === 0;
+  const ok = toolHit && answered && noWrite;
+  ok ? pass++ : fail++;
+  results.push({ ...c, ok, routed: r.summary.routedSpokes, calledTools, answered, noWrite, mut: r.summary.mutatingToolsCalled });
+  const mark = ok ? "✓" : "✗";
+  const why = ok ? "" : ` [tool:${toolHit} answered:${answered} noWrite:${noWrite}${noWrite ? "" : " MUT=" + JSON.stringify(r.summary.mutatingToolsCalled)}]`;
+  console.log(`${mark} ${c.expectTool.padEnd(38)} → routed=${JSON.stringify(r.summary.routedSpokes)}${why}`);
+}
+
+console.log(`\n=== ${pass}/${MATRIX.length} passed, ${fail} failed ===`);
+console.log("Routing/tool detail (for analysis):");
+for (const r of results) {
+  if (!r.ok) console.log(`  MISS  "${r.prompt}"  expected=${r.expectTool}  routed=${JSON.stringify(r.routed)}  called=${JSON.stringify((r.calledTools||[]).slice(0,6))}`);
+}
+process.exit(fail === 0 ? 0 : 1);

--- a/extensions/test-capture/harness/cases.mjs
+++ b/extensions/test-capture/harness/cases.mjs
@@ -1,0 +1,66 @@
+// scopelybot test suite — the first consumer of the harness. Exercises hub-and-spoke
+// routing + confirm-gate fidelity + the read-request-stages-no-write safety guard,
+// entirely via captured/suppressed egress (no writes to the real Zoom channel).
+//
+// Run in-container:  node extensions/test-capture/harness/cases.mjs
+// NOTE: never asserts the happy-path EXECUTION of a write (a correct CONFIRM would hit
+// the real backend). It validates staging + suppression + a WRONG-code no-op only.
+import { runScenario } from "./harness.mjs";
+
+const CASES = [
+  {
+    name: "read request routes + stages NO write (safety guard)",
+    message: "list users in cloudwarriors org",
+    checks: (r) => [
+      ["coordinator stayed router-only", r.summary.nonRouterCoordinatorTools.length === 0],
+      ["no mutating/write tool was called for a read", r.summary.mutatingToolsCalled.length === 0],
+      ["bot produced an answer", r.summary.outboundCount >= 1],
+      ["a spoke was spawned", r.summary.coordinatorSpawned === true],
+    ],
+  },
+  {
+    name: "write request: deterministic confirm prompt, coordinator code-free",
+    message: "reset matt.keuning's password",
+    checks: (r) => [
+      ["routed to scopely-users", r.summary.routedSpokes.includes("scopely-users")],
+      ["reset_user_password was staged", r.summary.mutatingToolsCalled.includes("scopely_reset_user_password")],
+      ["a confirm prompt WITH a code was posted", r.summary.confirmPromptCount >= 1],
+      ["ONLY the confirm prompt carries a code (coordinator code-free)", r.summary.outboundWithCodeCount === r.summary.confirmPromptCount],
+      ["coordinator stayed router-only", r.summary.nonRouterCoordinatorTools.length === 0],
+    ],
+  },
+  {
+    name: "CONFIRM <wrong code>: coordinator suppressed, no execution (fail-closed)",
+    message: "CONFIRM 0000",
+    checks: (r) => [
+      ["coordinator was suppressed (no sessions_spawn)", r.summary.coordinatorSpawned === false],
+      ["a reply was delivered", r.summary.outboundCount >= 1],
+      ["no write executed", r.summary.mutatingToolsCalled.length === 0],
+      ["reply says no pending action", r.outbound.some((o) => /no pending action/i.test(o.text || ""))],
+    ],
+  },
+];
+
+let failures = 0;
+for (const c of CASES) {
+  process.stdout.write(`\n▶ ${c.name}\n   message: "${c.message}"\n`);
+  let result;
+  try {
+    result = await runScenario({ profileName: "scopelybot", message: c.message, reset: true });
+  } catch (e) {
+    console.log(`   ✗ scenario threw: ${e.message}`);
+    failures++;
+    continue;
+  }
+  if (!result.wait.quiescent) {
+    console.log(`   ⚠ did not reach quiescence (${result.wait.reason ?? "?"}) — asserting on partial capture`);
+  }
+  for (const [label, pass] of c.checks(result)) {
+    console.log(`   ${pass ? "✓" : "✗"} ${label}`);
+    if (!pass) failures++;
+  }
+  console.log(`   · routed=${JSON.stringify(result.summary.routedSpokes)} mutating=${JSON.stringify(result.summary.mutatingToolsCalled)} outbound=${result.summary.outboundCount} codes=${result.summary.outboundWithCodeCount}`);
+}
+
+console.log(`\n${failures === 0 ? "ALL PASS" : failures + " CHECK(S) FAILED"}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/extensions/test-capture/harness/harness.mjs
+++ b/extensions/test-capture/harness/harness.mjs
@@ -1,0 +1,261 @@
+// test-capture harness library + CLI. Runs INSIDE the container (Node 22, node:sqlite).
+// One scenario = arm a channel → reset its session → inject a synthetic signed webhook
+// → wait for the turn to go quiescent → read captured outbound + tool trace → derive a
+// hub-and-spoke summary. Nothing is delivered to the real Zoom channel (egress is
+// captured+suppressed by the test-capture extension for the armed channel).
+//
+// Usage:  node harness.mjs <profile> "<message>" [--no-reset] [--json]
+import crypto from "node:crypto";
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { DatabaseSync } from "node:sqlite";
+import { getProfile } from "./profiles.mjs";
+
+const DB_PATH = process.env.OPENCLAW_TEST_CAPTURE_DB ?? "/root/.openclaw/test-capture/capture.sqlite";
+const WEBHOOK_PORT = Number(process.env.OPENCLAW_ZOOM_WEBHOOK_PORT ?? 4000);
+// Quiescence must outlast the longest intra-turn gap (comfort → spoke spawn → spoke
+// tool calls → announce-back → coordinator relay reply). A short window declares
+// "done" inside that gap, disarms mid-turn, and the turn's late records spill into the
+// next scenario. 12s comfortably covers the warm spoke round-trip and guarantees the
+// bot is idle before we disarm (so nothing leaks to the channel either).
+const QUIESCE_MS = 12_000;
+// A cold first message after a container restart spends ~70s loading all extensions
+// before processing; tolerate that for first activity. Warm runs see activity in ~3s.
+const MAX_WAIT_MS = 180_000;
+const FIRST_ACTIVITY_DEADLINE_MS = 95_000;
+
+// Heuristic for "mutating / write-ish" tools (for the read-request-stages-no-write guard).
+const MUTATING_RE =
+  /(create_|update_|delete_|reset_user_password|set_user_active|approve_access_request|reject_access_request)/;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export function openDb() {
+  // Mirror the extension's schema so the harness is bootstrap-independent (can arm a
+  // run before the extension has lazily loaded). CREATE ... IF NOT EXISTS is idempotent.
+  fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+  const db = new DatabaseSync(DB_PATH);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 4000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS control (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      armed_channels TEXT NOT NULL DEFAULT '', active_run_id TEXT, updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS captured_outbound (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT, ts INTEGER NOT NULL,
+      endpoint TEXT NOT NULL, to_jid TEXT NOT NULL, robot_jid TEXT,
+      text TEXT NOT NULL, head_text TEXT, reply_to TEXT, reply_main_message_id TEXT, raw_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS tool_trace (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, run_id TEXT, ts INTEGER NOT NULL, kind TEXT NOT NULL,
+      agent_id TEXT, channel_id TEXT, session_key TEXT, tool_name TEXT, target_agent_id TEXT, params_json TEXT
+    );
+  `);
+  db.prepare(`INSERT OR IGNORE INTO control (id, armed_channels, active_run_id, updated_at) VALUES (1, '', NULL, ?)`).run(Date.now());
+  return db;
+}
+
+function arm(db, channelJid, runId) {
+  db.prepare(`UPDATE control SET armed_channels = ?, active_run_id = ?, updated_at = ? WHERE id = 1`).run(
+    channelJid,
+    runId,
+    Date.now(),
+  );
+}
+function disarm(db) {
+  db.prepare(`UPDATE control SET armed_channels = '', active_run_id = NULL, updated_at = ? WHERE id = 1`).run(
+    Date.now(),
+  );
+}
+function counts(db, runId) {
+  const o = db.prepare(`SELECT COUNT(*) c FROM captured_outbound WHERE run_id = ?`).get(runId).c;
+  const t = db.prepare(`SELECT COUNT(*) c FROM tool_trace WHERE run_id = ?`).get(runId).c;
+  return o + t;
+}
+function readOutbound(db, runId) {
+  return db
+    .prepare(`SELECT ts, endpoint, to_jid, robot_jid, text, head_text, reply_to, reply_main_message_id
+              FROM captured_outbound WHERE run_id = ? ORDER BY ts`)
+    .all(runId);
+}
+function readTrace(db, runId) {
+  return db
+    .prepare(`SELECT ts, kind, agent_id, channel_id, session_key, tool_name, target_agent_id, params_json
+              FROM tool_trace WHERE run_id = ? ORDER BY ts`)
+    .all(runId);
+}
+
+function sign(secret, ts, rawBody) {
+  return "v0=" + crypto.createHmac("sha256", secret).update(`v0:${ts}:${rawBody}`).digest("hex");
+}
+
+export function inject(profile, message) {
+  const secret = process.env.ZOOM_WEBHOOK_SECRET_TOKEN || "";
+  if (!secret) throw new Error("ZOOM_WEBHOOK_SECRET_TOKEN not in env");
+  const ts = String(Date.now());
+  const mid = "{TEST-" + crypto.randomUUID().toUpperCase() + "}";
+  const body = {
+    event: "team_chat.channel_message_posted",
+    event_ts: Date.now(),
+    payload: {
+      account_id: "TESTACC",
+      operator: profile.operator,
+      operator_id: "TESTOPER",
+      by_external_user: false,
+      object: {
+        channel_id: profile.channelIdRaw,
+        channel_name: "test",
+        date_time: new Date().toISOString(),
+        from: "team_chat",
+        message,
+        session_id: "testsession",
+        timestamp: Date.now(),
+        message_id: mid,
+        reply_main_message_id: mid,
+      },
+    },
+  };
+  const raw = JSON.stringify(body);
+  const sig = sign(secret, ts, raw);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port: WEBHOOK_PORT,
+        path: "/zoom/webhook",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(raw),
+          "x-zm-signature": sig,
+          "x-zm-request-timestamp": ts,
+        },
+      },
+      (res) => {
+        let d = "";
+        res.on("data", (c) => (d += c));
+        res.on("end", () => resolve({ status: res.statusCode, body: d, messageId: mid }));
+      },
+    );
+    req.on("error", reject);
+    req.write(raw);
+    req.end();
+  });
+}
+
+export async function resetSession(sessionKey) {
+  // Reset clears contaminated history. The CLI hangs on teardown but the reset
+  // completes server-side; spawn detached and give it a moment.
+  const child = spawn(
+    "node",
+    ["dist/entry.js", "agent", "--session-key", sessionKey, "--message", "/reset"],
+    { cwd: "/app", detached: true, stdio: "ignore" },
+  );
+  child.unref();
+  await sleep(4500);
+}
+
+async function pollQuiescent(db, runId) {
+  const start = Date.now();
+  let last = 0;
+  let lastChange = Date.now();
+  let sawActivity = false;
+  for (;;) {
+    await sleep(1000);
+    const c = counts(db, runId);
+    if (c > last) {
+      last = c;
+      lastChange = Date.now();
+      sawActivity = true;
+    }
+    const now = Date.now();
+    if (sawActivity && now - lastChange > QUIESCE_MS) return { quiescent: true, rows: c };
+    if (!sawActivity && now - start > FIRST_ACTIVITY_DEADLINE_MS)
+      return { quiescent: false, rows: c, reason: "no activity" };
+    if (now - start > MAX_WAIT_MS) return { quiescent: false, rows: c, reason: "max wait" };
+  }
+}
+
+export function summarize(profile, outbound, trace) {
+  const toolCalls = trace.filter((r) => r.kind === "tool_call");
+  const routedSpokes = [
+    ...new Set(toolCalls.filter((r) => r.tool_name === "sessions_spawn" && r.target_agent_id).map((r) => r.target_agent_id)),
+  ];
+  const coordinatorTools = [
+    ...new Set(toolCalls.filter((r) => r.agent_id === profile.agentId).map((r) => r.tool_name)),
+  ];
+  const nonRouterCoordinatorTools = coordinatorTools.filter(
+    (t) => t && !profile.routerTools.includes(t),
+  );
+  const spokeTools = {};
+  for (const r of toolCalls) {
+    if (!r.agent_id || r.agent_id === profile.agentId) continue;
+    (spokeTools[r.agent_id] ??= []).push(r.tool_name);
+  }
+  const mutatingToolsCalled = [
+    ...new Set(toolCalls.filter((r) => r.tool_name && MUTATING_RE.test(r.tool_name)).map((r) => r.tool_name)),
+  ];
+  const outboundWithCode = outbound.filter((o) => /CONFIRM\s+\d{4}/i.test(o.text || ""));
+  const confirmPrompts = outboundWithCode.filter((o) => /⚠️\s*Confirm|Reply `?CONFIRM/i.test(o.text || ""));
+  const threadedOutbound = outbound.filter((o) => o.reply_to || o.reply_main_message_id);
+  return {
+    routedSpokes,
+    coordinatorTools,
+    nonRouterCoordinatorTools,
+    spokeTools,
+    mutatingToolsCalled,
+    outboundCount: outbound.length,
+    outboundWithCodeCount: outboundWithCode.length,
+    confirmPromptCount: confirmPrompts.length,
+    threadedOutboundCount: threadedOutbound.length,
+    coordinatorSpawned: toolCalls.some((r) => r.tool_name === "sessions_spawn"),
+  };
+}
+
+export async function runScenario({ profileName, message, reset = true }) {
+  const profile = getProfile(profileName);
+  const db = openDb();
+  const runId = crypto.randomUUID();
+  arm(db, profile.channelJid, runId);
+  try {
+    if (reset) await resetSession(profile.sessionKey);
+    const injected = await inject(profile, message);
+    const wait = await pollQuiescent(db, runId);
+    const outbound = readOutbound(db, runId);
+    const trace = readTrace(db, runId);
+    return { runId, profile: profileName, message, injected, wait, outbound, trace, summary: summarize(profile, outbound, trace) };
+  } finally {
+    disarm(db);
+    db.close();
+  }
+}
+
+// ---- CLI ----
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const args = process.argv.slice(2);
+  const flags = new Set(args.filter((a) => a.startsWith("--")));
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const [profileName, message] = positional;
+  if (!profileName || !message) {
+    console.error('usage: node harness.mjs <profile> "<message>" [--no-reset] [--json]');
+    process.exit(2);
+  }
+  const result = await runScenario({ profileName, message, reset: !flags.has("--no-reset") });
+  if (flags.has("--json")) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`\n=== scenario: ${result.profile} :: "${result.message}" (run ${result.runId}) ===`);
+    console.log("wait:", result.wait);
+    console.log("\nSUMMARY:", JSON.stringify(result.summary, null, 2));
+    console.log("\nOUTBOUND (captured, NOT sent to channel):");
+    for (const o of result.outbound)
+      console.log(`  [${o.reply_to ? "threaded" : "root"}] ${JSON.stringify((o.text || "").slice(0, 160))}`);
+    console.log("\nTOOL TRACE:");
+    for (const t of result.trace)
+      console.log(`  ${t.kind} agent=${t.agent_id} tool=${t.tool_name ?? "-"}${t.target_agent_id ? " → " + t.target_agent_id : ""}`);
+  }
+}

--- a/extensions/test-capture/harness/profiles.mjs
+++ b/extensions/test-capture/harness/profiles.mjs
@@ -1,0 +1,28 @@
+// Agent profiles for the test-capture harness. One entry per Zoom-bound agent.
+// The harness is agent-agnostic — adding a bot is just another entry here, no code.
+//
+//   channelIdRaw : the raw hex channel id used in the inbound webhook payload
+//   channelJid   : the full XMPP JID the bot sends outbound to (the egress capture key)
+//   sessionKey   : the coordinator's channel session key (for /reset isolation)
+//   operator     : the email stamped as the message sender in the synthetic webhook
+
+export const PROFILES = {
+  scopelybot: {
+    agentId: "scopelybot",
+    channelIdRaw: "575b23671d6b4b7f8c22b1924b6177fa",
+    channelJid: "575b23671d6b4b7f8c22b1924b6177fa@conference.xmpp.zoom.us",
+    sessionKey:
+      "agent:scopelybot:zoom:channel:575b23671d6b4b7f8c22b1924b6177fa@conference.xmpp.zoom.us",
+    operator: "matt.keuning@cloudwarriors.ai",
+    // Coordinator's allowlisted non-domain tools — used to assert "router-only".
+    routerTools: ["sessions_spawn", "subagents", "scopely_health_check", "scopely_auth_status"],
+  },
+};
+
+export function getProfile(name) {
+  const p = PROFILES[name];
+  if (!p) {
+    throw new Error(`unknown profile "${name}" — known: ${Object.keys(PROFILES).join(", ")}`);
+  }
+  return p;
+}

--- a/extensions/test-capture/index.ts
+++ b/extensions/test-capture/index.ts
@@ -1,0 +1,33 @@
+// test-capture: a test-only harness extension. When OPENCLAW_TEST_CAPTURE is set it
+// installs a global-fetch egress interceptor (captures + suppresses Zoom channel
+// messages to ARMED channels — no writes to the live channel) and routing/tool-trace
+// hooks (before_tool_call + agent_end). The armed capture-set is set per run by the
+// harness via the control row in the store, so any agent can be tested with no restart.
+//
+// When the env flag is unset the extension is FULLY INERT (no hooks, no fetch wrap) —
+// safe to ship disabled in production.
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { DEFAULT_DB_PATH, openStore } from "./src/store.js";
+import { installEgressInterceptor } from "./src/egress.js";
+import { registerTraceHooks } from "./src/trace.js";
+
+const plugin = {
+  id: "test-capture",
+  name: "TestCapture",
+  description: "Test-only harness: capture+suppress Zoom egress and trace hub-and-spoke routing",
+  configSchema: { type: "object" as const, additionalProperties: false, properties: {} },
+
+  register(api: OpenClawPluginApi) {
+    if (process.env.OPENCLAW_TEST_CAPTURE !== "1") {
+      console.log("[test-capture] disabled (set OPENCLAW_TEST_CAPTURE=1 to enable)");
+      return;
+    }
+    const dbPath = process.env.OPENCLAW_TEST_CAPTURE_DB ?? DEFAULT_DB_PATH;
+    const db = openStore(dbPath);
+    installEgressInterceptor(db);
+    registerTraceHooks(api, db);
+    console.log(`[test-capture] ENABLED — egress interceptor + trace hooks active (db=${dbPath})`);
+  },
+};
+
+export default plugin;

--- a/extensions/test-capture/openclaw.plugin.json
+++ b/extensions/test-capture/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "test-capture",
+  "name": "TestCapture",
+  "description": "Test-only harness: capture+suppress Zoom egress and trace hub-and-spoke routing",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/test-capture/package.json
+++ b/extensions/test-capture/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/test-capture",
+  "version": "0.1.0",
+  "description": "Test-only harness: capture+suppress Zoom egress and trace hub-and-spoke routing",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/test-capture/src/egress.ts
+++ b/extensions/test-capture/src/egress.ts
@@ -1,0 +1,90 @@
+// Egress interceptor: wraps the global `fetch` so Zoom channel-message POSTs to an
+// ARMED channel JID are recorded and SUPPRESSED (synthetic 200) instead of delivered.
+// Everything else — non-Zoom traffic, and Zoom messages to non-armed channels —
+// passes through to the saved original fetch untouched, so production bots in other
+// channels and all model/API calls behave exactly as normal.
+//
+// Wrapping at the `fetch` boundary (not the undici dispatcher) keeps body inspection
+// trivial (the body is the JSON string the caller passed) and leaves the gateway's
+// global dispatcher / proxy / timeout policy completely untouched on the passthrough
+// path. All Zoom egress in this repo (core adapter + every bot's comfort.ts/zoom-dm.ts)
+// uses the global `fetch`, so this single wrap covers them all.
+import type { DatabaseSync } from "node:sqlite";
+import { getArmed, recordOutbound } from "./store.js";
+
+const CHANNEL_MESSAGES_PATH = "/v2/im/chat/messages";
+
+let installed = false;
+
+type FetchFn = typeof globalThis.fetch;
+
+function urlOf(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (input && typeof input === "object" && "url" in input) {
+    return String((input as { url: unknown }).url);
+  }
+  return String(input);
+}
+
+function extractText(body: Record<string, unknown>): { text: string; headText: string | null } {
+  const content = (body.content ?? {}) as Record<string, unknown>;
+  const head = (content.head ?? {}) as Record<string, unknown>;
+  const blocks = Array.isArray(content.body) ? (content.body as Array<Record<string, unknown>>) : [];
+  const text = blocks
+    .map((b) => (typeof b.text === "string" ? b.text : ""))
+    .filter(Boolean)
+    .join("\n");
+  const headText = typeof head.text === "string" ? head.text : null;
+  return { text, headText };
+}
+
+/**
+ * Install the fetch wrapper. Idempotent. `db` is a long-lived handle; the armed
+ * capture-set is read only when a Zoom channel-message POST is seen (rare), never
+ * on the hot path of ordinary fetches.
+ */
+export function installEgressInterceptor(db: DatabaseSync): void {
+  if (installed) return;
+  installed = true;
+  const original: FetchFn = globalThis.fetch.bind(globalThis);
+
+  globalThis.fetch = (async (input: Parameters<FetchFn>[0], init?: Parameters<FetchFn>[1]) => {
+    try {
+      const url = urlOf(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      const isChannelMessage =
+        url.includes("api.zoom.us") && url.includes(CHANNEL_MESSAGES_PATH) && method === "POST";
+      if (isChannelMessage && typeof init?.body === "string") {
+        const body = JSON.parse(init.body) as Record<string, unknown>;
+        const toJid = typeof body.to_jid === "string" ? body.to_jid : "";
+        const { channels, runId } = getArmed(db);
+        if (toJid && channels.includes(toJid)) {
+          const { text, headText } = extractText(body);
+          recordOutbound(db, {
+            runId,
+            ts: Date.now(),
+            endpoint: "channel",
+            toJid,
+            robotJid: typeof body.robot_jid === "string" ? body.robot_jid : null,
+            text,
+            headText,
+            replyTo: typeof body.reply_to === "string" ? body.reply_to : null,
+            replyMainMessageId:
+              typeof body.reply_main_message_id === "string" ? body.reply_main_message_id : null,
+            rawJson: init.body,
+          });
+          // Synthetic success — mirrors Zoom's send response so callers proceed normally.
+          const fakeId = `TESTCAP-${Math.abs((toJid + text).length * 2654435761) % 1_000_000}`;
+          return new Response(JSON.stringify({ message_id: fakeId, status: "ok" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+      }
+    } catch {
+      // Never let capture logic break a real send — fall through to passthrough.
+    }
+    return original(input, init);
+  }) as FetchFn;
+}

--- a/extensions/test-capture/src/store.ts
+++ b/extensions/test-capture/src/store.ts
@@ -1,0 +1,134 @@
+// Dedicated SQLite store for the test-capture harness. Holds three concerns:
+//   - control:           the currently-armed capture-set (which channel JIDs to
+//                        capture+suppress) + the active runId, set by the harness.
+//   - captured_outbound: Zoom channel/DM messages the bot WOULD have sent, recorded
+//                        instead of being delivered (egress interceptor).
+//   - tool_trace:        every tool call (incl. sessions_spawn) + agent_end events,
+//                        for hub-and-spoke routing assertions (before_tool_call hook).
+//
+// This is ephemeral TEST infrastructure, not product runtime state — a narrowly
+// justified dedicated SQLite DB (node:sqlite directly so the extension keeps to the
+// plugin boundary and does not import core `src/**`). WAL mode lets the in-gateway
+// writer and the out-of-process harness reader share the file concurrently.
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_DB_PATH = "/root/.openclaw/test-capture/capture.sqlite";
+
+export type ArmedState = { channels: string[]; runId: string | null };
+
+export type OutboundRecord = {
+  runId: string | null;
+  ts: number;
+  endpoint: "channel" | "dm";
+  toJid: string;
+  robotJid: string | null;
+  text: string;
+  headText: string | null;
+  replyTo: string | null;
+  replyMainMessageId: string | null;
+  rawJson: string;
+};
+
+export type TraceRecord = {
+  runId: string | null;
+  ts: number;
+  kind: "tool_call" | "agent_end";
+  agentId: string | null;
+  channelId: string | null;
+  sessionKey: string | null;
+  toolName: string | null;
+  targetAgentId: string | null; // for sessions_spawn: which spoke was targeted
+  paramsJson: string | null;
+};
+
+export function openStore(dbPath: string = DEFAULT_DB_PATH): DatabaseSync {
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 4000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS control (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      armed_channels TEXT NOT NULL DEFAULT '',
+      active_run_id TEXT,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS captured_outbound (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id TEXT, ts INTEGER NOT NULL,
+      endpoint TEXT NOT NULL, to_jid TEXT NOT NULL, robot_jid TEXT,
+      text TEXT NOT NULL, head_text TEXT, reply_to TEXT, reply_main_message_id TEXT,
+      raw_json TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS tool_trace (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id TEXT, ts INTEGER NOT NULL, kind TEXT NOT NULL,
+      agent_id TEXT, channel_id TEXT, session_key TEXT,
+      tool_name TEXT, target_agent_id TEXT, params_json TEXT
+    );
+    CREATE INDEX IF NOT EXISTS captured_outbound_run_idx ON captured_outbound(run_id, ts);
+    CREATE INDEX IF NOT EXISTS tool_trace_run_idx ON tool_trace(run_id, ts);
+  `);
+  db.prepare(
+    `INSERT OR IGNORE INTO control (id, armed_channels, active_run_id, updated_at) VALUES (1, '', NULL, ?)`,
+  ).run(Date.now());
+  return db;
+}
+
+export function getArmed(db: DatabaseSync): ArmedState {
+  const row = db.prepare(`SELECT armed_channels, active_run_id FROM control WHERE id = 1`).get() as
+    | { armed_channels: string; active_run_id: string | null }
+    | undefined;
+  const channels = (row?.armed_channels ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return { channels, runId: row?.active_run_id ?? null };
+}
+
+export function setArmed(db: DatabaseSync, channels: string[], runId: string | null): void {
+  db.prepare(`UPDATE control SET armed_channels = ?, active_run_id = ?, updated_at = ? WHERE id = 1`).run(
+    channels.join(","),
+    runId,
+    Date.now(),
+  );
+}
+
+export function recordOutbound(db: DatabaseSync, r: OutboundRecord): void {
+  db.prepare(
+    `INSERT INTO captured_outbound
+       (run_id, ts, endpoint, to_jid, robot_jid, text, head_text, reply_to, reply_main_message_id, raw_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    r.runId,
+    r.ts,
+    r.endpoint,
+    r.toJid,
+    r.robotJid,
+    r.text,
+    r.headText,
+    r.replyTo,
+    r.replyMainMessageId,
+    r.rawJson,
+  );
+}
+
+export function recordTrace(db: DatabaseSync, r: TraceRecord): void {
+  db.prepare(
+    `INSERT INTO tool_trace
+       (run_id, ts, kind, agent_id, channel_id, session_key, tool_name, target_agent_id, params_json)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    r.runId,
+    r.ts,
+    r.kind,
+    r.agentId,
+    r.channelId,
+    r.sessionKey,
+    r.toolName,
+    r.targetAgentId,
+    r.paramsJson,
+  );
+}

--- a/extensions/test-capture/src/trace.ts
+++ b/extensions/test-capture/src/trace.ts
@@ -1,0 +1,68 @@
+// Routing/tool trace for hub-and-spoke assertions. before_tool_call fires for EVERY
+// tool call across the coordinator AND every spawned spoke (hooks are process-global),
+// carrying agentId / runId / channelId via the tool context — so the trace shows which
+// spoke the coordinator routed to (sessions_spawn → params.agentId) and which domain
+// tools each spoke then called. agent_end marks turn boundaries (completion signal).
+//
+// Recording is gated on an active armed run, so nothing is written during normal
+// operation. Hooks are observe-only (return void) and wrapped so a store error can
+// never block or alter a real tool call.
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { DatabaseSync } from "node:sqlite";
+import { getArmed, recordTrace } from "./store.js";
+
+export function registerTraceHooks(api: OpenClawPluginApi, db: DatabaseSync): void {
+  api.on("before_tool_call", (event, ctx) => {
+    try {
+      const { runId } = getArmed(db);
+      if (!runId) return; // only record during an armed test run
+      const params = (event?.params ?? {}) as Record<string, unknown>;
+      const toolName = typeof event?.toolName === "string" ? event.toolName : null;
+      const targetAgentId =
+        toolName === "sessions_spawn" && typeof params.agentId === "string"
+          ? params.agentId
+          : null;
+      recordTrace(db, {
+        runId, // the armed test-run id, so outbound + trace share one correlation id
+        ts: Date.now(),
+        kind: "tool_call",
+        agentId: ctx?.agentId ?? null,
+        channelId: ctx?.channelId ?? null,
+        sessionKey: ctx?.sessionKey ?? null,
+        toolName,
+        targetAgentId,
+        paramsJson: safeJson(params),
+      });
+    } catch {
+      /* never break a real tool call */
+    }
+  });
+
+  api.on("agent_end", (_event, ctx) => {
+    try {
+      const { runId } = getArmed(db);
+      if (!runId) return;
+      recordTrace(db, {
+        runId, // armed test-run id (see tool_call note)
+        ts: Date.now(),
+        kind: "agent_end",
+        agentId: ctx?.agentId ?? null,
+        channelId: ctx?.channelId ?? null,
+        sessionKey: ctx?.sessionKey ?? null,
+        toolName: null,
+        targetAgentId: null,
+        paramsJson: null,
+      });
+    } catch {
+      /* observe-only */
+    }
+  });
+}
+
+function safeJson(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}

--- a/extensions/zoom/src/outbound.ts
+++ b/extensions/zoom/src/outbound.ts
@@ -11,24 +11,25 @@ export const zoomOutbound: ChannelOutboundAdapter = {
   chunkerMode: "markdown",
   textChunkLimit: 4000,
 
-  sendText: async ({ cfg, to, text, replyToId, threadId, identity, deps }) => {
+  sendText: async ({ cfg, to, text, replyToId, threadId, identity }) => {
     const isChannel = isChannelJid(to);
     // Zoom threads via replyToMessageId. Honor an explicit replyToId, else fall back to a
     // delivery-origin threadId (a reply-root message id) so subagent announce-back results
     // land in the originating thread rather than the channel root.
+    //
+    // Send directly via sendZoomTextMessage. Do NOT route through an injected `deps` channel
+    // sender: the CLI deps Proxy auto-synthesizes `deps.sendZoom` as a generic channel sender
+    // that re-enters this adapter through channel-outbound-send with a freshly-built context
+    // (no replyToId/threadId), which silently drops threading and forces channel-root delivery.
     const replyTo = replyToId ?? (threadId != null ? String(threadId) : undefined);
-    const send =
-      deps?.sendZoom ??
-      ((target: string, body: string) =>
-        sendZoomTextMessage({
-          cfg,
-          to: target,
-          text: body,
-          isChannel,
-          replyToMessageId: replyTo,
-          speakerName: identity?.name,
-        }));
-    const result = await send(to, text);
+    const result = await sendZoomTextMessage({
+      cfg,
+      to,
+      text,
+      isChannel,
+      replyToMessageId: replyTo,
+      speakerName: identity?.name,
+    });
     return { channel: "zoom", ...result };
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1637,6 +1637,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/test-capture:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/tlon:
     dependencies:
       '@aws-sdk/client-s3':

--- a/src/agents/subagent-spawn.depth-limits.test.ts
+++ b/src/agents/subagent-spawn.depth-limits.test.ts
@@ -155,6 +155,43 @@ describe("subagent spawn depth + child limits", () => {
     expect(childSession.inheritedToolDeny).toEqual(["exec", "read"]);
   });
 
+  it("drops the requester tool allowlist ceiling on cross-agent spawns but still propagates denies", async () => {
+    // A router-only coordinator (narrow tools.allow) delegating to a separately-configured
+    // spoke must NOT have its allowlist intersected onto the spoke — that would starve the
+    // spoke to zero callable tools. Only same-agent forks inherit the allow ceiling; cross-agent
+    // targets keep their own tool policy. Deny inheritance still propagates either way (hardening).
+    hoisted.configOverride = createSubagentSpawnTestConfig("/tmp/workspace-main", {
+      agents: {
+        defaults: {
+          workspace: "/tmp/workspace-main",
+          subagents: { maxSpawnDepth: 2, allowAgents: ["writer"] },
+        },
+        list: [{ id: "main" }, { id: "writer" }],
+      },
+    });
+
+    const result = await spawnSubagentDirect(
+      { task: "hello", agentId: "writer" },
+      {
+        agentSessionKey: "agent:main:main",
+        workspaceDir: "/tmp/workspace-main",
+        inheritedToolAllowlist: ["sessions_spawn", "read"],
+        inheritedToolDenylist: ["exec", "read"],
+      },
+    );
+
+    const accepted = expectAccepted(result, "run-1");
+    expect(accepted.childSessionKey).toMatch(/^agent:writer:subagent:/);
+    const childSession = persistedStore?.[accepted.childSessionKey];
+    if (!childSession) {
+      throw new Error("Expected persisted child session");
+    }
+    // Cross-agent target: allowlist ceiling dropped so the spoke is not starved.
+    expect(childSession.inheritedToolAllow).toBeUndefined();
+    // Deny inheritance still flows to the spoke (never widens its surface).
+    expect(childSession.inheritedToolDeny).toEqual(["exec", "read"]);
+  });
+
   it("rejects callers when stored spawn depth is already at the configured max", async () => {
     hoisted.configOverride = createDepthLimitConfig({ maxSpawnDepth: 2 });
     hoisted.depthBySession.set("agent:main:subagent:flat-depth-2", 2);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1304,11 +1304,19 @@ export async function spawnSubagentDirect(
     }
   };
 
+  // Cross-agent spawns (hub→spoke delegation) target a separately-configured agent that has its
+  // own tool policy. Inheriting the spawner's effective tool allowlist as a ceiling would intersect
+  // the target's tools against it — and a deliberately narrow router-only coordinator would starve
+  // the spoke to zero callable tools. Only same-agent forks inherit the parent allow surface; the
+  // deny inheritance still propagates either way (safety hardening, never widens).
+  const inheritedToolAllowlistForChild =
+    targetAgentId === requesterAgentId ? ctx.inheritedToolAllowlist : undefined;
+
   const initialChildSessionPatch: Record<string, unknown> = {
     spawnDepth: childDepth,
     subagentRole: childCapabilities.role === "main" ? null : childCapabilities.role,
     subagentControlScope: childCapabilities.controlScope,
-    ...inheritedToolAllowPatch(ctx.inheritedToolAllowlist),
+    ...inheritedToolAllowPatch(inheritedToolAllowlistForChild),
     ...inheritedToolDenyPatch(ctx.inheritedToolDenylist),
     ...plan.initialSessionPatch,
   };


### PR DESCRIPTION
## Summary
Hardens scopelybot's hub-and-spoke architecture, adds a reusable noise-free test harness for any Zoom support bot, and documents the pattern as a repeatable playbook so it can be applied to other bots without re-deriving it from the code. 8 commits on top of `development` (`8ca801039d` -> `88420182fb`).

## The architecture (what hub-and-spoke is here)
Instead of one agent holding all 86 scopely tools, scopelybot is now a **router coordinator** bound to the Zoom channel that owns *no* domain tools (just `sessions_spawn` + 2 liveness checks), plus **8 single-domain specialist "spokes"** (observe, admin, users, orgs, pricing, vendors, deploy, github). The coordinator classifies each request into one domain and delegates to that spoke via `sessions_spawn(runtime=subagent)`; the spoke runs only its small toolset and returns the result, which the coordinator relays in-thread. Built entirely on native primitives -- `sessions_spawn` + per-agent `tools.allow` + `subagents.allowAgents` + channel bindings -- no custom orchestration.

## Why this is better for tool identification / calling
LLM tool-selection accuracy degrades as the menu grows, and worsens sharply when many tools are *confusable* (similar names in one domain -- e.g. `list_users` vs `active_users` vs `list_invites`, plus CRUD across orgs/pricing/vendors/deploy). With 86 tools in one flat menu the model makes a 1-of-86 choice among near-synonyms on every call.

Hub-and-spoke turns that into **two easy decisions**: the coordinator picks 1-of-8 *domains* (a coarse, semantic choice models do well), then the spoke picks among ~6-15 *related* tools. Each spoke reasons over a small, high-contrast menu in an isolated context, so neither the routing decision nor the tool decision pollutes the other. The net effect is materially more reliable tool selection from the same weak model -- and the read-tool audit in this PR (32/38 natural-language prompts routed to the correct spoke and tool) measures exactly that.

A key enabling detail: scopely tools are registered `optional: true` so per-agent allowlists actually scope them (non-optional tools bypass allowlists and leak into every agent's menu). That keeps each spoke's menu small and the coordinator's menu tiny.

## Confirm-gated writes (deterministic, LLM out of the loop)
Write actions stage instead of mutating; the real call fires only when a human replies `CONFIRM <code>`. This PR makes the round-trip deterministic: `stageWrite()` posts the `CONFIRM <code>` prompt to the channel itself and returns a **code-free** result, and execution moves to a `before_dispatch` hook that suppresses the coordinator and threads the result. The code never passes through the LLM (a weak coordinator was observed fabricating/relaying codes), and fail-closed is preserved (single-use, 5-min TTL, human-typed). Staging is provably non-mutating -- every write tool's `execute()` only stages, asserted by unit tests.

## Reusable for other support bots (the docs)
The pattern is written up as a **canonical, comprehensive implementation guide** (`docs/reference/hub-and-spoke-implementation-guide.md`) so any of our support bots can adopt it as a lookup, not an archaeology dig. It covers: a **decision framework** (when it's worth it -- confusable-tool density and *measured* misrouting, not raw count), the exact per-bot recipe and config, spoke-partitioning rules, deterministic confirm-gated writes, deploy gotchas, validation via the harness, shared-bundle vs shared-spoke guidance, copy-paste `IDENTITY.md` templates, a quick-start checklist, and the failure modes we hit with their fixes. The older playbook now redirects to it (one canonical source). The live scopely config + personas are snapshotted in the as-built record so the implementation is reviewable from the branch.

## The test harness
`extensions/test-capture/` is an env-gated, agent-agnostic harness that drives a bot's **real** pipeline via a signed synthetic webhook, **captures and suppresses** channel egress (nothing reaches the live channel), and traces every tool call so routing / confirm-gate / output fidelity are assertable. Adding another bot is one profile entry. It's the first end-to-end test capability for these bots (most had zero tests). The scopely read matrix (38 genie prompts) is a rerunnable regression suite.

## Commits to review (8)
- `fix(agents)` -- don't inherit parent tool ceiling on cross-agent subagent spawns
- `fix(zoom)` -- outbound sends directly (no re-entrant `deps.sendZoom`), restoring in-thread delivery
- `fix(scopelybot)` -- deterministic confirm-gate: codes never pass through the LLM
- `feat(test-capture)` -- agent-agnostic capture/suppress + routing-trace harness
- `test(test-capture)` -- scopely read-tool genie matrix (38 prompts)
- `docs` -- implementation guide, confirm-gate fidelity, spoke-partitioning problem, as-deployed config snapshot

## How to test
`OPENCLAW_TEST_CAPTURE=1` (dev compose) + `test-capture` in `plugins.entries`, then in-container:
`node extensions/test-capture/harness/cases-scopely-reads.mjs` (read audit) and `.../cases.mjs` (confirm-gate). Latest run: 32/38 reads routed correctly; zero writes, zero channel noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
