### PR TITLE
feat(bots): optional-tool scoping + channel-memory test relocation

### DIFF
--- a/extensions/bigheadbot/index.test.ts
+++ b/extensions/bigheadbot/index.test.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("bigheadbot tool scoping", () => {
+  it("registers every tool as optional so per-agent allowlists can scope them", () => {
+    // Non-optional plugin tools bypass allowlists and leak into every agent's
+    // menu; optional ones are only visible to agents whose tools.allow opts in.
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const optionalFlags: Array<boolean | undefined> = [];
+    const api = {
+      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
+        optionalFlags.push(opts?.optional);
+      }),
+      on: vi.fn(),
+    } as never;
+
+    plugin.register(api, undefined);
+
+    expect(optionalFlags.length).toBeGreaterThan(0);
+    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
+  });
+});

--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -35,10 +35,19 @@ const plugin = {
     const logger = createAuditLogger(workspaceDir);
     const pluginConfig: PluginConfig = config ?? { bhRepos: ["cloudwarriors-ai/bighead"] };
 
-    registerBhTools(api, logger);
-    registerGhTools(api, logger, pluginConfig);
-    registerCorrelationTools(api, logger, pluginConfig);
-    registerDevtoolsTools(api, logger);
+    // Register every tool as `optional: true` so per-agent allowlists actually
+    // scope them: non-optional plugin tools bypass allowlists and become visible
+    // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
+    // a tool name, the plugin id ("bigheadbot"), or "group:plugins" see them.
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    registerBhTools(optionalApi, logger);
+    registerGhTools(optionalApi, logger, pluginConfig);
+    registerCorrelationTools(optionalApi, logger, pluginConfig);
+    registerDevtoolsTools(optionalApi, logger);
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/extensions/cloudflow-support/index.test.ts
+++ b/extensions/cloudflow-support/index.test.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("cloudflow-support tool scoping", () => {
+  it("registers every tool as optional so per-agent allowlists can scope them", () => {
+    // Non-optional plugin tools bypass allowlists and leak into every agent's
+    // menu; optional ones are only visible to agents whose tools.allow opts in.
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const optionalFlags: Array<boolean | undefined> = [];
+    const api = {
+      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
+        optionalFlags.push(opts?.optional);
+      }),
+      on: vi.fn(),
+    } as never;
+
+    plugin.register(api, undefined);
+
+    expect(optionalFlags.length).toBeGreaterThan(0);
+    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
+  });
+});

--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -33,8 +33,17 @@ const plugin = {
     const logger = createAuditLogger(workspaceDir);
     const pluginConfig: PluginConfig = config ?? { cfRepos: ["cloudwarriors-ai/cloudflow"] };
 
-    registerCfOpsTools(api, logger);
-    registerGhTools(api, logger, pluginConfig);
+    // Register every tool as `optional: true` so per-agent allowlists actually
+    // scope them: non-optional plugin tools bypass allowlists and become visible
+    // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
+    // a tool name, the plugin id ("cloudflow-support"), or "group:plugins" see them.
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    registerCfOpsTools(optionalApi, logger);
+    registerGhTools(optionalApi, logger, pluginConfig);
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/extensions/memory-core/src/memory-tool-manager-mock.ts
+++ b/extensions/memory-core/src/memory-tool-manager-mock.ts
@@ -5,6 +5,8 @@ type SearchImpl = (opts?: {
   maxResults?: number;
   minScore?: number;
   sessionKey?: string;
+  scope?: "channel" | "all-customers" | "global";
+  channelSlug?: string;
   qmdSearchModeOverride?: "query" | "search" | "vsearch";
   onDebug?: (debug: MemorySearchRuntimeDebug) => void;
 }) => Promise<unknown[]>;

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMemorySearchManagerMockCalls,
   getMemorySearchManagerMockConfigs,
@@ -478,5 +478,64 @@ describe("memory_search corpus labels", () => {
         source: "sessions",
       },
     ]);
+  });
+});
+
+describe("memory_search channel scoping", () => {
+  // CW: customer-channel sessions get channel-scoped recall from the stored
+  // session subject (set from GroupSubject by deriveGroupSessionPatch). The slug
+  // is derived here from the session store — this replaced the pre-sync reply-run
+  // channelSlug producer, so the scope no longer threads through the reply run.
+  const CUSTOMER_SESSION_KEY = "agent:main:zoom-customer";
+  const sessions = sessionStore as Record<
+    string,
+    { sessionId: string; updatedAt: number; sessionFile: string; subject?: string }
+  >;
+
+  beforeEach(() => {
+    resetMemoryToolMockState({ searchImpl: async () => [] });
+    memoryToolsTesting.resetMemorySearchToolCooldowns();
+    sessions[CUSTOMER_SESSION_KEY] = {
+      sessionId: "thread-customer",
+      updatedAt: 1,
+      sessionFile: "/tmp/sessions/thread-customer.jsonl",
+      subject: "Test Customer",
+    };
+  });
+
+  afterEach(() => {
+    delete sessions[CUSTOMER_SESSION_KEY];
+  });
+
+  it("scopes search to the customer channel derived from the session subject", async () => {
+    let seenScope: string | undefined;
+    let seenChannelSlug: string | undefined;
+    setMemorySearchImpl(async (opts) => {
+      seenScope = opts?.scope;
+      seenChannelSlug = opts?.channelSlug;
+      return [];
+    });
+
+    const tool = createMemorySearchToolOrThrow({ agentSessionKey: CUSTOMER_SESSION_KEY });
+    await tool.execute("scoped", { query: "hello" });
+
+    expect(seenChannelSlug).toBe("test-customer");
+    expect(seenScope).toBe("channel");
+  });
+
+  it("leaves sessions without a subject globally scoped", async () => {
+    let seenScope: string | undefined;
+    let seenChannelSlug: string | undefined;
+    setMemorySearchImpl(async (opts) => {
+      seenScope = opts?.scope;
+      seenChannelSlug = opts?.channelSlug;
+      return [];
+    });
+
+    const tool = createMemorySearchToolOrThrow({ agentSessionKey: "agent:main:main" });
+    await tool.execute("unscoped", { query: "hello" });
+
+    expect(seenChannelSlug).toBeUndefined();
+    expect(seenScope).toBeUndefined();
   });
 });

--- a/extensions/pulsebot/index.test.ts
+++ b/extensions/pulsebot/index.test.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("pulsebot tool scoping", () => {
+  it("registers every tool as optional so per-agent allowlists can scope them", () => {
+    // Non-optional plugin tools bypass allowlists and leak into every agent's
+    // menu; optional ones are only visible to agents whose tools.allow opts in.
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const optionalFlags: Array<boolean | undefined> = [];
+    const api = {
+      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
+        optionalFlags.push(opts?.optional);
+      }),
+      on: vi.fn(),
+    } as never;
+
+    plugin.register(api, undefined);
+
+    expect(optionalFlags.length).toBeGreaterThan(0);
+    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
+  });
+});

--- a/extensions/pulsebot/index.ts
+++ b/extensions/pulsebot/index.ts
@@ -34,9 +34,18 @@ const plugin = {
     const logger = createAuditLogger(workspaceDir);
     const pluginConfig: PluginConfig = config ?? { ppRepos: ["cloudwarriors-ai/project-pulse"] };
 
-    registerPpTools(api, logger);
-    registerGhTools(api, logger, pluginConfig);
-    registerCorrelationTools(api, logger, pluginConfig);
+    // Register every tool as `optional: true` so per-agent allowlists actually
+    // scope them: non-optional plugin tools bypass allowlists and become visible
+    // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
+    // a tool name, the plugin id ("pulsebot"), or "group:plugins" see them.
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    registerPpTools(optionalApi, logger);
+    registerGhTools(optionalApi, logger, pluginConfig);
+    registerCorrelationTools(optionalApi, logger, pluginConfig);
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/extensions/zoomwarriorssupportbot/index.test.ts
+++ b/extensions/zoomwarriorssupportbot/index.test.ts
@@ -1,0 +1,23 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("zoomwarriorssupportbot tool scoping", () => {
+  it("registers every tool as optional so per-agent allowlists can scope them", () => {
+    // Non-optional plugin tools bypass allowlists and leak into every agent's
+    // menu; optional ones are only visible to agents whose tools.allow opts in.
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const optionalFlags: Array<boolean | undefined> = [];
+    const api = {
+      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
+        optionalFlags.push(opts?.optional);
+      }),
+      on: vi.fn(),
+    } as never;
+
+    plugin.register(api, undefined);
+
+    expect(optionalFlags.length).toBeGreaterThan(0);
+    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
+  });
+});

--- a/extensions/zoomwarriorssupportbot/index.ts
+++ b/extensions/zoomwarriorssupportbot/index.ts
@@ -35,10 +35,19 @@ const plugin = {
     const logger = createAuditLogger(workspaceDir);
     const pluginConfig: PluginConfig = config ?? { zwsRepos: ["cloudwarriors-ai/zoomwarriors2"] };
 
-    registerZwsTools(api, logger);
-    registerGhTools(api, logger, pluginConfig);
-    registerCorrelationTools(api, logger, pluginConfig);
-    registerDevtoolsTools(api, logger);
+    // Register every tool as `optional: true` so per-agent allowlists actually
+    // scope them: non-optional plugin tools bypass allowlists and become visible
+    // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
+    // a tool name, the plugin id ("zoomwarriorssupportbot"), or "group:plugins" see them.
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    registerZwsTools(optionalApi, logger);
+    registerGhTools(optionalApi, logger, pluginConfig);
+    registerCorrelationTools(optionalApi, logger, pluginConfig);
+    registerDevtoolsTools(optionalApi, logger);
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -651,28 +651,6 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.originatingChannel).toBe(channel);
   });
 
-  it("derives channel memory scope from GroupSubject when ChannelSlug is missing", async () => {
-    await runPreparedReply(
-      baseParams({
-        sessionCtx: {
-          Body: "",
-          BodyStripped: "",
-          MediaPath: "/tmp/input.png",
-          Provider: "zoom",
-          ChatType: "channel",
-          GroupSubject: "Test Customer",
-          GroupChannel: "a04c5d88d32d4ba3a3949fd6e5929d5b@conference.xmpp.zoom.us",
-          OriginatingChannel: "zoom",
-          OriginatingTo: "a04c5d88d32d4ba3a3949fd6e5929d5b@conference.xmpp.zoom.us",
-        },
-      }),
-    );
-
-    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
-    expect(call?.followupRun.run.channelSlug).toBe("test-customer");
-    expect(call?.followupRun.run.defaultMemoryScope).toBe("channel");
-  });
-
   it("keeps thread history context on follow-up turns", async () => {
     const result = await runPreparedReply(
       baseParams({


### PR DESCRIPTION
## Summary

Two changes from the hub-and-spoke fleet rollout (path B, measure-gated), landing on top of the merged confirm-gate work (#42).

### 1. Optional-tool scoping for the 4 support bots (`feat`)
`bigheadbot`, `pulsebot`, `zoomwarriorssupportbot`, `cloudflow-support` now wrap `api` in an `optionalApi` (`{ ...api, registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }) }`) and route every `register*Tools` call through it — mirroring `scopelybot`.

Why: non-optional plugin tools **bypass per-agent allowlists** and leak into *every* agent's menu (open-mode agents like `main` were carrying ~84 unrelated bot tools). With `optional: true`, a tool is visible only to agents whose `tools.allow` names the tool, the plugin id, or `group:plugins` (enforced by `isOptionalToolAllowed`, `src/plugins/tools.ts`). Each bot's own agent already has an explicit `tools.allow`, so the bots are unaffected.

Adds `extensions/<bot>/index.test.ts` per bot asserting every `registerTool` call carries `optional: true`.

### 2. Channel-scoped memory test relocation (`test`)
The `fc7f96c826` merge re-implemented channel-scoped memory: `resolveCwChannelSlug()` (memory-core) derives the customer slug from `session.subject`, replacing the removed `run.channelSlug` producer. This removes the stale `get-reply-run.media-only.test.ts` assertion on the old fields and adds real coverage at the owner (`memory-core/src/tools.test.ts`: `memory_search` runs `scope=channel`/`channelSlug` from `session.subject`; `global` when no subject). Adds `scope`/`channelSlug` to the mock `SearchImpl` type.

## Verification
- `node scripts/run-vitest.mjs` on the 4 bot `index.test.ts` + `memory-core/src/tools.test.ts`: **4 + 17 passed**.
- Baseline routing measurement (noob-root, genie phrasing): 34/38 (89%) — confirms **no coordinator/spoke split needed** for any of the 4 bots; optional-scoping is the leverage win, not a split.

## Deploy note
Optional-scoping requires each bot's agent `tools.allow` to name its tools (or the plugin id). Verified on noob-root: 3 bots were each missing one registered tool from `allow` (`bh_devtools_list_databases`, `gh_close_issue`, `zws_devtools_list_databases`) — paired by adding each bot's plugin id to its allowlist before restart.
