### PR TITLE
feat(support-bots): confirm-gate writes on bigheadbot, zws, pulsebot, cloudflow-support

### DIFF
--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -1,12 +1,17 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { createAuditLogger } from "./src/audit.js";
 import { registerBhTools } from "./src/bh-tools.js";
-import { registerGhTools } from "./src/gh-tools.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDevtoolsTools } from "./src/devtools-tools.js";
-import { sendComfortMessage } from "./src/comfort.js";
+import { registerGhTools } from "./src/gh-tools.js";
 
 type PluginConfig = { bhRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 const plugin = {
   id: "bigheadbot",
@@ -35,13 +40,33 @@ const plugin = {
     registerCorrelationTools(api, logger, pluginConfig);
     registerDevtoolsTools(api, logger);
 
-    // Send comfort message when a message arrives in the bigheadbot channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator) and runs before before_dispatch — if it
+    // consumed the pending action the before_dispatch handler would find nothing.
+    // So here we only (a) skip comfort for a CONFIRM reply and (b) stash the
+    // inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
+    });
+
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered threaded by core. The LLM is never in the
+    // execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return undefined;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return undefined;
+      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      return { handled: true, text: result ?? undefined };
     });
 
     console.log("[bigheadbot] Registered 25 tools (11 BH + 6 GH + 1 correlation + 7 devtools)");

--- a/extensions/bigheadbot/src/bh-tools.test.ts
+++ b/extensions/bigheadbot/src/bh-tools.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prod HTTP layer so no real network call is ever made and we can
+// assert exactly which path/method each write tool would hit on confirm.
+const fetchMock = vi.fn();
+vi.mock("./bh-api.js", () => ({
+  bhFetch: (...args: unknown[]) => fetchMock(...args),
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+// Mock the channel sender: staging delivers the confirm prompt (WITH the code)
+// to this spy instead of Zoom. The code lives ONLY here, never in the tool's
+// LLM-facing return value.
+// Hoisted so it is initialized before Vitest lifts the vi.mock factory above it.
+const FALLBACK_CHANNEL = vi.hoisted(() => "bigheadbot-default@conference.xmpp.zoom.us");
+const sendBigheadTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendBigheadText: (...args: unknown[]) => sendBigheadTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+  BIGHEADBOT_CHANNEL: FALLBACK_CHANNEL,
+}));
+
+import { registerBhTools } from "./bh-tools.js";
+import { tryExecuteConfirm } from "./confirm.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const CHANNEL = "bigheadbot@conference.xmpp.zoom.us";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerBhTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+// The confirm code travels ONLY through the deterministic channel send.
+function codeFromDelivery(): string | undefined {
+  const text = sendBigheadTextMock.mock.calls.at(-1)?.[1];
+  return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
+}
+
+describe("bigheadbot confirm-gated writes", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendBigheadTextMock.mockReset();
+    process.env.BIGHEADBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.BIGHEADBOT_ZOOM_CHANNEL;
+  });
+
+  it("read-only tools execute immediately and stage nothing", async () => {
+    const tools = buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: [] });
+    await tools.bh_list_projects.execute("t", {});
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/projects");
+    expect(sendBigheadTextMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket stages: code delivered to channel (threaded), NO code to the model, no prod write", async () => {
+    const tools = buildTools();
+    const staged = parse(
+      await tools.bh_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+
+    // Model-facing result is code-free — it cannot fabricate/relay/duplicate it.
+    expect(staged.staged).toBe(true);
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(JSON.stringify(staged)).not.toMatch(/\b\d{4}\b/);
+
+    // The real prompt — with the code — was posted to the channel, threaded.
+    expect(sendBigheadTextMock).toHaveBeenCalledTimes(1);
+    const [channel, text, replyTo] = sendBigheadTextMock.mock.calls[0];
+    expect(channel).toBe(CHANNEL);
+    expect(text).toMatch(/CONFIRM \d{4}/);
+    expect(replyTo).toBe("MSG-ANCHOR");
+
+    // Staging must not touch prod until confirmed.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket POSTs /api/v1/tickets only after a human CONFIRM", async () => {
+    const tools = buildTools();
+    await tools.bh_create_ticket.execute("t", {
+      title: "Boom",
+      projectId: "p1",
+      priority: "high",
+    });
+    const code = codeFromDelivery();
+    expect(code).toBeTruthy();
+
+    fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("update_ticket stages, then PATCHes the right id on confirm", async () => {
+    const tools = buildTools();
+    await tools.bh_update_ticket.execute("t", { id: "t9", status: "closed" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const code = codeFromDelivery();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets/t9",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+    delete process.env.BIGHEADBOT_ZOOM_CHANNEL;
+    const tools = buildTools();
+    const staged = parse(
+      await tools.bh_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+    // The production-safety fix: env unset must NOT degrade to the inline prompt.
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(sendBigheadTextMock).toHaveBeenCalledTimes(1);
+    expect(sendBigheadTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
+    expect(sendBigheadTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "t",
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/bigheadbot/src/bh-tools.ts
+++ b/extensions/bigheadbot/src/bh-tools.ts
@@ -1,8 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { bhFetch, jsonResult, errorResult } from "./bh-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { bhFetch, jsonResult, errorResult } from "./bh-api.js";
+import { describeChanges, pickBody, stageWrite } from "./gated.js";
 
 export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
   // bh_auth_status
@@ -10,7 +11,8 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "bh_auth_status",
-        description: "Check Project Pulse authentication status for Bighead. Returns current session info.",
+        description:
+          "Check Project Pulse authentication status for Bighead. Returns current session info.",
         parameters: Type.Object({}),
         async execute() {
           try {
@@ -33,7 +35,9 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
         name: "bh_list_projects",
         description: "List Project Pulse projects for Bighead. Supports optional query filters.",
         parameters: Type.Object({
-          status: Type.Optional(Type.String({ description: "Filter by status (e.g. active, completed)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (e.g. active, completed)" }),
+          ),
           search: Type.Optional(Type.String({ description: "Search term" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
@@ -41,7 +45,12 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["status", "search", "limit"]);
             const result = await bhFetch(`/api/v1/projects${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -63,8 +72,15 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await bhFetch(`/api/v1/projects/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await bhFetch(
+              `/api/v1/projects/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -91,7 +107,12 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "assigneeId", "limit"]);
             const result = await bhFetch(`/api/v1/tasks${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -113,8 +134,15 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await bhFetch(`/api/v1/tasks/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await bhFetch(
+              `/api/v1/tasks/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -130,18 +158,28 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "bh_list_tickets",
-        description: "List Project Pulse tickets for Bighead (bug reports, feature requests). Filter by status, priority, project.",
+        description:
+          "List Project Pulse tickets for Bighead (bug reports, feature requests). Filter by status, priority, project.",
         parameters: Type.Object({
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
-          status: Type.Optional(Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" })),
-          priority: Type.Optional(Type.String({ description: "Filter by priority (low, medium, high, critical)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" }),
+          ),
+          priority: Type.Optional(
+            Type.String({ description: "Filter by priority (low, medium, high, critical)" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "priority", "limit"]);
             const result = await bhFetch(`/api/v1/tickets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -157,28 +195,34 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "bh_create_ticket",
-        description: "Create a new ticket in Project Pulse for Bighead. Requires title and project ID.",
+        description:
+          "Create a new ticket in Project Pulse for Bighead. Requires title and project ID.",
         parameters: Type.Object({
           title: Type.String({ description: "Ticket title" }),
-          description: Type.Optional(Type.String({ description: "Ticket description (markdown supported)" })),
+          description: Type.Optional(
+            Type.String({ description: "Ticket description (markdown supported)" }),
+          ),
           projectId: Type.String({ description: "Project ID to create ticket in" }),
-          priority: Type.Optional(Type.String({ description: "Priority: low, medium, high, critical" })),
+          priority: Type.Optional(
+            Type.String({ description: "Priority: low, medium, high, critical" }),
+          ),
           assigneeId: Type.Optional(Type.String({ description: "User ID to assign" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await bhFetch("/api/v1/tickets", {
-              method: "POST",
-              body: JSON.stringify({
-                title: params.title,
-                description: params.description,
-                projectId: params.projectId,
-                priority: params.priority,
-                assigneeId: params.assigneeId,
+            const summary = `create ticket "${params.title as string}" in project ${params.projectId as string}`;
+            return await stageWrite(summary, () =>
+              bhFetch("/api/v1/tickets", {
+                method: "POST",
+                body: JSON.stringify({
+                  title: params.title,
+                  description: params.description,
+                  projectId: params.projectId,
+                  priority: params.priority,
+                  assigneeId: params.assigneeId,
+                }),
               }),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -204,13 +248,21 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const { id, ...body } = params;
-            const result = await bhFetch(`/api/v1/tickets/${encodeURIComponent(id as string)}`, {
-              method: "PATCH",
-              body: JSON.stringify(body),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            const id = params.id as string;
+            const body = pickBody(params, [
+              "title",
+              "description",
+              "status",
+              "priority",
+              "assigneeId",
+            ]);
+            const summary = `update ticket ${id}: ${describeChanges(body)}`;
+            return await stageWrite(summary, () =>
+              bhFetch(`/api/v1/tickets/${encodeURIComponent(id)}`, {
+                method: "PATCH",
+                body: JSON.stringify(body),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -234,7 +286,12 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["role", "search"]);
             const result = await bhFetch(`/api/v1/users${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -250,7 +307,8 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "bh_get_timesheets",
-        description: "Get Project Pulse timesheet data for Bighead. Filter by user, project, date range.",
+        description:
+          "Get Project Pulse timesheet data for Bighead. Filter by user, project, date range.",
         parameters: Type.Object({
           userId: Type.Optional(Type.String({ description: "Filter by user ID" })),
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
@@ -261,7 +319,12 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["userId", "projectId", "startDate", "endDate"]);
             const result = await bhFetch(`/api/v1/timesheets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -277,17 +340,25 @@ export function registerBhTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "bh_search",
-        description: "Full-text search across Project Pulse for Bighead (projects, tasks, tickets, users).",
+        description:
+          "Full-text search across Project Pulse for Bighead (projects, tasks, tickets, users).",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          type: Type.Optional(Type.String({ description: "Limit to type: projects, tasks, tickets, users" })),
+          type: Type.Optional(
+            Type.String({ description: "Limit to type: projects, tasks, tickets, users" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["query", "type", "limit"]);
             const result = await bhFetch(`/api/v1/search${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);

--- a/extensions/bigheadbot/src/comfort.ts
+++ b/extensions/bigheadbot/src/comfort.ts
@@ -1,5 +1,8 @@
-// TODO: Replace with actual bigheadbot Zoom channel JID
-const BIGHEADBOT_CHANNEL = "567a6810959543b5b7c1cacf6af7c013@conference.xmpp.zoom.us";
+// The bigheadbot Zoom channel JID. Exported so the confirm gate (gated.ts) can
+// deliver the CONFIRM prompt to the same channel deterministically when the
+// BIGHEADBOT_ZOOM_CHANNEL env override is not set — the code must never fall back
+// to an inline (LLM-relayed) prompt in production.
+export const BIGHEADBOT_CHANNEL = "567a6810959543b5b7c1cacf6af7c013@conference.xmpp.zoom.us";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -70,4 +73,67 @@ export async function sendComfortMessage(
   } catch (err) {
     console.error("[bigheadbot] comfort message failed:", err);
   }
+}
+
+// Generic text send to the bigheadbot Zoom channel (reuses the bot token). Used by
+// the confirm gate to deterministically post the CONFIRM prompt (with the code).
+// Pass replyToMessageId to thread the message under the originating request.
+export async function sendBigheadText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "BigheadBot" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[bigheadbot] sendBigheadText failed:", err);
+  }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside the write tool, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/bigheadbot/src/confirm.ts
+++ b/extensions/bigheadbot/src/confirm.ts
@@ -1,0 +1,61 @@
+// Confirm-gate execution for bigheadbot. A human `CONFIRM <code>` reply runs the
+// staged action. The LLM is never in the execution path: it cannot fabricate the
+// inbound CONFIRM, and the code never passed through it (delivered deterministically
+// by stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator (see hub-and-spoke-implementation-guide.md §7).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// A staged write's result data is produced only at confirm time (the mutation is
+// deferred). Surface a compact, useful tail (a created url, or an id/number) so the
+// human gets the actionable result back on confirm — without dumping the full body.
+function successDetail(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.url === "string" && d.url) return ` ${d.url}`;
+    const id = d.id ?? d.number;
+    if (typeof id === "string" || typeof id === "number") return ` (id ${id})`;
+  }
+  return "";
+}
+
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  const action = takePending(m[1]);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "bh_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.${successDetail(res.data)}`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "bh_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/bigheadbot/src/devtools-tools.test.ts
+++ b/extensions/bigheadbot/src/devtools-tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { assertReadOnlySql } from "./devtools-tools.js";
+
+describe("bh_devtools_db_query read-only guard", () => {
+  it("allows a single SELECT", () => {
+    expect(assertReadOnlySql("SELECT * FROM users WHERE id = $1")).toBeUndefined();
+  });
+
+  it("allows a WITH (CTE) query and tolerates a trailing semicolon", () => {
+    expect(assertReadOnlySql("WITH t AS (SELECT 1) SELECT * FROM t;")).toBeUndefined();
+  });
+
+  it("allows leading whitespace/newlines and is case-insensitive", () => {
+    expect(assertReadOnlySql("  \n select 1")).toBeUndefined();
+  });
+
+  it("rejects INSERT/UPDATE/DELETE/DROP", () => {
+    for (const sql of [
+      "INSERT INTO t VALUES (1)",
+      "UPDATE t SET x = 1",
+      "DELETE FROM t",
+      "DROP TABLE t",
+      "TRUNCATE t",
+    ]) {
+      expect(assertReadOnlySql(sql)).toMatch(/read-only/i);
+    }
+  });
+
+  it("rejects stacked statements (SQL injection via ;)", () => {
+    expect(assertReadOnlySql("SELECT 1; DROP TABLE users")).toMatch(/stacked|multiple/i);
+  });
+
+  it("rejects empty / non-SQL input", () => {
+    expect(assertReadOnlySql("")).toMatch(/read-only/i);
+    expect(assertReadOnlySql("   ")).toMatch(/read-only/i);
+  });
+});

--- a/extensions/bigheadbot/src/devtools-tools.ts
+++ b/extensions/bigheadbot/src/devtools-tools.ts
@@ -3,7 +3,10 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 
-const DEVTOOLS_BASE = () => process.env.DEVTOOLS_API_URL ?? process.env.BIGHEAD_DEVTOOLS_API_URL ?? "http://bighead-devtools-api:9100";
+const DEVTOOLS_BASE = () =>
+  process.env.DEVTOOLS_API_URL ??
+  process.env.BIGHEAD_DEVTOOLS_API_URL ??
+  "http://bighead-devtools-api:9100";
 const DEVTOOLS_TOKEN = () => process.env.DEV_TOOLS_API ?? process.env.BIGHEAD_DEV_TOOLS_API ?? "";
 
 function jsonResult(data: unknown) {
@@ -12,7 +15,24 @@ function jsonResult(data: unknown) {
 
 function errorResult(err: unknown) {
   const message = err instanceof Error ? err.message : String(err);
-  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }] };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
+}
+
+// Client-side defense-in-depth for bh_devtools_db_query. The /db/query endpoint is
+// contractually read-only (SELECT/WITH only), but the tool must not forward a
+// non-read or stacked statement and rely on the backend to refuse it. Returns an
+// error string when the SQL is not a single read-only statement, else undefined.
+export function assertReadOnlySql(sql: string): string | undefined {
+  const trimmed = sql.trim().replace(/;\s*$/, ""); // tolerate one trailing semicolon
+  if (!/^(select|with)\b/i.test(trimmed)) {
+    return "Only read-only SELECT or WITH queries are allowed.";
+  }
+  if (trimmed.includes(";")) {
+    return "Stacked/multiple statements are not allowed; submit a single SELECT/WITH query.";
+  }
+  return undefined;
 }
 
 async function bhDevtoolsFetch(
@@ -51,7 +71,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
         async execute() {
           try {
             const result = await bhDevtoolsFetch("/api/v1/containers");
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, containers: result.data });
           } catch (err) {
             return errorResult(err);
@@ -71,8 +96,15 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
           "Get logs from a Docker container on the Bighead server. Returns the last N lines of logs.",
         parameters: Type.Object({
           container_id: Type.String({ description: "The container ID or name" }),
-          tail: Type.Optional(Type.Number({ description: "Number of lines to return (default 200)", default: 200 })),
-          since: Type.Optional(Type.String({ description: "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')" })),
+          tail: Type.Optional(
+            Type.Number({ description: "Number of lines to return (default 200)", default: 200 }),
+          ),
+          since: Type.Optional(
+            Type.String({
+              description:
+                "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')",
+            }),
+          ),
           until: Type.Optional(Type.String({ description: "Show logs until timestamp" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -86,7 +118,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
             const result = await bhDevtoolsFetch(
               `/api/v1/containers/${encodeURIComponent(containerId)}/logs?${queryParams.toString()}`,
             );
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, logs: result.data });
           } catch (err) {
             return errorResult(err);
@@ -102,17 +139,23 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "bh_devtools_list_files",
-        description:
-          "List files and directories at a given path in the Bighead codebase.",
+        description: "List files and directories at a given path in the Bighead codebase.",
         parameters: Type.Object({
-          path: Type.Optional(Type.String({ description: "Directory path to list (defaults to root)" })),
+          path: Type.Optional(
+            Type.String({ description: "Directory path to list (defaults to root)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const path = params.path as string | undefined;
             const endpoint = path ? `/api/v1/files/${encodeURIComponent(path)}` : "/api/v1/files";
             const result = await bhDevtoolsFetch(endpoint);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, files: result.data });
           } catch (err) {
             return errorResult(err);
@@ -128,8 +171,7 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "bh_devtools_read_file",
-        description:
-          "Read the contents of a file from the Bighead codebase.",
+        description: "Read the contents of a file from the Bighead codebase.",
         parameters: Type.Object({
           path: Type.String({ description: "File path to read" }),
         }),
@@ -137,7 +179,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
           try {
             const path = params.path as string;
             const result = await bhDevtoolsFetch(`/api/v1/files/${encodeURIComponent(path)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, content: result.data });
           } catch (err) {
             return errorResult(err);
@@ -158,7 +205,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
         async execute() {
           try {
             const result = await bhDevtoolsFetch("/api/v1/databases");
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, databases: result.data });
           } catch (err) {
             return errorResult(err);
@@ -177,15 +229,25 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
         description:
           "List all tables in the public schema of a database. Use bh_devtools_list_databases to see available databases.",
         parameters: Type.Object({
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted." })),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const db = params.database as string | undefined;
             const qs = db ? `?database=${encodeURIComponent(db)}` : "";
             const result = await bhDevtoolsFetch(`/api/v1/db/tables${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }
@@ -204,16 +266,28 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
           "Get the column definitions for a database table. Use bh_devtools_list_databases to see available databases.",
         parameters: Type.Object({
           table_name: Type.String({ description: "The table name to get schema for" }),
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted." })),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const tableName = params.table_name as string;
             const db = params.database as string | undefined;
             const qs = db ? `?database=${encodeURIComponent(db)}` : "";
-            const result = await bhDevtoolsFetch(`/api/v1/db/tables/${encodeURIComponent(tableName)}/schema${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            const result = await bhDevtoolsFetch(
+              `/api/v1/db/tables/${encodeURIComponent(tableName)}/schema${qs}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }
@@ -232,12 +306,24 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
           "Execute a read-only SQL query (SELECT or WITH only) against a database. Returns up to 1000 rows. Use bh_devtools_list_databases to see available databases.",
         parameters: Type.Object({
           sql: Type.String({ description: "The SQL query to execute (SELECT or WITH only)" }),
-          params: Type.Optional(Type.Array(Type.Unknown(), { description: "Parameterized query values ($1, $2, etc.)" })),
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted." })),
+          params: Type.Optional(
+            Type.Array(Type.Unknown(), {
+              description: "Parameterized query values ($1, $2, etc.)",
+            }),
+          ),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Uses default if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const body: Record<string, unknown> = { sql: params.sql };
+            const sql = (params.sql as string) ?? "";
+            const sqlGuard = assertReadOnlySql(sql);
+            if (sqlGuard) return jsonResult({ ok: false, error: sqlGuard });
+            const body: Record<string, unknown> = { sql };
             if (params.params) body.params = params.params;
             if (params.database) body.database = params.database;
             const result = await bhDevtoolsFetch("/api/v1/db/query", {
@@ -245,8 +331,13 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(body),
             });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }

--- a/extensions/bigheadbot/src/gated.ts
+++ b/extensions/bigheadbot/src/gated.ts
@@ -1,0 +1,76 @@
+// Shared confirm-gate staging helper for bigheadbot write tools.
+//
+// THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never calls bhFetch with a mutating method directly. The real mutation lives
+// in the `run` closure, fired ONLY by tryExecuteConfirm() (confirm.ts) when a human
+// replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the bot
+// cannot self-mutate. Tests assert bhFetch is not called during execute().
+//
+// Ported from the proven scopelybot implementation (see
+// docs/reference/hub-and-spoke-implementation-guide.md §7).
+
+import { jsonResult } from "./bh-api.js";
+import { BIGHEADBOT_CHANNEL, getChannelThreadAnchor, sendBigheadText } from "./comfort.js";
+import { makeCode, putPending } from "./pending-confirm.js";
+
+let codeSeed = 1;
+
+type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
+
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live on scopelybot). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => RunResult) {
+  const code = makeCode(codeSeed++ * 7919 + summary.length);
+  putPending({ code, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly. Fall back to the bot's known
+  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
+  const channel = process.env.BIGHEADBOT_ZOOM_CHANNEL ?? BIGHEADBOT_CHANNEL;
+  if (channel) {
+    await sendBigheadText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
+}
+
+// Build a request body from only the fields the caller actually supplied, so we
+// never send undefined keys that would blank out existing values on a PATCH.
+export function pickBody(
+  params: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (params[k] !== undefined) {
+      body[k] = params[k];
+    }
+  }
+  return body;
+}
+
+// Human-readable "k=v, k2=v2" summary of a staged body, for the confirm prompt.
+export function describeChanges(body: Record<string, unknown>): string {
+  return Object.entries(body)
+    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+    .join(", ");
+}

--- a/extensions/bigheadbot/src/gh-tools.test.ts
+++ b/extensions/bigheadbot/src/gh-tools.test.ts
@@ -5,20 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const execSyncMock = vi.fn();
 vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
 
-vi.mock("./pp-api.js", () => ({
+vi.mock("./bh-api.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
   errorResult: (err: unknown) => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
 }));
 
-const sendPulseTextMock = vi.fn();
+const sendBigheadTextMock = vi.fn();
 vi.mock("./comfort.js", () => ({
-  sendPulseText: (...args: unknown[]) => sendPulseTextMock(...args),
+  sendBigheadText: (...args: unknown[]) => sendBigheadTextMock(...args),
   getChannelThreadAnchor: () => "MSG-ANCHOR",
   rememberChannelThreadAnchor: () => {},
   sendComfortMessage: () => {},
-  PULSEBOT_CHANNEL: "pulsebot-default@conference.xmpp.zoom.us",
+  BIGHEADBOT_CHANNEL: "bigheadbot-default@conference.xmpp.zoom.us",
 }));
 
 // Stakeholder/DM helpers are not under test here — stub to no-ops.
@@ -26,7 +26,7 @@ vi.mock("./stakeholders.js", () => ({
   buildStakeholderWorkPrefix: () => "",
   extractStakeholdersFromIssue: () => ({ stakeholders: [], reporter: undefined }),
   formatStakeholderBlock: () => "",
-  parseIssueNumberFromUrl: () => 77,
+  parseIssueNumberFromUrl: () => 42,
   resolveStakeholderDmTarget: () => undefined,
   upsertStakeholderBlock: (body: string) => body,
 }));
@@ -44,8 +44,7 @@ type ToolDef = {
 };
 
 const noopLogger = () => {};
-const CHANNEL = "pulsebot@conference.xmpp.zoom.us";
-const REPO = "cloudwarriors-ai/project-pulse";
+const CHANNEL = "bigheadbot@conference.xmpp.zoom.us";
 
 function buildTools(): Record<string, ToolDef> {
   const tools: Record<string, ToolDef> = {};
@@ -55,7 +54,7 @@ function buildTools(): Record<string, ToolDef> {
       tools[t.name] = t;
     },
   } as never;
-  registerGhTools(api, noopLogger as never, { ppRepos: [REPO] });
+  registerGhTools(api, noopLogger as never, { bhRepos: ["cloudwarriors-ai/bighead"] });
   return tools;
 }
 
@@ -64,77 +63,38 @@ function parse(res: { content: { text: string }[] }) {
 }
 
 function codeFromDelivery(): string | undefined {
-  const text = sendPulseTextMock.mock.calls.at(-1)?.[1];
+  const text = sendBigheadTextMock.mock.calls.at(-1)?.[1];
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
-describe("pulsebot gh reads", () => {
+describe("bigheadbot gh writes are confirm-gated", () => {
   beforeEach(() => {
     execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
-  });
-
-  it("list_issues returns parsed issue data (no staging)", async () => {
-    const tools = buildTools();
-    execSyncMock.mockReturnValue(
-      JSON.stringify([{ number: 42, title: "OAuth login fails", state: "open" }]),
-    );
-    const payload = parse(await tools.gh_list_issues.execute("t", { state: "open", limit: 1 }));
-    expect(payload.ok).toBe(true);
-    expect((payload.data as Array<Record<string, unknown>>)[0]?.number).toBe(42);
-    expect(String(execSyncMock.mock.calls[0]?.[0])).toContain("gh issue list");
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
-  });
-
-  it("surfaces gh-not-found errors without throwing", async () => {
-    const tools = buildTools();
-    execSyncMock.mockImplementation(() => {
-      throw new Error("/bin/sh: 1: gh: not found");
-    });
-    const payload = parse(await tools.gh_search_issues.execute("t", { query: "oauth timeout" }));
-    expect(payload.ok).toBe(false);
-    expect(String(payload.error)).toContain("gh: not found");
-  });
-
-  it("blocks repositories outside the allowlist", async () => {
-    const tools = buildTools();
-    const payload = parse(
-      await tools.gh_list_issues.execute("t", { repo: "other-org/other-repo" }),
-    );
-    expect(payload.ok).toBe(false);
-    expect(String(payload.error)).toContain("not in allowed list");
-    expect(execSyncMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("pulsebot gh writes are confirm-gated", () => {
-  beforeEach(() => {
-    execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
-    process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
+    sendBigheadTextMock.mockReset();
+    process.env.BIGHEADBOT_ZOOM_CHANNEL = CHANNEL;
   });
   afterEach(() => {
-    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+    delete process.env.BIGHEADBOT_ZOOM_CHANNEL;
   });
 
   it("create_issue stages — no gh shell-out, code-free result, prompt to channel", async () => {
     const tools = buildTools();
     const staged = parse(
-      await tools.gh_create_issue.execute("t", { title: "Crash on boot", body: "details" }),
+      await tools.bh_gh_create_issue.execute("t", { title: "Crash on boot", body: "details" }),
     );
 
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
     expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
-    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
-    expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    expect(sendBigheadTextMock).toHaveBeenCalledTimes(1);
+    expect(sendBigheadTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
-    await tools.gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/bighead/issues/42");
+    await tools.bh_gh_create_issue.execute("t", { title: "Crash", body: "x" });
     expect(execSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
@@ -149,12 +109,13 @@ describe("pulsebot gh writes are confirm-gated", () => {
     );
     expect(createCalls.length).toBe(1);
     expect(reply).toMatch(/✅ Done/);
+    expect(reply).toContain("https://github.com/cloudwarriors-ai/bighead/issues/42");
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
     execSyncMock.mockReturnValue("closed");
-    await tools.gh_close_issue.execute("t", { number: 7 });
+    await tools.bh_gh_close_issue.execute("t", { number: 7 });
     // Stage time: nothing shells out (not even the issue-view read inside the closure).
     expect(execSyncMock).not.toHaveBeenCalled();
 
@@ -169,10 +130,14 @@ describe("pulsebot gh writes are confirm-gated", () => {
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
     const tools = buildTools();
     const res = parse(
-      await tools.gh_create_issue.execute("t", { repo: "evil/repo", title: "x", body: "y" }),
+      await tools.bh_gh_create_issue.execute("t", {
+        repo: "evil/repo",
+        title: "x",
+        body: "y",
+      }),
     );
     expect(res.ok).toBe(false);
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
+    expect(sendBigheadTextMock).not.toHaveBeenCalled();
     expect(execSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/bigheadbot/src/gh-tools.ts
+++ b/extensions/bigheadbot/src/gh-tools.ts
@@ -1,9 +1,10 @@
-import { Type } from "@sinclair/typebox";
 import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./bh-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./bh-api.js";
+import { stageWrite } from "./gated.js";
 import {
   buildStakeholderWorkPrefix,
   extractStakeholdersFromIssue,
@@ -77,10 +78,15 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "bh_gh_list_issues",
-        description: "List GitHub issues from a Bighead repo. Returns title, number, state, labels, assignees.",
+        description:
+          "List GitHub issues from a Bighead repo. Returns title, number, state, labels, assignees.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
-          state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
           label: Type.Optional(Type.String({ description: "Filter by label" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
         }),
@@ -112,7 +118,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -141,67 +149,72 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Create a new GitHub issue in a Bighead repo. BigheadBot persists reporter/stakeholders in a machine-readable metadata block for retrieval.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
           title: Type.String({ description: "Issue title" }),
           body: Type.String({ description: "Issue body (markdown)" }),
           labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
           reporter: Type.Optional(
             Type.String({
-              description: "Reporter identity (email, @github-user, or Zoom JID). Added to stakeholder metadata.",
+              description:
+                "Reporter identity (email, @github-user, or Zoom JID). Added to stakeholder metadata.",
             }),
           ),
           stakeholders: Type.Optional(
-            Type.Array(
-              Type.String(),
-              { description: "Additional stakeholder identities (emails, @github-users, or JIDs)." },
-            ),
+            Type.Array(Type.String(), {
+              description: "Additional stakeholder identities (emails, @github-users, or JIDs).",
+            }),
           ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const labels = params.labels as string[] | undefined;
-            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-            const bodyStr = String(params.body ?? "");
-            const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
-            const stakeholders = Array.isArray(params.stakeholders)
-              ? (params.stakeholders as string[])
-              : [];
-            const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const labels = params.labels as string[] | undefined;
+              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+              const bodyStr = String(params.body ?? "");
+              const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+              const stakeholders = Array.isArray(params.stakeholders)
+                ? (params.stakeholders as string[])
+                : [];
+              const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-            const result = execSync(
-              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: enrichedBody,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            const url = result.trim();
-            const issueNumber = parseIssueNumberFromUrl(url);
-
-            if (issueNumber) {
-              const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-              execSync(
-                `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+              const result = execSync(
+                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
                 {
                   encoding: "utf-8",
-                  input: metadataComment,
+                  input: enrichedBody,
                   timeout: 30000,
                   env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
                 },
               );
-            }
+              const url = result.trim();
+              const issueNumber = parseIssueNumberFromUrl(url);
 
-            return jsonResult({
-              ok: true,
-              url,
-              issueNumber,
-              reporter,
-              stakeholders,
-              metadataSaved: Boolean(issueNumber),
+              if (issueNumber) {
+                const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
+                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                  encoding: "utf-8",
+                  input: metadataComment,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                });
+              }
+
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url,
+                  issueNumber,
+                  reporter,
+                  stakeholders,
+                  metadataSaved: Boolean(issueNumber),
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);
@@ -220,39 +233,47 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Add a comment to an existing GitHub issue. BigheadBot auto-mentions stored stakeholders so work updates are visible.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
           body: Type.String({ description: "Comment body (markdown)" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const issue = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            const originalBody = String(params.body ?? "");
-            const body =
-              prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
-                ? `${prefix}\n\n${originalBody}`
-                : originalBody;
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              const originalBody = String(params.body ?? "");
+              const body =
+                prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
+                  ? `${prefix}\n\n${originalBody}`
+                  : originalBody;
 
-            const result = execSync(
-              `gh issue comment ${params.number} --repo ${repo} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: body,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            return jsonResult({
-              ok: true,
-              url: result.trim(),
-              stakeholders: extracted.stakeholders,
-              reporter: extracted.reporter,
+              const result = execSync(
+                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url: result.trim(),
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);
@@ -271,7 +292,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description: "Search GitHub issues by keyword in Bighead repos.",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -301,94 +324,102 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary Bighead repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
-          comment: Type.Optional(Type.String({ description: "Closing update comment to post before close." })),
-          reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+          comment: Type.Optional(
+            Type.String({ description: "Closing update comment to post before close." }),
+          ),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
             const issueNumber = Number(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
-
-            const issue = gh(
-              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            if (closingComment || prefix) {
-              const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
-              if (commentBody) {
-                execSync(
-                  `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
-                  {
+            const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              if (closingComment || prefix) {
+                const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+                if (commentBody) {
+                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
                     encoding: "utf-8",
                     input: commentBody,
                     timeout: 30000,
                     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  },
-                );
+                  });
+                }
               }
-            }
 
-            const closeOutput = execSync(
-              `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
-              {
-                encoding: "utf-8",
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            ).trim();
+              const closeOutput = execSync(
+                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+                {
+                  encoding: "utf-8",
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              ).trim();
 
-            const dmTargets = extracted.stakeholders
-              .map((stakeholder) =>
-                resolveStakeholderDmTarget(stakeholder, {
-                  mapEnv: process.env.BIGHEADBOT_STAKEHOLDER_MAP,
-                  defaultDomain: process.env.BIGHEADBOT_STAKEHOLDER_EMAIL_DOMAIN,
-                }),
-              )
-              .filter((value): value is string => Boolean(value));
+              const dmTargets = extracted.stakeholders
+                .map((stakeholder) =>
+                  resolveStakeholderDmTarget(stakeholder, {
+                    mapEnv: process.env.BIGHEADBOT_STAKEHOLDER_MAP,
+                    defaultDomain: process.env.BIGHEADBOT_STAKEHOLDER_EMAIL_DOMAIN,
+                  }),
+                )
+                .filter((value): value is string => Boolean(value));
 
-            const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
-            const issueTitle = issue.title || `Issue ${issueNumber}`;
-            const dmMessage = formatStakeholderDmMessage({
-              issueNumber,
-              issueTitle,
-              repo,
-              closedBy: "bigheadbot",
-              closingComment,
-            });
-
-            const notified: string[] = [];
-            const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
-            for (const stakeholder of uniqueTargets) {
-              const dmResult = await sendStakeholderZoomDm({
-                toContact: stakeholder,
-                message: dmMessage,
+              const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
+              const issueTitle = issue.title || `Issue ${issueNumber}`;
+              const dmMessage = formatStakeholderDmMessage({
+                issueNumber,
+                issueTitle,
+                repo,
+                closedBy: "bigheadbot",
+                closingComment,
               });
-              if (dmResult.ok) {
-                notified.push(stakeholder);
-              } else {
-                notifyErrors.push({
-                  stakeholder,
-                  error: dmResult.error ?? "unknown error",
-                });
-              }
-            }
 
-            return jsonResult({
-              ok: true,
-              number: issueNumber,
-              repo,
-              closeOutput,
-              closeReason,
-              stakeholders: extracted.stakeholders,
-              reporter: extracted.reporter,
-              notified,
-              notifyErrors,
+              const notified: string[] = [];
+              const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+              for (const stakeholder of uniqueTargets) {
+                const dmResult = await sendStakeholderZoomDm({
+                  toContact: stakeholder,
+                  message: dmMessage,
+                });
+                if (dmResult.ok) {
+                  notified.push(stakeholder);
+                } else {
+                  notifyErrors.push({
+                    stakeholder,
+                    error: dmResult.error ?? "unknown error",
+                  });
+                }
+              }
+
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  number: issueNumber,
+                  repo,
+                  closeOutput,
+                  closeReason,
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                  notified,
+                  notifyErrors,
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);

--- a/extensions/bigheadbot/src/pending-confirm.ts
+++ b/extensions/bigheadbot/src/pending-confirm.ts
@@ -1,0 +1,43 @@
+// In-memory, single-use, TTL store for pending bigheadbot write actions.
+// An action only runs after a human types `CONFIRM <code>` in the channel — the
+// LLM cannot fabricate that inbound message, so it cannot self-approve.
+
+export type PendingAction = {
+  code: string;
+  summary: string; // human-readable description, echoed + audited
+  run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
+  expiresAt: number;
+};
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const store = new Map<string, PendingAction>();
+
+function prune(): void {
+  const now = Date.now();
+  for (const [code, a] of store) {
+    if (a.expiresAt <= now) store.delete(code);
+  }
+}
+
+// 4-digit code, unique within the live store. `seed` varies per call.
+export function makeCode(seed: number): string {
+  prune();
+  let code = String(1000 + (Math.abs(seed) % 9000));
+  let bump = 0;
+  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  return code;
+}
+
+export function putPending(a: Omit<PendingAction, "expiresAt">): void {
+  prune();
+  store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
+}
+
+// Retrieve and consume a pending action (one-time use).
+export function takePending(code: string): PendingAction | undefined {
+  prune();
+  const a = store.get(code);
+  if (!a) return undefined;
+  store.delete(code);
+  return a;
+}

--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -1,10 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { createAuditLogger } from "./src/audit.js";
-import { registerGhTools } from "./src/gh-tools.js";
 import { registerCfOpsTools } from "./src/cf-ops-tools.js";
-import { sendComfortMessage } from "./src/comfort.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
+import { registerGhTools } from "./src/gh-tools.js";
 
 type PluginConfig = { cfRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 const plugin = {
   id: "cloudflow-support",
@@ -31,13 +36,33 @@ const plugin = {
     registerCfOpsTools(api, logger);
     registerGhTools(api, logger, pluginConfig);
 
-    // Send comfort message when a message arrives in the CloudFlow channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator) and runs before before_dispatch — if it
+    // consumed the pending action the before_dispatch handler would find nothing.
+    // So here we only (a) skip comfort for a CONFIRM reply and (b) stash the
+    // inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
+    });
+
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered threaded by core. The LLM is never in the
+    // execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return undefined;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return undefined;
+      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      return { handled: true, text: result ?? undefined };
     });
 
     console.log("[cloudflow-support] Registered 15 tools (9 ops + 6 GH)");

--- a/extensions/cloudflow-support/src/cf-ops-tools.test.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth is mocked so cfApi never fetches a real Firebase token.
+vi.mock("./cf-auth.js", () => ({
+  getFirebaseIdToken: async () => "test-token",
+  getApiBaseUrl: () => "https://cf.test",
+  clearFirebaseToken: () => {},
+}));
+
+vi.mock("./helpers.js", () => ({
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+// Channel sender spy: staging delivers the confirm prompt (WITH the code) here,
+// never through the tool's LLM-facing return value.
+// Hoisted so it is initialized before Vitest lifts the vi.mock factory above it.
+const FALLBACK_CHANNEL = vi.hoisted(() => "cf-default@conference.xmpp.zoom.us");
+const sendCfTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendCfText: (...args: unknown[]) => sendCfTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+  CF_CHANNEL: FALLBACK_CHANNEL,
+}));
+
+import { registerCfOpsTools } from "./cf-ops-tools.js";
+import { tryExecuteConfirm } from "./confirm.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const CHANNEL = "cloudflow@conference.xmpp.zoom.us";
+const fetchMock = vi.fn();
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerCfOpsTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+function codeFromDelivery(): string | undefined {
+  const text = sendCfTextMock.mock.calls.at(-1)?.[1];
+  return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
+}
+
+describe("cloudflow cf_execute_op is confirm-gated", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendCfTextMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.CF_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.CF_ZOOM_CHANNEL;
+    vi.unstubAllGlobals();
+  });
+
+  it("dedicated read tools (cf_list_tickets) execute immediately and stage nothing", async () => {
+    const tools = buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ rows: [] }) });
+    await tools.cf_list_tickets.execute("t", {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendCfTextMock).not.toHaveBeenCalled();
+  });
+
+  it("cf_execute_op stages: code to channel, code-free model result, no API call", async () => {
+    const tools = buildTools();
+    const staged = parse(
+      await tools.cf_execute_op.execute("t", {
+        operationId: "resetTenant",
+        payload: { tenantId: "x" },
+      }),
+    );
+    expect(staged.staged).toBe(true);
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(fetchMock).not.toHaveBeenCalled(); // deferred until confirm
+    expect(sendCfTextMock).toHaveBeenCalledTimes(1);
+    const [channel, text, replyTo] = sendCfTextMock.mock.calls[0];
+    expect(channel).toBe(CHANNEL);
+    expect(text).toMatch(/CONFIRM \d{4}/);
+    expect(replyTo).toBe("MSG-ANCHOR");
+  });
+
+  it("cf_execute_op POSTs /api/internal/ops/execute only after a human CONFIRM", async () => {
+    const tools = buildTools();
+    await tools.cf_execute_op.execute("t", { operationId: "resetTenant", payload: {} });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const code = codeFromDelivery();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ done: true }) });
+    const reply = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      logger: noopLogger as never,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/internal/ops/execute");
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "POST" });
+    expect(reply).toMatch(/✅ Done/);
+  });
+
+  it("without the env override, still delivers to the channel constant", async () => {
+    delete process.env.CF_ZOOM_CHANNEL;
+    const tools = buildTools();
+    const staged = parse(
+      await tools.cf_execute_op.execute("t", { operationId: "resetTenant", payload: {} }),
+    );
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(sendCfTextMock).toHaveBeenCalledTimes(1);
+    expect(sendCfTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
+    expect(sendCfTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "t",
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/cloudflow-support/src/cf-ops-tools.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.ts
@@ -1,11 +1,15 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./helpers.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 import { getFirebaseIdToken, getApiBaseUrl, clearFirebaseToken } from "./cf-auth.js";
+import { stageWrite } from "./gated.js";
+import { jsonResult, errorResult } from "./helpers.js";
 
-async function cfApi(path: string, opts?: { method?: string; body?: unknown; retried?: boolean }): Promise<unknown> {
+async function cfApi(
+  path: string,
+  opts?: { method?: string; body?: unknown; retried?: boolean },
+): Promise<unknown> {
   const token = await getFirebaseIdToken();
   const baseUrl = getApiBaseUrl();
   const resp = await fetch(`${baseUrl}${path}`, {
@@ -48,7 +52,8 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
     wrapToolWithAudit(
       {
         name: "cf_discover_ops",
-        description: "List all available CloudFlow operations with their domains, descriptions, required scopes, and input/output schemas.",
+        description:
+          "List all available CloudFlow operations with their domains, descriptions, required scopes, and input/output schemas.",
         parameters: Type.Object({}),
         async execute(_id: string, _params: Record<string, unknown>) {
           try {
@@ -68,17 +73,32 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
     wrapToolWithAudit(
       {
         name: "cf_execute_op",
-        description: "Execute any CloudFlow operation by ID. Use cf_discover_ops first to see available operations and their required payloads.",
+        description:
+          "Execute any CloudFlow operation by ID. Use cf_discover_ops first to see available operations and their required payloads.",
         parameters: Type.Object({
-          operationId: Type.String({ description: "The operation ID (e.g., 'listTickets', 'getDeployment')" }),
-          payload: Type.Optional(Type.Object({}, { additionalProperties: true, description: "Operation-specific input payload" })),
+          operationId: Type.String({
+            description: "The operation ID (e.g., 'listTickets', 'getDeployment')",
+          }),
+          payload: Type.Optional(
+            Type.Object(
+              {},
+              { additionalProperties: true, description: "Operation-specific input payload" },
+            ),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const operationId = params.operationId as string;
             const payload = (params.payload as Record<string, unknown>) ?? {};
-            const data = await executeOp(operationId, payload);
-            return jsonResult({ ok: true, data });
+            // cf_execute_op runs an ARBITRARY operation by id — it can be a mutating op.
+            // The operation catalog is not statically known here, so we cannot classify
+            // read vs write deterministically; gate every call fail-closed. Dedicated
+            // read tools (cf_list_*, cf_get_*) call executeOp() directly and stay ungated.
+            const summary = `execute CloudFlow operation "${operationId}"`;
+            return await stageWrite(summary, async () => {
+              const data = await executeOp(operationId, payload);
+              return { ok: true, status: 200, data };
+            });
           } catch (err) {
             return errorResult(err);
           }
@@ -95,7 +115,11 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
         name: "cf_list_tickets",
         description: "List CloudFlow support tickets. Optionally filter by status or tenant.",
         parameters: Type.Object({
-          status: Type.Optional(Type.String({ description: "Filter by ticket status (open, in_progress, resolved, closed)" })),
+          status: Type.Optional(
+            Type.String({
+              description: "Filter by ticket status (open, in_progress, resolved, closed)",
+            }),
+          ),
           tenantId: Type.Optional(Type.String({ description: "Filter by tenant ID" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 25)" })),
         }),
@@ -193,7 +217,9 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
         name: "cf_list_users",
         description: "List CloudFlow platform users. Filter by role or search by name/email.",
         parameters: Type.Object({
-          role: Type.Optional(Type.String({ description: "Filter by platform role (PM, PE, SM, Dev, HR)" })),
+          role: Type.Optional(
+            Type.String({ description: "Filter by platform role (PM, PE, SM, Dev, HR)" }),
+          ),
           search: Type.Optional(Type.String({ description: "Search by name or email" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -243,7 +269,9 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
         name: "cf_get_deploy_status",
         description: "Check the latest Firebase App Hosting deployment status via GitHub Actions.",
         parameters: Type.Object({
-          limit: Type.Optional(Type.Number({ description: "Number of recent runs to check (default 5)" })),
+          limit: Type.Optional(
+            Type.Number({ description: "Number of recent runs to check (default 5)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {

--- a/extensions/cloudflow-support/src/comfort.ts
+++ b/extensions/cloudflow-support/src/comfort.ts
@@ -1,4 +1,8 @@
-const CF_CHANNEL = "82a0a9b6ca134457b58151734ee5643b@conference.xmpp.zoom.us";
+// The cloudflow-support Zoom channel JID. Exported so the confirm gate (gated.ts)
+// can deliver the CONFIRM prompt to the same channel deterministically when the
+// CF_ZOOM_CHANNEL env override is not set — the code must never fall back to an
+// inline (LLM-relayed) prompt in production.
+export const CF_CHANNEL = "82a0a9b6ca134457b58151734ee5643b@conference.xmpp.zoom.us";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -69,4 +73,67 @@ export async function sendComfortMessage(
   } catch (err) {
     console.error("[cf] comfort message failed:", err);
   }
+}
+
+// Generic text send to the cloudflow-support Zoom channel (reuses the bot token).
+// Used by the confirm gate to deterministically post the CONFIRM prompt (with the
+// code). Pass replyToMessageId to thread the message under the originating request.
+export async function sendCfText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "CloudFlowSupport" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[cf] sendCfText failed:", err);
+  }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside the write tool, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/cloudflow-support/src/confirm.ts
+++ b/extensions/cloudflow-support/src/confirm.ts
@@ -1,0 +1,61 @@
+// Confirm-gate execution for cloudflow-support. A human `CONFIRM <code>` reply runs
+// the staged action. The LLM is never in the execution path: it cannot fabricate the
+// inbound CONFIRM, and the code never passed through it (delivered deterministically
+// by stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator (see hub-and-spoke-implementation-guide.md §7).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// A staged write's result data is produced only at confirm time (the mutation is
+// deferred). Surface a compact, useful tail (a created url, or an id/number) so the
+// human gets the actionable result back on confirm — without dumping the full body.
+function successDetail(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.url === "string" && d.url) return ` ${d.url}`;
+    const id = d.id ?? d.number;
+    if (typeof id === "string" || typeof id === "number") return ` (id ${id})`;
+  }
+  return "";
+}
+
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  const action = takePending(m[1]);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "cf_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.${successDetail(res.data)}`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "cf_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/cloudflow-support/src/gated.ts
+++ b/extensions/cloudflow-support/src/gated.ts
@@ -1,0 +1,54 @@
+// Shared confirm-gate staging helper for cloudflow-support write tools.
+//
+// THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never performs the mutation directly. The real mutation lives in the `run`
+// closure, fired ONLY by tryExecuteConfirm() (confirm.ts) when a human replies
+// `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the bot cannot
+// self-mutate. Tests assert no mutation fires during execute().
+//
+// Ported from the proven bigheadbot/scopelybot implementation (see
+// docs/reference/hub-and-spoke-implementation-guide.md §7).
+
+import { CF_CHANNEL, getChannelThreadAnchor, sendCfText } from "./comfort.js";
+import { jsonResult } from "./helpers.js";
+import { makeCode, putPending } from "./pending-confirm.js";
+
+let codeSeed = 1;
+
+type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
+
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live on scopelybot). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => RunResult) {
+  const code = makeCode(codeSeed++ * 7919 + summary.length);
+  putPending({ code, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly. Fall back to the bot's known
+  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
+  const channel = process.env.CF_ZOOM_CHANNEL ?? CF_CHANNEL;
+  if (channel) {
+    await sendCfText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
+}

--- a/extensions/cloudflow-support/src/gh-tools.test.ts
+++ b/extensions/cloudflow-support/src/gh-tools.test.ts
@@ -5,20 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const execSyncMock = vi.fn();
 vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
 
-vi.mock("./pp-api.js", () => ({
+vi.mock("./helpers.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
   errorResult: (err: unknown) => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
 }));
 
-const sendPulseTextMock = vi.fn();
+const sendCfTextMock = vi.fn();
 vi.mock("./comfort.js", () => ({
-  sendPulseText: (...args: unknown[]) => sendPulseTextMock(...args),
+  sendCfText: (...args: unknown[]) => sendCfTextMock(...args),
   getChannelThreadAnchor: () => "MSG-ANCHOR",
   rememberChannelThreadAnchor: () => {},
   sendComfortMessage: () => {},
-  PULSEBOT_CHANNEL: "pulsebot-default@conference.xmpp.zoom.us",
+  CF_CHANNEL: "cf-default@conference.xmpp.zoom.us",
 }));
 
 // Stakeholder/DM helpers are not under test here — stub to no-ops.
@@ -26,7 +26,7 @@ vi.mock("./stakeholders.js", () => ({
   buildStakeholderWorkPrefix: () => "",
   extractStakeholdersFromIssue: () => ({ stakeholders: [], reporter: undefined }),
   formatStakeholderBlock: () => "",
-  parseIssueNumberFromUrl: () => 77,
+  parseIssueNumberFromUrl: () => 42,
   resolveStakeholderDmTarget: () => undefined,
   upsertStakeholderBlock: (body: string) => body,
 }));
@@ -44,8 +44,8 @@ type ToolDef = {
 };
 
 const noopLogger = () => {};
-const CHANNEL = "pulsebot@conference.xmpp.zoom.us";
-const REPO = "cloudwarriors-ai/project-pulse";
+const CHANNEL = "cloudflow@conference.xmpp.zoom.us";
+const REPO = "cloudwarriors-ai/cloudflow";
 
 function buildTools(): Record<string, ToolDef> {
   const tools: Record<string, ToolDef> = {};
@@ -55,7 +55,7 @@ function buildTools(): Record<string, ToolDef> {
       tools[t.name] = t;
     },
   } as never;
-  registerGhTools(api, noopLogger as never, { ppRepos: [REPO] });
+  registerGhTools(api, noopLogger as never, { cfRepos: [REPO] });
   return tools;
 }
 
@@ -64,42 +64,32 @@ function parse(res: { content: { text: string }[] }) {
 }
 
 function codeFromDelivery(): string | undefined {
-  const text = sendPulseTextMock.mock.calls.at(-1)?.[1];
+  const text = sendCfTextMock.mock.calls.at(-1)?.[1];
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
-describe("pulsebot gh reads", () => {
+describe("cloudflow gh reads", () => {
   beforeEach(() => {
     execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
+    sendCfTextMock.mockReset();
   });
 
   it("list_issues returns parsed issue data (no staging)", async () => {
     const tools = buildTools();
     execSyncMock.mockReturnValue(
-      JSON.stringify([{ number: 42, title: "OAuth login fails", state: "open" }]),
+      JSON.stringify([{ number: 42, title: "Deploy broke", state: "open" }]),
     );
-    const payload = parse(await tools.gh_list_issues.execute("t", { state: "open", limit: 1 }));
+    const payload = parse(await tools.cf_gh_list_issues.execute("t", { state: "open", limit: 1 }));
     expect(payload.ok).toBe(true);
     expect((payload.data as Array<Record<string, unknown>>)[0]?.number).toBe(42);
     expect(String(execSyncMock.mock.calls[0]?.[0])).toContain("gh issue list");
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
-  });
-
-  it("surfaces gh-not-found errors without throwing", async () => {
-    const tools = buildTools();
-    execSyncMock.mockImplementation(() => {
-      throw new Error("/bin/sh: 1: gh: not found");
-    });
-    const payload = parse(await tools.gh_search_issues.execute("t", { query: "oauth timeout" }));
-    expect(payload.ok).toBe(false);
-    expect(String(payload.error)).toContain("gh: not found");
+    expect(sendCfTextMock).not.toHaveBeenCalled();
   });
 
   it("blocks repositories outside the allowlist", async () => {
     const tools = buildTools();
     const payload = parse(
-      await tools.gh_list_issues.execute("t", { repo: "other-org/other-repo" }),
+      await tools.cf_gh_list_issues.execute("t", { repo: "other-org/other-repo" }),
     );
     expect(payload.ok).toBe(false);
     expect(String(payload.error)).toContain("not in allowed list");
@@ -107,34 +97,33 @@ describe("pulsebot gh reads", () => {
   });
 });
 
-describe("pulsebot gh writes are confirm-gated", () => {
+describe("cloudflow gh writes are confirm-gated", () => {
   beforeEach(() => {
     execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
-    process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
+    sendCfTextMock.mockReset();
+    process.env.CF_ZOOM_CHANNEL = CHANNEL;
   });
   afterEach(() => {
-    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+    delete process.env.CF_ZOOM_CHANNEL;
   });
 
   it("create_issue stages — no gh shell-out, code-free result, prompt to channel", async () => {
     const tools = buildTools();
     const staged = parse(
-      await tools.gh_create_issue.execute("t", { title: "Crash on boot", body: "details" }),
+      await tools.cf_gh_create_issue.execute("t", { title: "Deploy broke", body: "details" }),
     );
-
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
-    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
-    expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(sendCfTextMock).toHaveBeenCalledTimes(1);
+    expect(sendCfTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
-    await tools.gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/cloudflow/issues/42");
+    await tools.cf_gh_create_issue.execute("t", { title: "Deploy broke", body: "x" });
     expect(execSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
@@ -154,8 +143,7 @@ describe("pulsebot gh writes are confirm-gated", () => {
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
     execSyncMock.mockReturnValue("closed");
-    await tools.gh_close_issue.execute("t", { number: 7 });
-    // Stage time: nothing shells out (not even the issue-view read inside the closure).
+    await tools.cf_gh_close_issue.execute("t", { number: 7 });
     expect(execSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
@@ -169,10 +157,10 @@ describe("pulsebot gh writes are confirm-gated", () => {
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
     const tools = buildTools();
     const res = parse(
-      await tools.gh_create_issue.execute("t", { repo: "evil/repo", title: "x", body: "y" }),
+      await tools.cf_gh_create_issue.execute("t", { repo: "evil/repo", title: "x", body: "y" }),
     );
     expect(res.ok).toBe(false);
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
+    expect(sendCfTextMock).not.toHaveBeenCalled();
     expect(execSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/cloudflow-support/src/gh-tools.ts
+++ b/extensions/cloudflow-support/src/gh-tools.ts
@@ -1,9 +1,10 @@
-import { Type } from "@sinclair/typebox";
 import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./helpers.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
+import { jsonResult, errorResult } from "./helpers.js";
 import {
   buildStakeholderWorkPrefix,
   extractStakeholdersFromIssue,
@@ -22,7 +23,8 @@ function getAllowedRepos(config: PluginConfig): string[] {
 
 function assertAllowedRepo(repo: string, config: PluginConfig) {
   const allowed = getAllowedRepos(config);
-  if (!allowed.includes(repo)) throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
+  if (!allowed.includes(repo))
+    throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
 }
 
 function gh(args: string): unknown {
@@ -31,12 +33,20 @@ function gh(args: string): unknown {
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
   });
-  try { return JSON.parse(result); } catch { return result.trim(); }
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result.trim();
+  }
 }
 
 type GhIssueLike = {
-  number?: number; url?: string; title?: string; body?: string;
-  assignees?: Array<{ login?: string }>; comments?: Array<{ body?: string }>;
+  number?: number;
+  url?: string;
+  title?: string;
+  body?: string;
+  assignees?: Array<{ login?: string }>;
+  comments?: Array<{ body?: string }>;
 };
 
 function stringifyReason(reason: unknown): string {
@@ -44,180 +54,331 @@ function stringifyReason(reason: unknown): string {
   return raw === "not_planned" ? "not planned" : "completed";
 }
 
-function formatDmMessage(p: { issueNumber: number; issueTitle: string; repo: string; closedBy?: string; closingComment?: string }): string {
+function formatDmMessage(p: {
+  issueNumber: number;
+  issueTitle: string;
+  repo: string;
+  closedBy?: string;
+  closingComment?: string;
+}): string {
   const url = `https://github.com/${p.repo}/issues/${p.issueNumber}`;
   return [
     `Issue #${p.issueNumber} was updated and closed: ${p.issueTitle}`,
     p.closedBy ? `Closed by: ${p.closedBy}` : undefined,
     p.closingComment ? `Update: ${p.closingComment}` : undefined,
     url,
-  ].filter(Boolean).join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 }
 
 export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_list_issues",
-    description: "List GitHub issues from the CloudFlow repo.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary CF repo." })),
-      state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
-      label: Type.Optional(Type.String({ description: "Filter by label" })),
-      limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const state = (params.state as string) || "open";
-        const limit = (params.limit as number) || 30;
-        const labelFlag = params.label ? ` --label "${params.label}"` : "";
-        const data = gh(`issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`);
-        return jsonResult({ ok: true, data });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_list_issues",
+        description: "List GitHub issues from the CloudFlow repo.",
+        parameters: Type.Object({
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary CF repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
+          label: Type.Optional(Type.String({ description: "Filter by label" })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const state = (params.state as string) || "open";
+            const limit = (params.limit as number) || 30;
+            const labelFlag = params.label ? ` --label "${params.label}"` : "";
+            const data = gh(
+              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_get_issue",
-    description: "Get details of a specific GitHub issue including comments and stakeholder metadata.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
-      number: Type.Number({ description: "Issue number" }),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const data = gh(`issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`) as GhIssueLike;
-        const stakeholders = extractStakeholdersFromIssue(data);
-        return jsonResult({ ok: true, data, stakeholders });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_get_issue",
+        description:
+          "Get details of a specific GitHub issue including comments and stakeholder metadata.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+          number: Type.Number({ description: "Issue number" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const data = gh(
+              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
+            ) as GhIssueLike;
+            const stakeholders = extractStakeholdersFromIssue(data);
+            return jsonResult({ ok: true, data, stakeholders });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_create_issue",
-    description: "Create a new GitHub issue in the CloudFlow repo with stakeholder metadata.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
-      title: Type.String({ description: "Issue title" }),
-      body: Type.String({ description: "Issue body (markdown)" }),
-      labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
-      reporter: Type.Optional(Type.String({ description: "Reporter identity." })),
-      stakeholders: Type.Optional(Type.Array(Type.String(), { description: "Additional stakeholder identities." })),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const labels = params.labels as string[] | undefined;
-        const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-        const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
-        const stakeholders = Array.isArray(params.stakeholders) ? (params.stakeholders as string[]) : [];
-        const enrichedBody = upsertStakeholderBlock(String(params.body ?? ""), { reporter, stakeholders });
-        const result = execSync(
-          `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
-          { encoding: "utf-8", input: enrichedBody, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" } },
-        );
-        const url = result.trim();
-        const issueNumber = parseIssueNumberFromUrl(url);
-        if (issueNumber) {
-          execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-            encoding: "utf-8", input: formatStakeholderBlock({ reporter, stakeholders }), timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-          });
-        }
-        return jsonResult({ ok: true, url, issueNumber, reporter, stakeholders, metadataSaved: Boolean(issueNumber) });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_create_issue",
+        description: "Create a new GitHub issue in the CloudFlow repo with stakeholder metadata.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+          title: Type.String({ description: "Issue title" }),
+          body: Type.String({ description: "Issue body (markdown)" }),
+          labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
+          reporter: Type.Optional(Type.String({ description: "Reporter identity." })),
+          stakeholders: Type.Optional(
+            Type.Array(Type.String(), { description: "Additional stakeholder identities." }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const labels = params.labels as string[] | undefined;
+              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+              const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+              const stakeholders = Array.isArray(params.stakeholders)
+                ? (params.stakeholders as string[])
+                : [];
+              const enrichedBody = upsertStakeholderBlock(String(params.body ?? ""), {
+                reporter,
+                stakeholders,
+              });
+              const result = execSync(
+                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: enrichedBody,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              const url = result.trim();
+              const issueNumber = parseIssueNumberFromUrl(url);
+              if (issueNumber) {
+                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                  encoding: "utf-8",
+                  input: formatStakeholderBlock({ reporter, stakeholders }),
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                });
+              }
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url,
+                  issueNumber,
+                  reporter,
+                  stakeholders,
+                  metadataSaved: Boolean(issueNumber),
+                },
+              };
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_add_comment",
-    description: "Add a comment to a GitHub issue. Auto-mentions stored stakeholders.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
-      number: Type.Number({ description: "Issue number" }),
-      body: Type.String({ description: "Comment body (markdown)" }),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const issue = gh(`issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`) as GhIssueLike;
-        const extracted = extractStakeholdersFromIssue(issue);
-        const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-        const originalBody = String(params.body ?? "");
-        const body = prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody) ? `${prefix}\n\n${originalBody}` : originalBody;
-        const result = execSync(`gh issue comment ${params.number} --repo ${repo} --body-file -`, {
-          encoding: "utf-8", input: body, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-        });
-        return jsonResult({ ok: true, url: result.trim(), stakeholders: extracted.stakeholders, reporter: extracted.reporter });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_add_comment",
+        description: "Add a comment to a GitHub issue. Auto-mentions stored stakeholders.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+          number: Type.Number({ description: "Issue number" }),
+          body: Type.String({ description: "Comment body (markdown)" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              const originalBody = String(params.body ?? "");
+              const body =
+                prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
+                  ? `${prefix}\n\n${originalBody}`
+                  : originalBody;
+              const result = execSync(
+                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url: result.trim(),
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                },
+              };
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_search_issues",
-    description: "Search GitHub issues by keyword in CloudFlow repos.",
-    parameters: Type.Object({
-      query: Type.String({ description: "Search query" }),
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
-      limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const limit = (params.limit as number) || 20;
-        const query = (params.query as string).replace(/"/g, '\\"');
-        const data = gh(`search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`);
-        return jsonResult({ ok: true, data });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_search_issues",
+        description: "Search GitHub issues by keyword in CloudFlow repos.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+          limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config);
+            const limit = (params.limit as number) || 20;
+            const query = (params.query as string).replace(/"/g, '\\"');
+            const data = gh(
+              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
+            );
+            return jsonResult({ ok: true, data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 
-  api.registerTool(() => wrapToolWithAudit({
-    name: "cf_gh_close_issue",
-    description: "Close a GitHub issue, mention stakeholders, and DM them on Zoom.",
-    parameters: Type.Object({
-      repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
-      number: Type.Number({ description: "Issue number" }),
-      comment: Type.Optional(Type.String({ description: "Closing comment." })),
-      reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
-    }),
-    async execute(_id: string, params: Record<string, unknown>) {
-      try {
-        const repo = (params.repo as string) || getAllowedRepos(config)[0];
-        assertAllowedRepo(repo, config);
-        const issueNumber = Number(params.number);
-        const closeReason = stringifyReason(params.reason);
-        const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
-        const issue = gh(`issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`) as GhIssueLike;
-        const extracted = extractStakeholdersFromIssue(issue);
-        const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-        if (closingComment || prefix) {
-          const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
-          if (commentBody) execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-            encoding: "utf-8", input: commentBody, timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-          });
-        }
-        const closeOutput = execSync(`gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`, {
-          encoding: "utf-8", timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-        }).trim();
-        const dmTargets = extracted.stakeholders
-          .map((s) => resolveStakeholderDmTarget(s, { mapEnv: process.env.CF_STAKEHOLDER_MAP, defaultDomain: process.env.CF_STAKEHOLDER_EMAIL_DOMAIN }))
-          .filter((v): v is string => Boolean(v));
-        const uniqueTargets = [...new Set(dmTargets.map((t) => t.toLowerCase()))];
-        const dmMessage = formatDmMessage({ issueNumber, issueTitle: issue.title || `Issue ${issueNumber}`, repo, closedBy: "cloudflow-support", closingComment });
-        const notified: string[] = [];
-        const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
-        for (const target of uniqueTargets) {
-          const r = await sendStakeholderZoomDm({ toContact: target, message: dmMessage });
-          if (r.ok) notified.push(target);
-          else notifyErrors.push({ stakeholder: target, error: r.error ?? "unknown" });
-        }
-        return jsonResult({ ok: true, number: issueNumber, repo, closeOutput, closeReason, stakeholders: extracted.stakeholders, reporter: extracted.reporter, notified, notifyErrors });
-      } catch (err) { return errorResult(err); }
-    },
-  }, logger));
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "cf_gh_close_issue",
+        description: "Close a GitHub issue, mention stakeholders, and DM them on Zoom.",
+        parameters: Type.Object({
+          repo: Type.Optional(Type.String({ description: "Repo (owner/name)." })),
+          number: Type.Number({ description: "Issue number" }),
+          comment: Type.Optional(Type.String({ description: "Closing comment." })),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const repo = (params.repo as string) || getAllowedRepos(config)[0];
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const issueNumber = Number(params.number);
+            const closeReason = stringifyReason(params.reason);
+            const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
+            const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              if (closingComment || prefix) {
+                const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+                if (commentBody)
+                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                    encoding: "utf-8",
+                    input: commentBody,
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  });
+              }
+              const closeOutput = execSync(
+                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+                {
+                  encoding: "utf-8",
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              ).trim();
+              const dmTargets = extracted.stakeholders
+                .map((s) =>
+                  resolveStakeholderDmTarget(s, {
+                    mapEnv: process.env.CF_STAKEHOLDER_MAP,
+                    defaultDomain: process.env.CF_STAKEHOLDER_EMAIL_DOMAIN,
+                  }),
+                )
+                .filter((v): v is string => Boolean(v));
+              const uniqueTargets = [...new Set(dmTargets.map((t) => t.toLowerCase()))];
+              const dmMessage = formatDmMessage({
+                issueNumber,
+                issueTitle: issue.title || `Issue ${issueNumber}`,
+                repo,
+                closedBy: "cloudflow-support",
+                closingComment,
+              });
+              const notified: string[] = [];
+              const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+              for (const target of uniqueTargets) {
+                const r = await sendStakeholderZoomDm({ toContact: target, message: dmMessage });
+                if (r.ok) notified.push(target);
+                else notifyErrors.push({ stakeholder: target, error: r.error ?? "unknown" });
+              }
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  number: issueNumber,
+                  repo,
+                  closeOutput,
+                  closeReason,
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                  notified,
+                  notifyErrors,
+                },
+              };
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
 }

--- a/extensions/cloudflow-support/src/pending-confirm.ts
+++ b/extensions/cloudflow-support/src/pending-confirm.ts
@@ -1,0 +1,43 @@
+// In-memory, single-use, TTL store for pending cloudflow-support write actions.
+// An action only runs after a human types `CONFIRM <code>` in the channel — the
+// LLM cannot fabricate that inbound message, so it cannot self-approve.
+
+export type PendingAction = {
+  code: string;
+  summary: string; // human-readable description, echoed + audited
+  run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
+  expiresAt: number;
+};
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const store = new Map<string, PendingAction>();
+
+function prune(): void {
+  const now = Date.now();
+  for (const [code, a] of store) {
+    if (a.expiresAt <= now) store.delete(code);
+  }
+}
+
+// 4-digit code, unique within the live store. `seed` varies per call.
+export function makeCode(seed: number): string {
+  prune();
+  let code = String(1000 + (Math.abs(seed) % 9000));
+  let bump = 0;
+  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  return code;
+}
+
+export function putPending(a: Omit<PendingAction, "expiresAt">): void {
+  prune();
+  store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
+}
+
+// Retrieve and consume a pending action (one-time use).
+export function takePending(code: string): PendingAction | undefined {
+  prune();
+  const a = store.get(code);
+  if (!a) return undefined;
+  store.delete(code);
+  return a;
+}

--- a/extensions/pulsebot/index.ts
+++ b/extensions/pulsebot/index.ts
@@ -1,11 +1,16 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { createAuditLogger } from "./src/audit.js";
-import { registerPpTools } from "./src/pp-tools.js";
-import { registerGhTools } from "./src/gh-tools.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
-import { sendComfortMessage } from "./src/comfort.js";
+import { registerGhTools } from "./src/gh-tools.js";
+import { registerPpTools } from "./src/pp-tools.js";
 
 type PluginConfig = { ppRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 const plugin = {
   id: "pulsebot",
@@ -33,13 +38,33 @@ const plugin = {
     registerGhTools(api, logger, pluginConfig);
     registerCorrelationTools(api, logger, pluginConfig);
 
-    // Send comfort message when a message arrives in the pulsebot channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator) and runs before before_dispatch — if it
+    // consumed the pending action the before_dispatch handler would find nothing.
+    // So here we only (a) skip comfort for a CONFIRM reply and (b) stash the
+    // inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
+    });
+
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered threaded by core. The LLM is never in the
+    // execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return undefined;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return undefined;
+      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      return { handled: true, text: result ?? undefined };
     });
 
     console.log("[pulsebot] Registered 18 tools (11 PP + 6 GH + 1 correlation)");

--- a/extensions/pulsebot/src/comfort.ts
+++ b/extensions/pulsebot/src/comfort.ts
@@ -1,4 +1,8 @@
-const PULSEBOT_CHANNEL = "b6a0428ca4364fd9873fe6a2ea1376fd@conference.xmpp.zoom.us";
+// The pulsebot Zoom channel JID. Exported so the confirm gate (gated.ts) can deliver
+// the CONFIRM prompt to the same channel deterministically when the PULSEBOT_ZOOM_CHANNEL
+// env override is not set — the code must never fall back to an inline (LLM-relayed)
+// prompt in production.
+export const PULSEBOT_CHANNEL = "b6a0428ca4364fd9873fe6a2ea1376fd@conference.xmpp.zoom.us";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -70,4 +74,67 @@ export async function sendComfortMessage(
   } catch (err) {
     console.error("[pulsebot] comfort message failed:", err);
   }
+}
+
+// Generic text send to the pulsebot Zoom channel (reuses the bot token). Used by the
+// confirm gate to deterministically post the CONFIRM prompt (with the code). Pass
+// replyToMessageId to thread the message under the originating request.
+export async function sendPulseText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "PulseBot" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[pulsebot] sendPulseText failed:", err);
+  }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside the write tool, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/pulsebot/src/confirm.ts
+++ b/extensions/pulsebot/src/confirm.ts
@@ -1,0 +1,61 @@
+// Confirm-gate execution for pulsebot. A human `CONFIRM <code>` reply runs the
+// staged action. The LLM is never in the execution path: it cannot fabricate the
+// inbound CONFIRM, and the code never passed through it (delivered deterministically
+// by stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator (see hub-and-spoke-implementation-guide.md §7).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// A staged write's result data is produced only at confirm time (the mutation is
+// deferred). Surface a compact, useful tail (a created url, or an id/number) so the
+// human gets the actionable result back on confirm — without dumping the full body.
+function successDetail(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.url === "string" && d.url) return ` ${d.url}`;
+    const id = d.id ?? d.number;
+    if (typeof id === "string" || typeof id === "number") return ` (id ${id})`;
+  }
+  return "";
+}
+
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  const action = takePending(m[1]);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "pp_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.${successDetail(res.data)}`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "pp_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/pulsebot/src/gated.ts
+++ b/extensions/pulsebot/src/gated.ts
@@ -1,0 +1,76 @@
+// Shared confirm-gate staging helper for pulsebot write tools.
+//
+// THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never calls ppFetch with a mutating method directly. The real mutation lives
+// in the `run` closure, fired ONLY by tryExecuteConfirm() (confirm.ts) when a human
+// replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the bot
+// cannot self-mutate. Tests assert ppFetch is not called during execute().
+//
+// Ported from the proven bigheadbot/scopelybot implementation (see
+// docs/reference/hub-and-spoke-implementation-guide.md §7).
+
+import { PULSEBOT_CHANNEL, getChannelThreadAnchor, sendPulseText } from "./comfort.js";
+import { makeCode, putPending } from "./pending-confirm.js";
+import { jsonResult } from "./pp-api.js";
+
+let codeSeed = 1;
+
+type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
+
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live on scopelybot). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => RunResult) {
+  const code = makeCode(codeSeed++ * 7919 + summary.length);
+  putPending({ code, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly. Fall back to the bot's known
+  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
+  const channel = process.env.PULSEBOT_ZOOM_CHANNEL ?? PULSEBOT_CHANNEL;
+  if (channel) {
+    await sendPulseText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
+}
+
+// Build a request body from only the fields the caller actually supplied, so we
+// never send undefined keys that would blank out existing values on a PATCH.
+export function pickBody(
+  params: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (params[k] !== undefined) {
+      body[k] = params[k];
+    }
+  }
+  return body;
+}
+
+// Human-readable "k=v, k2=v2" summary of a staged body, for the confirm prompt.
+export function describeChanges(body: Record<string, unknown>): string {
+  return Object.entries(body)
+    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+    .join(", ");
+}

--- a/extensions/pulsebot/src/gh-tools.ts
+++ b/extensions/pulsebot/src/gh-tools.ts
@@ -1,9 +1,10 @@
-import { Type } from "@sinclair/typebox";
 import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./pp-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
+import { jsonResult, errorResult } from "./pp-api.js";
 import {
   buildStakeholderWorkPrefix,
   extractStakeholdersFromIssue,
@@ -77,10 +78,15 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "gh_list_issues",
-        description: "List GitHub issues from a Project Pulse repo. Returns title, number, state, labels, assignees.",
+        description:
+          "List GitHub issues from a Project Pulse repo. Returns title, number, state, labels, assignees.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
-          state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
           label: Type.Optional(Type.String({ description: "Filter by label" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
         }),
@@ -112,7 +118,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -141,67 +149,72 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Create a new GitHub issue in a Project Pulse repo. PulseBot persists reporter/stakeholders in a machine-readable metadata block for retrieval.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
           title: Type.String({ description: "Issue title" }),
           body: Type.String({ description: "Issue body (markdown)" }),
           labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
           reporter: Type.Optional(
             Type.String({
-              description: "Reporter identity (email, @github-user, or Zoom JID). Added to stakeholder metadata.",
+              description:
+                "Reporter identity (email, @github-user, or Zoom JID). Added to stakeholder metadata.",
             }),
           ),
           stakeholders: Type.Optional(
-            Type.Array(
-              Type.String(),
-              { description: "Additional stakeholder identities (emails, @github-users, or JIDs)." },
-            ),
+            Type.Array(Type.String(), {
+              description: "Additional stakeholder identities (emails, @github-users, or JIDs).",
+            }),
           ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const labels = params.labels as string[] | undefined;
-            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-            const bodyStr = String(params.body ?? "");
-            const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
-            const stakeholders = Array.isArray(params.stakeholders)
-              ? (params.stakeholders as string[])
-              : [];
-            const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const labels = params.labels as string[] | undefined;
+              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+              const bodyStr = String(params.body ?? "");
+              const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+              const stakeholders = Array.isArray(params.stakeholders)
+                ? (params.stakeholders as string[])
+                : [];
+              const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-            const result = execSync(
-              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: enrichedBody,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            const url = result.trim();
-            const issueNumber = parseIssueNumberFromUrl(url);
-
-            if (issueNumber) {
-              const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-              execSync(
-                `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+              const result = execSync(
+                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
                 {
                   encoding: "utf-8",
-                  input: metadataComment,
+                  input: enrichedBody,
                   timeout: 30000,
                   env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
                 },
               );
-            }
+              const url = result.trim();
+              const issueNumber = parseIssueNumberFromUrl(url);
 
-            return jsonResult({
-              ok: true,
-              url,
-              issueNumber,
-              reporter,
-              stakeholders,
-              metadataSaved: Boolean(issueNumber),
+              if (issueNumber) {
+                const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
+                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                  encoding: "utf-8",
+                  input: metadataComment,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                });
+              }
+
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url,
+                  issueNumber,
+                  reporter,
+                  stakeholders,
+                  metadataSaved: Boolean(issueNumber),
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);
@@ -220,39 +233,47 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Add a comment to an existing GitHub issue. PulseBot auto-mentions stored stakeholders so work updates are visible.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
           body: Type.String({ description: "Comment body (markdown)" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const issue = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            const originalBody = String(params.body ?? "");
-            const body =
-              prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
-                ? `${prefix}\n\n${originalBody}`
-                : originalBody;
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              const originalBody = String(params.body ?? "");
+              const body =
+                prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
+                  ? `${prefix}\n\n${originalBody}`
+                  : originalBody;
 
-            const result = execSync(
-              `gh issue comment ${params.number} --repo ${repo} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: body,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            return jsonResult({
-              ok: true,
-              url: result.trim(),
-              stakeholders: extracted.stakeholders,
-              reporter: extracted.reporter,
+              const result = execSync(
+                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url: result.trim(),
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);
@@ -271,7 +292,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description: "Search GitHub issues by keyword in Project Pulse repos.",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -301,94 +324,102 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary PP repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
-          comment: Type.Optional(Type.String({ description: "Closing update comment to post before close." })),
-          reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+          comment: Type.Optional(
+            Type.String({ description: "Closing update comment to post before close." }),
+          ),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
             const issueNumber = Number(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
-
-            const issue = gh(
-              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            if (closingComment || prefix) {
-              const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
-              if (commentBody) {
-                execSync(
-                  `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
-                  {
+            const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              if (closingComment || prefix) {
+                const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+                if (commentBody) {
+                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
                     encoding: "utf-8",
                     input: commentBody,
                     timeout: 30000,
                     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  },
-                );
+                  });
+                }
               }
-            }
 
-            const closeOutput = execSync(
-              `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
-              {
-                encoding: "utf-8",
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            ).trim();
+              const closeOutput = execSync(
+                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+                {
+                  encoding: "utf-8",
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              ).trim();
 
-            const dmTargets = extracted.stakeholders
-              .map((stakeholder) =>
-                resolveStakeholderDmTarget(stakeholder, {
-                  mapEnv: process.env.PULSEBOT_STAKEHOLDER_MAP,
-                  defaultDomain: process.env.PULSEBOT_STAKEHOLDER_EMAIL_DOMAIN,
-                }),
-              )
-              .filter((value): value is string => Boolean(value));
+              const dmTargets = extracted.stakeholders
+                .map((stakeholder) =>
+                  resolveStakeholderDmTarget(stakeholder, {
+                    mapEnv: process.env.PULSEBOT_STAKEHOLDER_MAP,
+                    defaultDomain: process.env.PULSEBOT_STAKEHOLDER_EMAIL_DOMAIN,
+                  }),
+                )
+                .filter((value): value is string => Boolean(value));
 
-            const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
-            const issueTitle = issue.title || `Issue ${issueNumber}`;
-            const dmMessage = formatStakeholderDmMessage({
-              issueNumber,
-              issueTitle,
-              repo,
-              closedBy: "pulsebot",
-              closingComment,
-            });
-
-            const notified: string[] = [];
-            const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
-            for (const stakeholder of uniqueTargets) {
-              const dmResult = await sendStakeholderZoomDm({
-                toContact: stakeholder,
-                message: dmMessage,
+              const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
+              const issueTitle = issue.title || `Issue ${issueNumber}`;
+              const dmMessage = formatStakeholderDmMessage({
+                issueNumber,
+                issueTitle,
+                repo,
+                closedBy: "pulsebot",
+                closingComment,
               });
-              if (dmResult.ok) {
-                notified.push(stakeholder);
-              } else {
-                notifyErrors.push({
-                  stakeholder,
-                  error: dmResult.error ?? "unknown error",
-                });
-              }
-            }
 
-            return jsonResult({
-              ok: true,
-              number: issueNumber,
-              repo,
-              closeOutput,
-              closeReason,
-              stakeholders: extracted.stakeholders,
-              reporter: extracted.reporter,
-              notified,
-              notifyErrors,
+              const notified: string[] = [];
+              const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+              for (const stakeholder of uniqueTargets) {
+                const dmResult = await sendStakeholderZoomDm({
+                  toContact: stakeholder,
+                  message: dmMessage,
+                });
+                if (dmResult.ok) {
+                  notified.push(stakeholder);
+                } else {
+                  notifyErrors.push({
+                    stakeholder,
+                    error: dmResult.error ?? "unknown error",
+                  });
+                }
+              }
+
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  number: issueNumber,
+                  repo,
+                  closeOutput,
+                  closeReason,
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                  notified,
+                  notifyErrors,
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);

--- a/extensions/pulsebot/src/pending-confirm.ts
+++ b/extensions/pulsebot/src/pending-confirm.ts
@@ -1,0 +1,43 @@
+// In-memory, single-use, TTL store for pending pulsebot write actions.
+// An action only runs after a human types `CONFIRM <code>` in the channel — the
+// LLM cannot fabricate that inbound message, so it cannot self-approve.
+
+export type PendingAction = {
+  code: string;
+  summary: string; // human-readable description, echoed + audited
+  run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
+  expiresAt: number;
+};
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const store = new Map<string, PendingAction>();
+
+function prune(): void {
+  const now = Date.now();
+  for (const [code, a] of store) {
+    if (a.expiresAt <= now) store.delete(code);
+  }
+}
+
+// 4-digit code, unique within the live store. `seed` varies per call.
+export function makeCode(seed: number): string {
+  prune();
+  let code = String(1000 + (Math.abs(seed) % 9000));
+  let bump = 0;
+  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  return code;
+}
+
+export function putPending(a: Omit<PendingAction, "expiresAt">): void {
+  prune();
+  store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
+}
+
+// Retrieve and consume a pending action (one-time use).
+export function takePending(code: string): PendingAction | undefined {
+  prune();
+  const a = store.get(code);
+  if (!a) return undefined;
+  store.delete(code);
+  return a;
+}

--- a/extensions/pulsebot/src/pp-tools.test.ts
+++ b/extensions/pulsebot/src/pp-tools.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prod HTTP layer so no real network call is ever made and we can
+// assert exactly which path/method each write tool would hit on confirm.
+const fetchMock = vi.fn();
+vi.mock("./pp-api.js", () => ({
+  ppFetch: (...args: unknown[]) => fetchMock(...args),
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+// Mock the channel sender: staging delivers the confirm prompt (WITH the code)
+// to this spy instead of Zoom. The code lives ONLY here, never in the tool's
+// LLM-facing return value.
+// Hoisted so it is initialized before Vitest lifts the vi.mock factory above it.
+const FALLBACK_CHANNEL = vi.hoisted(() => "pulsebot-default@conference.xmpp.zoom.us");
+const sendPulseTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendPulseText: (...args: unknown[]) => sendPulseTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+  PULSEBOT_CHANNEL: FALLBACK_CHANNEL,
+}));
+
+import { tryExecuteConfirm } from "./confirm.js";
+import { registerPpTools } from "./pp-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const CHANNEL = "pulsebot@conference.xmpp.zoom.us";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerPpTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+// The confirm code travels ONLY through the deterministic channel send.
+function codeFromDelivery(): string | undefined {
+  const text = sendPulseTextMock.mock.calls.at(-1)?.[1];
+  return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
+}
+
+describe("pulsebot confirm-gated writes", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendPulseTextMock.mockReset();
+    process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+  });
+
+  it("read-only tools execute immediately and stage nothing", async () => {
+    const tools = buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: [] });
+    await tools.pp_list_projects.execute("t", {});
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/projects");
+    expect(sendPulseTextMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket stages: code delivered to channel (threaded), NO code to the model, no prod write", async () => {
+    const tools = buildTools();
+    const staged = parse(
+      await tools.pp_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+
+    // Model-facing result is code-free — it cannot fabricate/relay/duplicate it.
+    expect(staged.staged).toBe(true);
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(JSON.stringify(staged)).not.toMatch(/\b\d{4}\b/);
+
+    // The real prompt — with the code — was posted to the channel, threaded.
+    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
+    const [channel, text, replyTo] = sendPulseTextMock.mock.calls[0];
+    expect(channel).toBe(CHANNEL);
+    expect(text).toMatch(/CONFIRM \d{4}/);
+    expect(replyTo).toBe("MSG-ANCHOR");
+
+    // Staging must not touch prod until confirmed.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket POSTs /api/v1/tickets only after a human CONFIRM", async () => {
+    const tools = buildTools();
+    await tools.pp_create_ticket.execute("t", {
+      title: "Boom",
+      projectId: "p1",
+      priority: "high",
+    });
+    const code = codeFromDelivery();
+    expect(code).toBeTruthy();
+
+    fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("update_ticket stages, then PATCHes the right id on confirm", async () => {
+    const tools = buildTools();
+    await tools.pp_update_ticket.execute("t", { id: "t9", status: "closed" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const code = codeFromDelivery();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets/t9",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+    const tools = buildTools();
+    const staged = parse(
+      await tools.pp_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+    // The production-safety fix: env unset must NOT degrade to the inline prompt.
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
+    expect(sendPulseTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
+    expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "t",
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/pulsebot/src/pp-tools.ts
+++ b/extensions/pulsebot/src/pp-tools.ts
@@ -1,8 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { ppFetch, jsonResult, errorResult } from "./pp-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { describeChanges, pickBody, stageWrite } from "./gated.js";
+import { ppFetch, jsonResult, errorResult } from "./pp-api.js";
 
 export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
   // pp_auth_status
@@ -33,7 +34,9 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         name: "pp_list_projects",
         description: "List Project Pulse projects. Supports optional query filters.",
         parameters: Type.Object({
-          status: Type.Optional(Type.String({ description: "Filter by status (e.g. active, completed)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (e.g. active, completed)" }),
+          ),
           search: Type.Optional(Type.String({ description: "Search term" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
@@ -41,7 +44,12 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["status", "search", "limit"]);
             const result = await ppFetch(`/api/v1/projects${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -63,8 +71,15 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await ppFetch(`/api/v1/projects/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await ppFetch(
+              `/api/v1/projects/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -91,7 +106,12 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "assigneeId", "limit"]);
             const result = await ppFetch(`/api/v1/tasks${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -113,8 +133,15 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await ppFetch(`/api/v1/tasks/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await ppFetch(
+              `/api/v1/tasks/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -130,18 +157,28 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "pp_list_tickets",
-        description: "List Project Pulse tickets (bug reports, feature requests). Filter by status, priority, project.",
+        description:
+          "List Project Pulse tickets (bug reports, feature requests). Filter by status, priority, project.",
         parameters: Type.Object({
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
-          status: Type.Optional(Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" })),
-          priority: Type.Optional(Type.String({ description: "Filter by priority (low, medium, high, critical)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" }),
+          ),
+          priority: Type.Optional(
+            Type.String({ description: "Filter by priority (low, medium, high, critical)" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "priority", "limit"]);
             const result = await ppFetch(`/api/v1/tickets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -160,25 +197,30 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         description: "Create a new ticket in Project Pulse. Requires title and project ID.",
         parameters: Type.Object({
           title: Type.String({ description: "Ticket title" }),
-          description: Type.Optional(Type.String({ description: "Ticket description (markdown supported)" })),
+          description: Type.Optional(
+            Type.String({ description: "Ticket description (markdown supported)" }),
+          ),
           projectId: Type.String({ description: "Project ID to create ticket in" }),
-          priority: Type.Optional(Type.String({ description: "Priority: low, medium, high, critical" })),
+          priority: Type.Optional(
+            Type.String({ description: "Priority: low, medium, high, critical" }),
+          ),
           assigneeId: Type.Optional(Type.String({ description: "User ID to assign" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await ppFetch("/api/v1/tickets", {
-              method: "POST",
-              body: JSON.stringify({
-                title: params.title,
-                description: params.description,
-                projectId: params.projectId,
-                priority: params.priority,
-                assigneeId: params.assigneeId,
+            const summary = `create ticket "${params.title as string}" in project ${params.projectId as string}`;
+            return await stageWrite(summary, () =>
+              ppFetch("/api/v1/tickets", {
+                method: "POST",
+                body: JSON.stringify({
+                  title: params.title,
+                  description: params.description,
+                  projectId: params.projectId,
+                  priority: params.priority,
+                  assigneeId: params.assigneeId,
+                }),
               }),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -204,13 +246,21 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const { id, ...body } = params;
-            const result = await ppFetch(`/api/v1/tickets/${encodeURIComponent(id as string)}`, {
-              method: "PATCH",
-              body: JSON.stringify(body),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            const id = params.id as string;
+            const body = pickBody(params, [
+              "title",
+              "description",
+              "status",
+              "priority",
+              "assigneeId",
+            ]);
+            const summary = `update ticket ${id}: ${describeChanges(body)}`;
+            return await stageWrite(summary, () =>
+              ppFetch(`/api/v1/tickets/${encodeURIComponent(id)}`, {
+                method: "PATCH",
+                body: JSON.stringify(body),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -234,7 +284,12 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["role", "search"]);
             const result = await ppFetch(`/api/v1/users${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -261,7 +316,12 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["userId", "projectId", "startDate", "endDate"]);
             const result = await ppFetch(`/api/v1/timesheets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -280,14 +340,21 @@ export function registerPpTools(api: OpenClawPluginApi, logger: AuditLogger) {
         description: "Full-text search across Project Pulse (projects, tasks, tickets, users).",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          type: Type.Optional(Type.String({ description: "Limit to type: projects, tasks, tickets, users" })),
+          type: Type.Optional(
+            Type.String({ description: "Limit to type: projects, tasks, tickets, users" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["query", "type", "limit"]);
             const result = await ppFetch(`/api/v1/search${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);

--- a/extensions/test-capture/harness/profiles.mjs
+++ b/extensions/test-capture/harness/profiles.mjs
@@ -17,6 +17,55 @@ export const PROFILES = {
     // Coordinator's allowlisted non-domain tools — used to assert "router-only".
     routerTools: ["sessions_spawn", "subagents", "scopely_health_check", "scopely_auth_status"],
   },
+  bigheadbot: {
+    agentId: "bigheadbot",
+    channelIdRaw: "567a6810959543b5b7c1cacf6af7c013",
+    channelJid: "567a6810959543b5b7c1cacf6af7c013@conference.xmpp.zoom.us",
+    sessionKey:
+      "agent:bigheadbot:zoom:channel:567a6810959543b5b7c1cacf6af7c013@conference.xmpp.zoom.us",
+    operator: "matt.keuning@cloudwarriors.ai",
+    // bigheadbot is currently a SINGLE agent (confirm-gate hardened, not yet hub-split).
+    // The router-only assertion is N/A until the optional measure-gated coordinator/spoke
+    // split lands; this lists the planned coordinator liveness set for that future state.
+    routerTools: ["sessions_spawn", "subagents", "bh_auth_status"],
+    split: false,
+  },
+  zoomwarriorssupportbot: {
+    agentId: "zoomwarriorssupportbot",
+    channelIdRaw: "f1f7b4c3e9b54e8cbc205b007c5fd6e5",
+    channelJid: "f1f7b4c3e9b54e8cbc205b007c5fd6e5@conference.xmpp.zoom.us",
+    sessionKey:
+      "agent:zoomwarriorssupportbot:zoom:channel:f1f7b4c3e9b54e8cbc205b007c5fd6e5@conference.xmpp.zoom.us",
+    operator: "matt.keuning@cloudwarriors.ai",
+    // Confirm-gate hardened, not yet hub-split (measure-gated). Planned coordinator
+    // liveness set for the future split state.
+    routerTools: ["sessions_spawn", "subagents", "zws_auth_status"],
+    split: false,
+  },
+  pulsebot: {
+    agentId: "pulsebot",
+    channelIdRaw: "b6a0428ca4364fd9873fe6a2ea1376fd",
+    channelJid: "b6a0428ca4364fd9873fe6a2ea1376fd@conference.xmpp.zoom.us",
+    sessionKey:
+      "agent:pulsebot:zoom:channel:b6a0428ca4364fd9873fe6a2ea1376fd@conference.xmpp.zoom.us",
+    operator: "matt.keuning@cloudwarriors.ai",
+    // Confirm-gate hardened, not yet hub-split (measure-gated). Planned coordinator
+    // liveness set for the future split state.
+    routerTools: ["sessions_spawn", "subagents", "pp_auth_status"],
+    split: false,
+  },
+  "cloudflow-support": {
+    agentId: "cloudflow-support",
+    channelIdRaw: "82a0a9b6ca134457b58151734ee5643b",
+    channelJid: "82a0a9b6ca134457b58151734ee5643b@conference.xmpp.zoom.us",
+    sessionKey:
+      "agent:cloudflow-support:zoom:channel:82a0a9b6ca134457b58151734ee5643b@conference.xmpp.zoom.us",
+    operator: "matt.keuning@cloudwarriors.ai",
+    // Confirm-gate hardened, not yet hub-split (measure-gated). Planned coordinator
+    // liveness set for the future split state.
+    routerTools: ["sessions_spawn", "subagents", "cf_discover_ops"],
+    split: false,
+  },
 };
 
 export function getProfile(name) {

--- a/extensions/zoomwarriorssupportbot/index.ts
+++ b/extensions/zoomwarriorssupportbot/index.ts
@@ -1,12 +1,17 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { createAuditLogger } from "./src/audit.js";
-import { registerZwsTools } from "./src/zws-tools.js";
-import { registerGhTools } from "./src/gh-tools.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDevtoolsTools } from "./src/devtools-tools.js";
-import { sendComfortMessage } from "./src/comfort.js";
+import { registerGhTools } from "./src/gh-tools.js";
+import { registerZwsTools } from "./src/zws-tools.js";
 
 type PluginConfig = { zwsRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 const plugin = {
   id: "zoomwarriorssupportbot",
@@ -35,16 +40,38 @@ const plugin = {
     registerCorrelationTools(api, logger, pluginConfig);
     registerDevtoolsTools(api, logger);
 
-    // Send comfort message when a message arrives in the zws channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator) and runs before before_dispatch — if it
+    // consumed the pending action the before_dispatch handler would find nothing.
+    // So here we only (a) skip comfort for a CONFIRM reply and (b) stash the
+    // inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
     });
 
-    console.log("[zoomwarriorssupportbot] Registered 25 tools (11 ZWS + 6 GH + 1 correlation + 7 devtools)");
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered threaded by core. The LLM is never in the
+    // execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return undefined;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return undefined;
+      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      return { handled: true, text: result ?? undefined };
+    });
+
+    console.log(
+      "[zoomwarriorssupportbot] Registered 25 tools (11 ZWS + 6 GH + 1 correlation + 7 devtools)",
+    );
   },
 };
 

--- a/extensions/zoomwarriorssupportbot/src/comfort.ts
+++ b/extensions/zoomwarriorssupportbot/src/comfort.ts
@@ -1,4 +1,8 @@
-const ZWS_CHANNEL = "f1f7b4c3e9b54e8cbc205b007c5fd6e5@conference.xmpp.zoom.us";
+// The zws Zoom channel JID. Exported so the confirm gate (gated.ts) can deliver the
+// CONFIRM prompt to the same channel deterministically when the ZWS_ZOOM_CHANNEL env
+// override is not set — the code must never fall back to an inline (LLM-relayed)
+// prompt in production.
+export const ZWS_CHANNEL = "f1f7b4c3e9b54e8cbc205b007c5fd6e5@conference.xmpp.zoom.us";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -69,4 +73,67 @@ export async function sendComfortMessage(
   } catch (err) {
     console.error("[zws] comfort message failed:", err);
   }
+}
+
+// Generic text send to the zws Zoom channel (reuses the bot token). Used by the
+// confirm gate to deterministically post the CONFIRM prompt (with the code). Pass
+// replyToMessageId to thread the message under the originating request.
+export async function sendZwsText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "ZWSupportBot" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[zws] sendZwsText failed:", err);
+  }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside the write tool, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/zoomwarriorssupportbot/src/confirm.ts
+++ b/extensions/zoomwarriorssupportbot/src/confirm.ts
@@ -1,0 +1,61 @@
+// Confirm-gate execution for zws. A human `CONFIRM <code>` reply runs the
+// staged action. The LLM is never in the execution path: it cannot fabricate the
+// inbound CONFIRM, and the code never passed through it (delivered deterministically
+// by stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator (see hub-and-spoke-implementation-guide.md §7).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// A staged write's result data is produced only at confirm time (the mutation is
+// deferred). Surface a compact, useful tail (a created url, or an id/number) so the
+// human gets the actionable result back on confirm — without dumping the full body.
+function successDetail(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.url === "string" && d.url) return ` ${d.url}`;
+    const id = d.id ?? d.number;
+    if (typeof id === "string" || typeof id === "number") return ` (id ${id})`;
+  }
+  return "";
+}
+
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  const action = takePending(m[1]);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "zws_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.${successDetail(res.data)}`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "zws_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/zoomwarriorssupportbot/src/devtools-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/devtools-tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { assertReadOnlySql } from "./devtools-tools.js";
+
+describe("zws_devtools_db_query read-only guard", () => {
+  it("allows a single SELECT", () => {
+    expect(assertReadOnlySql("SELECT * FROM users WHERE id = $1")).toBeUndefined();
+  });
+
+  it("allows a WITH (CTE) query and tolerates a trailing semicolon", () => {
+    expect(assertReadOnlySql("WITH t AS (SELECT 1) SELECT * FROM t;")).toBeUndefined();
+  });
+
+  it("allows leading whitespace/newlines and is case-insensitive", () => {
+    expect(assertReadOnlySql("  \n select 1")).toBeUndefined();
+  });
+
+  it("rejects INSERT/UPDATE/DELETE/DROP", () => {
+    for (const sql of [
+      "INSERT INTO t VALUES (1)",
+      "UPDATE t SET x = 1",
+      "DELETE FROM t",
+      "DROP TABLE t",
+      "TRUNCATE t",
+    ]) {
+      expect(assertReadOnlySql(sql)).toMatch(/read-only/i);
+    }
+  });
+
+  it("rejects stacked statements (SQL injection via ;)", () => {
+    expect(assertReadOnlySql("SELECT 1; DROP TABLE users")).toMatch(/stacked|multiple/i);
+  });
+
+  it("rejects empty / non-SQL input", () => {
+    expect(assertReadOnlySql("")).toMatch(/read-only/i);
+    expect(assertReadOnlySql("   ")).toMatch(/read-only/i);
+  });
+});

--- a/extensions/zoomwarriorssupportbot/src/devtools-tools.ts
+++ b/extensions/zoomwarriorssupportbot/src/devtools-tools.ts
@@ -3,8 +3,16 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 
-const DEVTOOLS_BASE = () => process.env.ZWS_DEVTOOLS_API_URL ?? process.env.DEVTOOLS_API_URL ?? process.env.BIGHEAD_DEVTOOLS_API_URL ?? "http://bighead-devtools-api:9100";
-const DEVTOOLS_TOKEN = () => process.env.ZWS_DEV_TOOLS_API ?? process.env.DEV_TOOLS_API ?? process.env.BIGHEAD_DEV_TOOLS_API ?? "";
+const DEVTOOLS_BASE = () =>
+  process.env.ZWS_DEVTOOLS_API_URL ??
+  process.env.DEVTOOLS_API_URL ??
+  process.env.BIGHEAD_DEVTOOLS_API_URL ??
+  "http://bighead-devtools-api:9100";
+const DEVTOOLS_TOKEN = () =>
+  process.env.ZWS_DEV_TOOLS_API ??
+  process.env.DEV_TOOLS_API ??
+  process.env.BIGHEAD_DEV_TOOLS_API ??
+  "";
 
 function jsonResult(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
@@ -12,7 +20,24 @@ function jsonResult(data: unknown) {
 
 function errorResult(err: unknown) {
   const message = err instanceof Error ? err.message : String(err);
-  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }] };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
+}
+
+// Client-side defense-in-depth for zws_devtools_db_query. The /db/query endpoint is
+// contractually read-only (SELECT/WITH only), but the tool must not forward a
+// non-read or stacked statement and rely on the backend to refuse it. Returns an
+// error string when the SQL is not a single read-only statement, else undefined.
+export function assertReadOnlySql(sql: string): string | undefined {
+  const trimmed = sql.trim().replace(/;\s*$/, ""); // tolerate one trailing semicolon
+  if (!/^(select|with)\b/i.test(trimmed)) {
+    return "Only read-only SELECT or WITH queries are allowed.";
+  }
+  if (trimmed.includes(";")) {
+    return "Stacked/multiple statements are not allowed; submit a single SELECT/WITH query.";
+  }
+  return undefined;
 }
 
 async function zwsDevtoolsFetch(
@@ -45,12 +70,18 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_list_containers",
-        description: "List all Docker containers on the ZoomWarriors server with their name, image, state, and status.",
+        description:
+          "List all Docker containers on the ZoomWarriors server with their name, image, state, and status.",
         parameters: Type.Object({}),
         async execute() {
           try {
             const result = await zwsDevtoolsFetch("/api/v1/containers");
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, containers: result.data });
           } catch (err) {
             return errorResult(err);
@@ -66,11 +97,19 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_get_logs",
-        description: "Get logs from a Docker container on the ZoomWarriors server. Returns the last N lines of logs.",
+        description:
+          "Get logs from a Docker container on the ZoomWarriors server. Returns the last N lines of logs.",
         parameters: Type.Object({
           container_id: Type.String({ description: "The container ID or name" }),
-          tail: Type.Optional(Type.Number({ description: "Number of lines to return (default 200)", default: 200 })),
-          since: Type.Optional(Type.String({ description: "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')" })),
+          tail: Type.Optional(
+            Type.Number({ description: "Number of lines to return (default 200)", default: 200 }),
+          ),
+          since: Type.Optional(
+            Type.String({
+              description:
+                "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')",
+            }),
+          ),
           until: Type.Optional(Type.String({ description: "Show logs until timestamp" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -83,7 +122,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
             const result = await zwsDevtoolsFetch(
               `/api/v1/containers/${encodeURIComponent(containerId)}/logs?${queryParams.toString()}`,
             );
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, logs: result.data });
           } catch (err) {
             return errorResult(err);
@@ -101,14 +145,21 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
         name: "zws_devtools_list_files",
         description: "List files and directories at a given path in the ZoomWarriors codebase.",
         parameters: Type.Object({
-          path: Type.Optional(Type.String({ description: "Directory path to list (defaults to root)" })),
+          path: Type.Optional(
+            Type.String({ description: "Directory path to list (defaults to root)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const path = params.path as string | undefined;
             const endpoint = path ? `/api/v1/files/${encodeURIComponent(path)}` : "/api/v1/files";
             const result = await zwsDevtoolsFetch(endpoint);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, files: result.data });
           } catch (err) {
             return errorResult(err);
@@ -132,7 +183,12 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
           try {
             const path = params.path as string;
             const result = await zwsDevtoolsFetch(`/api/v1/files/${encodeURIComponent(path)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, content: result.data });
           } catch (err) {
             return errorResult(err);
@@ -148,12 +204,18 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_list_databases",
-        description: "List all available databases that can be queried via devtools. Returns database names to use with the database parameter on other DB tools.",
+        description:
+          "List all available databases that can be queried via devtools. Returns database names to use with the database parameter on other DB tools.",
         parameters: Type.Object({}),
         async execute() {
           try {
             const result = await zwsDevtoolsFetch("/api/v1/databases");
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, databases: result.data });
           } catch (err) {
             return errorResult(err);
@@ -169,17 +231,28 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_db_tables",
-        description: "List all tables in the public schema of a ZoomWarriors database. Use zws_devtools_list_databases to see available databases.",
+        description:
+          "List all tables in the public schema of a ZoomWarriors database. Use zws_devtools_list_databases to see available databases.",
         parameters: Type.Object({
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted." })),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const db = params.database as string | undefined;
             const qs = db ? `?database=${encodeURIComponent(db)}` : "";
             const result = await zwsDevtoolsFetch(`/api/v1/db/tables${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }
@@ -194,19 +267,32 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_db_table_schema",
-        description: "Get the column definitions for a database table. Use zws_devtools_list_databases to see available databases.",
+        description:
+          "Get the column definitions for a database table. Use zws_devtools_list_databases to see available databases.",
         parameters: Type.Object({
           table_name: Type.String({ description: "The table name to get schema for" }),
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted." })),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const tableName = params.table_name as string;
             const db = params.database as string | undefined;
             const qs = db ? `?database=${encodeURIComponent(db)}` : "";
-            const result = await zwsDevtoolsFetch(`/api/v1/db/tables/${encodeURIComponent(tableName)}/schema${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            const result = await zwsDevtoolsFetch(
+              `/api/v1/db/tables/${encodeURIComponent(tableName)}/schema${qs}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }
@@ -221,15 +307,28 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "zws_devtools_db_query",
-        description: "Execute a read-only SQL query (SELECT or WITH only) against a ZoomWarriors database. Returns up to 1000 rows. Use zws_devtools_list_databases to see available databases.",
+        description:
+          "Execute a read-only SQL query (SELECT or WITH only) against a ZoomWarriors database. Returns up to 1000 rows. Use zws_devtools_list_databases to see available databases.",
         parameters: Type.Object({
           sql: Type.String({ description: "The SQL query to execute (SELECT or WITH only)" }),
-          params: Type.Optional(Type.Array(Type.Unknown(), { description: "Parameterized query values ($1, $2, etc.)" })),
-          database: Type.Optional(Type.String({ description: "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted." })),
+          params: Type.Optional(
+            Type.Array(Type.Unknown(), {
+              description: "Parameterized query values ($1, $2, etc.)",
+            }),
+          ),
+          database: Type.Optional(
+            Type.String({
+              description:
+                "Database name (e.g. 'zoomwarriors2', 'zoomwarriors2_studio'). Defaults to zoomwarriors2 if omitted.",
+            }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const body: Record<string, unknown> = { sql: params.sql };
+            const sql = (params.sql as string) ?? "";
+            const sqlGuard = assertReadOnlySql(sql);
+            if (sqlGuard) return jsonResult({ ok: false, error: sqlGuard });
+            const body: Record<string, unknown> = { sql };
             if (params.params) body.params = params.params;
             if (params.database) body.database = params.database;
             const result = await zwsDevtoolsFetch("/api/v1/db/query", {
@@ -237,8 +336,13 @@ export function registerDevtoolsTools(api: OpenClawPluginApi, logger: AuditLogge
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify(body),
             });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, ...result.data as object });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
+            return jsonResult({ ok: true, ...(result.data as object) });
           } catch (err) {
             return errorResult(err);
           }

--- a/extensions/zoomwarriorssupportbot/src/gated.ts
+++ b/extensions/zoomwarriorssupportbot/src/gated.ts
@@ -1,0 +1,76 @@
+// Shared confirm-gate staging helper for zws write tools.
+//
+// THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never calls zwsFetch with a mutating method directly. The real mutation lives
+// in the `run` closure, fired ONLY by tryExecuteConfirm() (confirm.ts) when a human
+// replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the bot
+// cannot self-mutate. Tests assert zwsFetch is not called during execute().
+//
+// Ported from the proven bigheadbot/scopelybot implementation (see
+// docs/reference/hub-and-spoke-implementation-guide.md §7).
+
+import { ZWS_CHANNEL, getChannelThreadAnchor, sendZwsText } from "./comfort.js";
+import { makeCode, putPending } from "./pending-confirm.js";
+import { jsonResult } from "./zws-api.js";
+
+let codeSeed = 1;
+
+type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
+
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live on scopelybot). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => RunResult) {
+  const code = makeCode(codeSeed++ * 7919 + summary.length);
+  putPending({ code, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly. Fall back to the bot's known
+  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
+  const channel = process.env.ZWS_ZOOM_CHANNEL ?? ZWS_CHANNEL;
+  if (channel) {
+    await sendZwsText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
+}
+
+// Build a request body from only the fields the caller actually supplied, so we
+// never send undefined keys that would blank out existing values on a PATCH.
+export function pickBody(
+  params: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const k of keys) {
+    if (params[k] !== undefined) {
+      body[k] = params[k];
+    }
+  }
+  return body;
+}
+
+// Human-readable "k=v, k2=v2" summary of a staged body, for the confirm prompt.
+export function describeChanges(body: Record<string, unknown>): string {
+  return Object.entries(body)
+    .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+    .join(", ");
+}

--- a/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
@@ -5,20 +5,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const execSyncMock = vi.fn();
 vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
 
-vi.mock("./pp-api.js", () => ({
+vi.mock("./zws-api.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
   errorResult: (err: unknown) => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
 }));
 
-const sendPulseTextMock = vi.fn();
+const sendZwsTextMock = vi.fn();
 vi.mock("./comfort.js", () => ({
-  sendPulseText: (...args: unknown[]) => sendPulseTextMock(...args),
+  sendZwsText: (...args: unknown[]) => sendZwsTextMock(...args),
   getChannelThreadAnchor: () => "MSG-ANCHOR",
   rememberChannelThreadAnchor: () => {},
   sendComfortMessage: () => {},
-  PULSEBOT_CHANNEL: "pulsebot-default@conference.xmpp.zoom.us",
+  ZWS_CHANNEL: "zws-default@conference.xmpp.zoom.us",
 }));
 
 // Stakeholder/DM helpers are not under test here — stub to no-ops.
@@ -26,7 +26,7 @@ vi.mock("./stakeholders.js", () => ({
   buildStakeholderWorkPrefix: () => "",
   extractStakeholdersFromIssue: () => ({ stakeholders: [], reporter: undefined }),
   formatStakeholderBlock: () => "",
-  parseIssueNumberFromUrl: () => 77,
+  parseIssueNumberFromUrl: () => 42,
   resolveStakeholderDmTarget: () => undefined,
   upsertStakeholderBlock: (body: string) => body,
 }));
@@ -44,8 +44,7 @@ type ToolDef = {
 };
 
 const noopLogger = () => {};
-const CHANNEL = "pulsebot@conference.xmpp.zoom.us";
-const REPO = "cloudwarriors-ai/project-pulse";
+const CHANNEL = "zws@conference.xmpp.zoom.us";
 
 function buildTools(): Record<string, ToolDef> {
   const tools: Record<string, ToolDef> = {};
@@ -55,7 +54,7 @@ function buildTools(): Record<string, ToolDef> {
       tools[t.name] = t;
     },
   } as never;
-  registerGhTools(api, noopLogger as never, { ppRepos: [REPO] });
+  registerGhTools(api, noopLogger as never, { zwsRepos: ["cloudwarriors-ai/zoomwarriors2"] });
   return tools;
 }
 
@@ -64,77 +63,38 @@ function parse(res: { content: { text: string }[] }) {
 }
 
 function codeFromDelivery(): string | undefined {
-  const text = sendPulseTextMock.mock.calls.at(-1)?.[1];
+  const text = sendZwsTextMock.mock.calls.at(-1)?.[1];
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
-describe("pulsebot gh reads", () => {
+describe("zws gh writes are confirm-gated", () => {
   beforeEach(() => {
     execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
-  });
-
-  it("list_issues returns parsed issue data (no staging)", async () => {
-    const tools = buildTools();
-    execSyncMock.mockReturnValue(
-      JSON.stringify([{ number: 42, title: "OAuth login fails", state: "open" }]),
-    );
-    const payload = parse(await tools.gh_list_issues.execute("t", { state: "open", limit: 1 }));
-    expect(payload.ok).toBe(true);
-    expect((payload.data as Array<Record<string, unknown>>)[0]?.number).toBe(42);
-    expect(String(execSyncMock.mock.calls[0]?.[0])).toContain("gh issue list");
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
-  });
-
-  it("surfaces gh-not-found errors without throwing", async () => {
-    const tools = buildTools();
-    execSyncMock.mockImplementation(() => {
-      throw new Error("/bin/sh: 1: gh: not found");
-    });
-    const payload = parse(await tools.gh_search_issues.execute("t", { query: "oauth timeout" }));
-    expect(payload.ok).toBe(false);
-    expect(String(payload.error)).toContain("gh: not found");
-  });
-
-  it("blocks repositories outside the allowlist", async () => {
-    const tools = buildTools();
-    const payload = parse(
-      await tools.gh_list_issues.execute("t", { repo: "other-org/other-repo" }),
-    );
-    expect(payload.ok).toBe(false);
-    expect(String(payload.error)).toContain("not in allowed list");
-    expect(execSyncMock).not.toHaveBeenCalled();
-  });
-});
-
-describe("pulsebot gh writes are confirm-gated", () => {
-  beforeEach(() => {
-    execSyncMock.mockReset();
-    sendPulseTextMock.mockReset();
-    process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
+    sendZwsTextMock.mockReset();
+    process.env.ZWS_ZOOM_CHANNEL = CHANNEL;
   });
   afterEach(() => {
-    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+    delete process.env.ZWS_ZOOM_CHANNEL;
   });
 
   it("create_issue stages — no gh shell-out, code-free result, prompt to channel", async () => {
     const tools = buildTools();
     const staged = parse(
-      await tools.gh_create_issue.execute("t", { title: "Crash on boot", body: "details" }),
+      await tools.zws_gh_create_issue.execute("t", { title: "Crash on boot", body: "details" }),
     );
 
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
     expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
-    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
-    expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    expect(sendZwsTextMock).toHaveBeenCalledTimes(1);
+    expect(sendZwsTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
-    await tools.gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
+    await tools.zws_gh_create_issue.execute("t", { title: "Crash", body: "x" });
     expect(execSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
@@ -149,12 +109,13 @@ describe("pulsebot gh writes are confirm-gated", () => {
     );
     expect(createCalls.length).toBe(1);
     expect(reply).toMatch(/✅ Done/);
+    expect(reply).toContain("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
     execSyncMock.mockReturnValue("closed");
-    await tools.gh_close_issue.execute("t", { number: 7 });
+    await tools.zws_gh_close_issue.execute("t", { number: 7 });
     // Stage time: nothing shells out (not even the issue-view read inside the closure).
     expect(execSyncMock).not.toHaveBeenCalled();
 
@@ -169,10 +130,14 @@ describe("pulsebot gh writes are confirm-gated", () => {
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
     const tools = buildTools();
     const res = parse(
-      await tools.gh_create_issue.execute("t", { repo: "evil/repo", title: "x", body: "y" }),
+      await tools.zws_gh_create_issue.execute("t", {
+        repo: "evil/repo",
+        title: "x",
+        body: "y",
+      }),
     );
     expect(res.ok).toBe(false);
-    expect(sendPulseTextMock).not.toHaveBeenCalled();
+    expect(sendZwsTextMock).not.toHaveBeenCalled();
     expect(execSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/zoomwarriorssupportbot/src/gh-tools.ts
+++ b/extensions/zoomwarriorssupportbot/src/gh-tools.ts
@@ -1,9 +1,9 @@
-import { Type } from "@sinclair/typebox";
 import { execSync } from "child_process";
+import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./zws-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
 import {
   buildStakeholderWorkPrefix,
   extractStakeholdersFromIssue,
@@ -13,6 +13,7 @@ import {
   upsertStakeholderBlock,
 } from "./stakeholders.js";
 import { sendStakeholderZoomDm } from "./zoom-dm.js";
+import { jsonResult, errorResult } from "./zws-api.js";
 
 type PluginConfig = { zwsRepos?: string[] };
 
@@ -77,10 +78,15 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "zws_gh_list_issues",
-        description: "List GitHub issues from a ZoomWarriors2 repo. Returns title, number, state, labels, assignees.",
+        description:
+          "List GitHub issues from a ZoomWarriors2 repo. Returns title, number, state, labels, assignees.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
-          state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
           label: Type.Optional(Type.String({ description: "Filter by label" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
         }),
@@ -109,9 +115,12 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "zws_gh_get_issue",
-        description: "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
+        description:
+          "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -140,7 +149,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description:
           "Create a new GitHub issue in a ZoomWarriors2 repo. Persists reporter/stakeholders in a machine-readable metadata block.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
           title: Type.String({ description: "Issue title" }),
           body: Type.String({ description: "Issue body (markdown)" }),
           labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
@@ -154,42 +165,52 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const labels = params.labels as string[] | undefined;
-            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-            const bodyStr = String(params.body ?? "");
-            const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
-            const stakeholders = Array.isArray(params.stakeholders)
-              ? (params.stakeholders as string[])
-              : [];
-            const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const labels = params.labels as string[] | undefined;
+              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+              const bodyStr = String(params.body ?? "");
+              const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
+              const stakeholders = Array.isArray(params.stakeholders)
+                ? (params.stakeholders as string[])
+                : [];
+              const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-            const result = execSync(
-              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: enrichedBody,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            const url = result.trim();
-            const issueNumber = parseIssueNumberFromUrl(url);
-
-            if (issueNumber) {
-              const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-              execSync(
-                `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+              const result = execSync(
+                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
                 {
                   encoding: "utf-8",
-                  input: metadataComment,
+                  input: enrichedBody,
                   timeout: 30000,
                   env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
                 },
               );
-            }
+              const url = result.trim();
+              const issueNumber = parseIssueNumberFromUrl(url);
 
-            return jsonResult({ ok: true, url, issueNumber, reporter, stakeholders, metadataSaved: Boolean(issueNumber) });
+              if (issueNumber) {
+                const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
+                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
+                  encoding: "utf-8",
+                  input: metadataComment,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                });
+              }
+
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url,
+                  issueNumber,
+                  reporter,
+                  stakeholders,
+                  metadataSaved: Boolean(issueNumber),
+                },
+              };
+            });
           } catch (err) {
             return errorResult(err);
           }
@@ -204,37 +225,51 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "zws_gh_add_comment",
-        description: "Add a comment to an existing GitHub issue. Auto-mentions stored stakeholders.",
+        description:
+          "Add a comment to an existing GitHub issue. Auto-mentions stored stakeholders.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
           body: Type.String({ description: "Comment body (markdown)" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
-            const issue = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            const originalBody = String(params.body ?? "");
-            const body =
-              prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
-                ? `${prefix}\n\n${originalBody}`
-                : originalBody;
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
+            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              const originalBody = String(params.body ?? "");
+              const body =
+                prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
+                  ? `${prefix}\n\n${originalBody}`
+                  : originalBody;
 
-            const result = execSync(
-              `gh issue comment ${params.number} --repo ${repo} --body-file -`,
-              {
-                encoding: "utf-8",
-                input: body,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            return jsonResult({ ok: true, url: result.trim(), stakeholders: extracted.stakeholders, reporter: extracted.reporter });
+              const result = execSync(
+                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  url: result.trim(),
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                },
+              };
+            });
           } catch (err) {
             return errorResult(err);
           }
@@ -252,7 +287,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description: "Search GitHub issues by keyword in ZoomWarriors2 repos.",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -279,81 +316,99 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "zws_gh_close_issue",
-        description: "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
+        description:
+          "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary ZW2 repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
-          comment: Type.Optional(Type.String({ description: "Closing update comment to post before close." })),
-          reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+          comment: Type.Optional(
+            Type.String({ description: "Closing update comment to post before close." }),
+          ),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
-            assertAllowedRepo(repo, config);
+            assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
             const issueNumber = Number(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
-
-            const issue = gh(
-              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
-            const extracted = extractStakeholdersFromIssue(issue);
-            const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            if (closingComment || prefix) {
-              const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
-              if (commentBody) {
-                execSync(
-                  `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
-                  {
+            const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
+            return await stageWrite(summary, async () => {
+              const issue = gh(
+                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
+              ) as GhIssueLike;
+              const extracted = extractStakeholdersFromIssue(issue);
+              const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
+              if (closingComment || prefix) {
+                const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
+                if (commentBody) {
+                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
                     encoding: "utf-8",
                     input: commentBody,
                     timeout: 30000,
                     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  },
-                );
+                  });
+                }
               }
-            }
 
-            const closeOutput = execSync(
-              `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
-              {
-                encoding: "utf-8",
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            ).trim();
+              const closeOutput = execSync(
+                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+                {
+                  encoding: "utf-8",
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              ).trim();
 
-            const dmTargets = extracted.stakeholders
-              .map((stakeholder) =>
-                resolveStakeholderDmTarget(stakeholder, {
-                  mapEnv: process.env.ZWS_STAKEHOLDER_MAP,
-                  defaultDomain: process.env.ZWS_STAKEHOLDER_EMAIL_DOMAIN,
-                }),
-              )
-              .filter((value): value is string => Boolean(value));
+              const dmTargets = extracted.stakeholders
+                .map((stakeholder) =>
+                  resolveStakeholderDmTarget(stakeholder, {
+                    mapEnv: process.env.ZWS_STAKEHOLDER_MAP,
+                    defaultDomain: process.env.ZWS_STAKEHOLDER_EMAIL_DOMAIN,
+                  }),
+                )
+                .filter((value): value is string => Boolean(value));
 
-            const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
-            const issueTitle = issue.title || `Issue ${issueNumber}`;
-            const dmMessage = formatStakeholderDmMessage({
-              issueNumber,
-              issueTitle,
-              repo,
-              closedBy: "zoomwarriorssupportbot",
-              closingComment,
-            });
+              const uniqueTargets = [...new Set(dmTargets.map((target) => target.toLowerCase()))];
+              const issueTitle = issue.title || `Issue ${issueNumber}`;
+              const dmMessage = formatStakeholderDmMessage({
+                issueNumber,
+                issueTitle,
+                repo,
+                closedBy: "zoomwarriorssupportbot",
+                closingComment,
+              });
 
-            const notified: string[] = [];
-            const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
-            for (const stakeholder of uniqueTargets) {
-              const dmResult = await sendStakeholderZoomDm({ toContact: stakeholder, message: dmMessage });
-              if (dmResult.ok) notified.push(stakeholder);
-              else notifyErrors.push({ stakeholder, error: dmResult.error ?? "unknown error" });
-            }
+              const notified: string[] = [];
+              const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
+              for (const stakeholder of uniqueTargets) {
+                const dmResult = await sendStakeholderZoomDm({
+                  toContact: stakeholder,
+                  message: dmMessage,
+                });
+                if (dmResult.ok) notified.push(stakeholder);
+                else notifyErrors.push({ stakeholder, error: dmResult.error ?? "unknown error" });
+              }
 
-            return jsonResult({
-              ok: true, number: issueNumber, repo, closeOutput, closeReason,
-              stakeholders: extracted.stakeholders, reporter: extracted.reporter,
-              notified, notifyErrors,
+              return {
+                ok: true,
+                status: 200,
+                data: {
+                  number: issueNumber,
+                  repo,
+                  closeOutput,
+                  closeReason,
+                  stakeholders: extracted.stakeholders,
+                  reporter: extracted.reporter,
+                  notified,
+                  notifyErrors,
+                },
+              };
             });
           } catch (err) {
             return errorResult(err);

--- a/extensions/zoomwarriorssupportbot/src/pending-confirm.ts
+++ b/extensions/zoomwarriorssupportbot/src/pending-confirm.ts
@@ -1,0 +1,43 @@
+// In-memory, single-use, TTL store for pending zws write actions.
+// An action only runs after a human types `CONFIRM <code>` in the channel — the
+// LLM cannot fabricate that inbound message, so it cannot self-approve.
+
+export type PendingAction = {
+  code: string;
+  summary: string; // human-readable description, echoed + audited
+  run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
+  expiresAt: number;
+};
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const store = new Map<string, PendingAction>();
+
+function prune(): void {
+  const now = Date.now();
+  for (const [code, a] of store) {
+    if (a.expiresAt <= now) store.delete(code);
+  }
+}
+
+// 4-digit code, unique within the live store. `seed` varies per call.
+export function makeCode(seed: number): string {
+  prune();
+  let code = String(1000 + (Math.abs(seed) % 9000));
+  let bump = 0;
+  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  return code;
+}
+
+export function putPending(a: Omit<PendingAction, "expiresAt">): void {
+  prune();
+  store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
+}
+
+// Retrieve and consume a pending action (one-time use).
+export function takePending(code: string): PendingAction | undefined {
+  prune();
+  const a = store.get(code);
+  if (!a) return undefined;
+  store.delete(code);
+  return a;
+}

--- a/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the prod HTTP layer so no real network call is ever made and we can
+// assert exactly which path/method each write tool would hit on confirm.
+const fetchMock = vi.fn();
+vi.mock("./zws-api.js", () => ({
+  zwsFetch: (...args: unknown[]) => fetchMock(...args),
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+// Mock the channel sender: staging delivers the confirm prompt (WITH the code)
+// to this spy instead of Zoom. The code lives ONLY here, never in the tool's
+// LLM-facing return value.
+// Hoisted so it is initialized before Vitest lifts the vi.mock factory above it.
+const FALLBACK_CHANNEL = vi.hoisted(() => "zws-default@conference.xmpp.zoom.us");
+const sendZwsTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendZwsText: (...args: unknown[]) => sendZwsTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+  ZWS_CHANNEL: FALLBACK_CHANNEL,
+}));
+
+import { tryExecuteConfirm } from "./confirm.js";
+import { registerZwsTools } from "./zws-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const CHANNEL = "zws@conference.xmpp.zoom.us";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerZwsTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+// The confirm code travels ONLY through the deterministic channel send.
+function codeFromDelivery(): string | undefined {
+  const text = sendZwsTextMock.mock.calls.at(-1)?.[1];
+  return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
+}
+
+describe("zws confirm-gated writes", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendZwsTextMock.mockReset();
+    process.env.ZWS_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.ZWS_ZOOM_CHANNEL;
+  });
+
+  it("read-only tools execute immediately and stage nothing", async () => {
+    const tools = buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: [] });
+    await tools.zws_list_projects.execute("t", {});
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/projects");
+    expect(sendZwsTextMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket stages: code delivered to channel (threaded), NO code to the model, no prod write", async () => {
+    const tools = buildTools();
+    const staged = parse(
+      await tools.zws_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+
+    // Model-facing result is code-free — it cannot fabricate/relay/duplicate it.
+    expect(staged.staged).toBe(true);
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(JSON.stringify(staged)).not.toMatch(/\b\d{4}\b/);
+
+    // The real prompt — with the code — was posted to the channel, threaded.
+    expect(sendZwsTextMock).toHaveBeenCalledTimes(1);
+    const [channel, text, replyTo] = sendZwsTextMock.mock.calls[0];
+    expect(channel).toBe(CHANNEL);
+    expect(text).toMatch(/CONFIRM \d{4}/);
+    expect(replyTo).toBe("MSG-ANCHOR");
+
+    // Staging must not touch prod until confirmed.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("create_ticket POSTs /api/v1/tickets only after a human CONFIRM", async () => {
+    const tools = buildTools();
+    await tools.zws_create_ticket.execute("t", {
+      title: "Boom",
+      projectId: "p1",
+      priority: "high",
+    });
+    const code = codeFromDelivery();
+    expect(code).toBeTruthy();
+
+    fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("update_ticket stages, then PATCHes the right id on confirm", async () => {
+    const tools = buildTools();
+    await tools.zws_update_ticket.execute("t", { id: "t9", status: "closed" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const code = codeFromDelivery();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/tickets/t9",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+    delete process.env.ZWS_ZOOM_CHANNEL;
+    const tools = buildTools();
+    const staged = parse(
+      await tools.zws_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
+    );
+    // The production-safety fix: env unset must NOT degrade to the inline prompt.
+    expect(staged.awaiting_confirmation).toBe(true);
+    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    expect(sendZwsTextMock).toHaveBeenCalledTimes(1);
+    expect(sendZwsTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
+    expect(sendZwsTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "t",
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/zoomwarriorssupportbot/src/zws-tools.ts
+++ b/extensions/zoomwarriorssupportbot/src/zws-tools.ts
@@ -1,8 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { zwsFetch, jsonResult, errorResult } from "./zws-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { describeChanges, pickBody, stageWrite } from "./gated.js";
+import { zwsFetch, jsonResult, errorResult } from "./zws-api.js";
 
 export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
   // zws_auth_status
@@ -10,7 +11,8 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_auth_status",
-        description: "Check Project Pulse authentication status for ZoomWarriors support. Returns current session info.",
+        description:
+          "Check Project Pulse authentication status for ZoomWarriors support. Returns current session info.",
         parameters: Type.Object({}),
         async execute() {
           try {
@@ -31,9 +33,12 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_list_projects",
-        description: "List Project Pulse projects for ZoomWarriors. Supports optional query filters.",
+        description:
+          "List Project Pulse projects for ZoomWarriors. Supports optional query filters.",
         parameters: Type.Object({
-          status: Type.Optional(Type.String({ description: "Filter by status (e.g. active, completed)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (e.g. active, completed)" }),
+          ),
           search: Type.Optional(Type.String({ description: "Search term" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
@@ -41,7 +46,12 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["status", "search", "limit"]);
             const result = await zwsFetch(`/api/v1/projects${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -63,8 +73,15 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await zwsFetch(`/api/v1/projects/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await zwsFetch(
+              `/api/v1/projects/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -80,7 +97,8 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_list_tasks",
-        description: "List Project Pulse tasks for ZoomWarriors. Filter by project, status, assignee.",
+        description:
+          "List Project Pulse tasks for ZoomWarriors. Filter by project, status, assignee.",
         parameters: Type.Object({
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
           status: Type.Optional(Type.String({ description: "Filter by status" })),
@@ -91,7 +109,12 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "assigneeId", "limit"]);
             const result = await zwsFetch(`/api/v1/tasks${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -113,8 +136,15 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await zwsFetch(`/api/v1/tasks/${encodeURIComponent(params.id as string)}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            const result = await zwsFetch(
+              `/api/v1/tasks/${encodeURIComponent(params.id as string)}`,
+            );
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -130,18 +160,28 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_list_tickets",
-        description: "List Project Pulse tickets for ZoomWarriors (bug reports, feature requests). Filter by status, priority, project.",
+        description:
+          "List Project Pulse tickets for ZoomWarriors (bug reports, feature requests). Filter by status, priority, project.",
         parameters: Type.Object({
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
-          status: Type.Optional(Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" })),
-          priority: Type.Optional(Type.String({ description: "Filter by priority (low, medium, high, critical)" })),
+          status: Type.Optional(
+            Type.String({ description: "Filter by status (open, in_progress, resolved, closed)" }),
+          ),
+          priority: Type.Optional(
+            Type.String({ description: "Filter by priority (low, medium, high, critical)" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 50)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["projectId", "status", "priority", "limit"]);
             const result = await zwsFetch(`/api/v1/tickets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -157,28 +197,34 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_create_ticket",
-        description: "Create a new ticket in Project Pulse for ZoomWarriors. Requires title and project ID.",
+        description:
+          "Create a new ticket in Project Pulse for ZoomWarriors. Requires title and project ID.",
         parameters: Type.Object({
           title: Type.String({ description: "Ticket title" }),
-          description: Type.Optional(Type.String({ description: "Ticket description (markdown supported)" })),
+          description: Type.Optional(
+            Type.String({ description: "Ticket description (markdown supported)" }),
+          ),
           projectId: Type.String({ description: "Project ID to create ticket in" }),
-          priority: Type.Optional(Type.String({ description: "Priority: low, medium, high, critical" })),
+          priority: Type.Optional(
+            Type.String({ description: "Priority: low, medium, high, critical" }),
+          ),
           assigneeId: Type.Optional(Type.String({ description: "User ID to assign" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = await zwsFetch("/api/v1/tickets", {
-              method: "POST",
-              body: JSON.stringify({
-                title: params.title,
-                description: params.description,
-                projectId: params.projectId,
-                priority: params.priority,
-                assigneeId: params.assigneeId,
+            const summary = `create ticket "${params.title as string}" in project ${params.projectId as string}`;
+            return await stageWrite(summary, () =>
+              zwsFetch("/api/v1/tickets", {
+                method: "POST",
+                body: JSON.stringify({
+                  title: params.title,
+                  description: params.description,
+                  projectId: params.projectId,
+                  priority: params.priority,
+                  assigneeId: params.assigneeId,
+                }),
               }),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -204,13 +250,21 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const { id, ...body } = params;
-            const result = await zwsFetch(`/api/v1/tickets/${encodeURIComponent(id as string)}`, {
-              method: "PATCH",
-              body: JSON.stringify(body),
-            });
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-            return jsonResult({ ok: true, data: result.data });
+            const id = params.id as string;
+            const body = pickBody(params, [
+              "title",
+              "description",
+              "status",
+              "priority",
+              "assigneeId",
+            ]);
+            const summary = `update ticket ${id}: ${describeChanges(body)}`;
+            return await stageWrite(summary, () =>
+              zwsFetch(`/api/v1/tickets/${encodeURIComponent(id)}`, {
+                method: "PATCH",
+                body: JSON.stringify(body),
+              }),
+            );
           } catch (err) {
             return errorResult(err);
           }
@@ -234,7 +288,12 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["role", "search"]);
             const result = await zwsFetch(`/api/v1/users${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -250,7 +309,8 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_get_timesheets",
-        description: "Get Project Pulse timesheet data for ZoomWarriors. Filter by user, project, date range.",
+        description:
+          "Get Project Pulse timesheet data for ZoomWarriors. Filter by user, project, date range.",
         parameters: Type.Object({
           userId: Type.Optional(Type.String({ description: "Filter by user ID" })),
           projectId: Type.Optional(Type.String({ description: "Filter by project ID" })),
@@ -261,7 +321,12 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
           try {
             const qs = buildQuery(params, ["userId", "projectId", "startDate", "endDate"]);
             const result = await zwsFetch(`/api/v1/timesheets${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);
@@ -277,17 +342,25 @@ export function registerZwsTools(api: OpenClawPluginApi, logger: AuditLogger) {
     wrapToolWithAudit(
       {
         name: "zws_search",
-        description: "Full-text search across Project Pulse for ZoomWarriors (projects, tasks, tickets, users).",
+        description:
+          "Full-text search across Project Pulse for ZoomWarriors (projects, tasks, tickets, users).",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          type: Type.Optional(Type.String({ description: "Limit to type: projects, tasks, tickets, users" })),
+          type: Type.Optional(
+            Type.String({ description: "Limit to type: projects, tasks, tickets, users" }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const qs = buildQuery(params, ["query", "type", "limit"]);
             const result = await zwsFetch(`/api/v1/search${qs}`);
-            if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+            if (!result.ok)
+              return jsonResult({
+                ok: false,
+                error: `HTTP ${result.status}`,
+                details: result.data,
+              });
             return jsonResult({ ok: true, data: result.data });
           } catch (err) {
             return errorResult(err);


### PR DESCRIPTION
## Summary

Ports the proven scopelybot confirm-gate (PR #41) to the four remaining support bots. Every **write** tool now STAGES instead of mutating: it registers a pending action and posts a deterministic `CONFIRM <code>` prompt to the bot's own Zoom channel (threaded under the request). The code never travels through the LLM — the model's tool result is code-free. The real mutation fires only when a human replies `CONFIRM <code>`, executed in the `before_dispatch` hook so the coordinator is suppressed (no spurious re-stage, LLM never in the execution path).

This is the **measure-gated path B** confirm-gate slice — no hub/spoke split yet (all four `split:false`).

### Per bot
- **bigheadbot** — 5 writes gated (`bh_create_ticket`, `bh_update_ticket`, `bh_gh_create_issue`, `bh_gh_add_comment`, `bh_gh_close_issue`) + read-only SQL guard on `bh_devtools_db_query`
- **zoomwarriorssupportbot** — 5 writes (same shape) + read-only SQL guard on `zws_devtools_db_query`
- **pulsebot** — 5 writes (`pp_create_ticket`, `pp_update_ticket`, `gh_create_issue`, `gh_add_comment`, `gh_close_issue`); no devtools
- **cloudflow-support** — `cf_execute_op` (arbitrary ops executor — gated fail-closed since the op catalog isn't statically classifiable) + 3 `cf_gh_*` writes

New per bot: `pending-confirm.ts` (single-use, 5-min TTL store), `gated.ts` (`stageWrite` + channel-constant fallback so prod never drops to an inline LLM-relayed prompt), `confirm.ts` (`before_dispatch` executor). `comfort.ts` exports the channel JID and adds `send<X>Text` + thread-anchor helpers. Harness profiles registered for all four.

## Verification

**Unit:** `pnpm test extensions/{bigheadbot,zoomwarriorssupportbot,pulsebot,cloudflow-support}` → **62 passing** (read immediate / write stages code-free / mutation only on CONFIRM / env-unset still delivers to channel constant / wrong code fail-closed / unknown gh repo rejected at stage time).

**Typecheck:** `tsgo:extensions` — no new errors; remaining `registerTool` factory `TS2345` is pre-existing fleet-wide debt (identical in scopelybot/bighead/catfish/2fa-github).

**Live e2e on noob-root** (branch checked out in `/root/web/moltbot`, `openclaw` container restarted, test-capture harness — egress captured+suppressed, nothing sent to real Zoom):
- All four bots load clean: `[bigheadbot] Registered 25 tools`, `[zoomwarriorssupportbot] 25`, `[pulsebot] 18`, `[cloudflow-support] 15`.
- Write request on each → tool called → **staged** with threaded `⚠️ Confirm: … on PROD. Reply CONFIRM <code>` prompt, **no mutation** (`confirmPromptCount: 1`, clean `agent_end`).
- `before_dispatch` confirm hook live: `CONFIRM 0000` → "No pending action for code 0000 …", `toolCalls: []` (coordinator suppressed, fail-closed).

## Refs
Follows #41 (scopelybot confirm-gate, merged). Guide: `docs/reference/hub-and-spoke-implementation-guide.md`.