### PR TITLE
fix(bots): close gh/cli shell command injection across the support-bot fleet

### DIFF
--- a/extensions/bigheadbot/src/correlation-tools.ts
+++ b/extensions/bigheadbot/src/correlation-tools.ts
@@ -1,16 +1,21 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./bh-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./bh-api.js";
 
-const DEVTOOLS_BASE = () => process.env.BIGHEAD_DEVTOOLS_API_URL ?? "http://bighead-devtools-api:9100";
+const DEVTOOLS_BASE = () =>
+  process.env.BIGHEAD_DEVTOOLS_API_URL ?? "http://bighead-devtools-api:9100";
 const DEVTOOLS_TOKEN = () => process.env.BIGHEAD_DEV_TOOLS_API ?? process.env.DEV_TOOLS_API ?? "";
 
 type PluginConfig = { bhRepos?: string[] };
 
-export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+export function registerCorrelationTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  config: PluginConfig,
+) {
   api.registerTool(() =>
     wrapToolWithAudit(
       {
@@ -20,9 +25,20 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
           "Searches Docker logs via devtools API and GH issues for matching patterns, then returns correlated results.",
         parameters: Type.Object({
           pattern: Type.String({ description: "Error pattern or message to search for" }),
-          container: Type.Optional(Type.String({ description: "Container name to search logs in (default: searches Bighead containers)" })),
-          since: Type.Optional(Type.String({ description: "Log time range start (e.g. '1h', '2024-01-01T00:00:00Z')" })),
-          tail: Type.Optional(Type.Number({ description: "Number of log lines to search (default 500)" })),
+          container: Type.Optional(
+            Type.String({
+              description:
+                "Container name to search logs in (default: searches Bighead containers)",
+            }),
+          ),
+          since: Type.Optional(
+            Type.String({
+              description: "Log time range start (e.g. '1h', '2024-01-01T00:00:00Z')",
+            }),
+          ),
+          tail: Type.Optional(
+            Type.Number({ description: "Number of log lines to search (default 500)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
@@ -36,7 +52,9 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
             const token = DEVTOOLS_TOKEN();
             if (token) {
               const qs = new URLSearchParams({ tail: String(tail) });
-              if (since) qs.set("since", since);
+              if (since) {
+                qs.set("since", since);
+              }
               try {
                 const resp = await fetch(
                   `${DEVTOOLS_BASE()}/api/v1/containers/${encodeURIComponent(container)}/logs?${qs}`,
@@ -44,7 +62,8 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
                 );
                 if (resp.ok) {
                   const data = (await resp.json()) as { logs?: string };
-                  const logText = typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
+                  const logText =
+                    typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
                   const lines = logText.split("\n");
                   const lowerPattern = pattern.toLowerCase();
                   logMatches = lines.filter((l: string) => l.toLowerCase().includes(lowerPattern));
@@ -58,9 +77,21 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
             let ghMatches: unknown = [];
             try {
               const repo = (config.bhRepos ?? ["cloudwarriors-ai/bighead"])[0];
-              const query = pattern.replace(/"/g, '\\"').slice(0, 100);
-              const result = execSync(
-                `gh search issues "${query}" --repo ${repo} --limit 10 --json number,title,state,labels,createdAt`,
+              const query = pattern.slice(0, 100);
+              // Explicit argv (NO shell): the LLM-controlled query is passed literally.
+              const result = execFileSync(
+                "gh",
+                [
+                  "search",
+                  "issues",
+                  query,
+                  "--repo",
+                  repo,
+                  "--limit",
+                  "10",
+                  "--json",
+                  "number,title,state,labels,createdAt",
+                ],
                 {
                   encoding: "utf-8",
                   timeout: 15000,

--- a/extensions/bigheadbot/src/gh-tools.test.ts
+++ b/extensions/bigheadbot/src/gh-tools.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the shell boundary so no real `gh` command ever runs and we can assert
-// exactly when (stage vs confirm) a mutation would fire.
-const execSyncMock = vi.fn();
-vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
+// Mock the process boundary so no real `gh` command ever runs and we can assert
+// exactly when (stage vs confirm) a mutation fires AND that LLM-controlled values
+// reach gh as literal argv elements (execFileSync = no shell), never a shell string.
+const execFileSyncMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
 
 vi.mock("./bh-api.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
@@ -67,9 +70,18 @@ function codeFromDelivery(): string | undefined {
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given subcommand token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
 describe("bigheadbot gh writes are confirm-gated", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendBigheadTextMock.mockReset();
     process.env.BIGHEADBOT_ZOOM_CHANNEL = CHANNEL;
   });
@@ -86,16 +98,16 @@ describe("bigheadbot gh writes are confirm-gated", () => {
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
+    expect(execFileSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
     expect(sendBigheadTextMock).toHaveBeenCalledTimes(1);
     expect(sendBigheadTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/bighead/issues/42");
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/bighead/issues/42");
     await tools.bh_gh_create_issue.execute("t", { title: "Crash", body: "x" });
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     const reply = await tryExecuteConfirm({
@@ -104,27 +116,21 @@ describe("bigheadbot gh writes are confirm-gated", () => {
       logger: noopLogger as never,
     });
 
-    const createCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue create"),
-    );
-    expect(createCalls.length).toBe(1);
+    expect(ghArgvContaining("create")).toBeDefined();
     expect(reply).toMatch(/✅ Done/);
     expect(reply).toContain("https://github.com/cloudwarriors-ai/bighead/issues/42");
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("closed");
+    execFileSyncMock.mockReturnValue("closed");
     await tools.bh_gh_close_issue.execute("t", { number: 7 });
     // Stage time: nothing shells out (not even the issue-view read inside the closure).
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
-    const closeCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue close"),
-    );
-    expect(closeCalls.length).toBe(1);
+    expect(ghArgvContaining("close")).toBeDefined();
   });
 
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
@@ -138,6 +144,66 @@ describe("bigheadbot gh writes are confirm-gated", () => {
     );
     expect(res.ok).toBe(false);
     expect(sendBigheadTextMock).not.toHaveBeenCalled();
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("bigheadbot gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    sendBigheadTextMock.mockReset();
+    process.env.BIGHEADBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.BIGHEADBOT_ZOOM_CHANNEL;
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.bh_gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.bh_gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    // The query is a single argv element, passed verbatim — not escaped, not split,
+    // not quote-wrapped. execFileSync gives it no shell, so it cannot be expanded.
+    expect(argv).toContain(malicious);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.bh_gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.bh_gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("create passes a metachar title as a verbatim argv element after CONFIRM", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/bighead/issues/42");
+    const title = 'Crash "$(rm -rf /)" `id`';
+    await tools.bh_gh_create_issue.execute("t", { title, body: "x" });
+    const code = codeFromDelivery();
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    const argv = ghArgvContaining("create");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(title); // verbatim, unescaped
   });
 });

--- a/extensions/bigheadbot/src/gh-tools.ts
+++ b/extensions/bigheadbot/src/gh-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -28,8 +28,12 @@ function assertAllowedRepo(repo: string, config: PluginConfig) {
   }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -39,6 +43,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 type GhIssueLike = {
@@ -94,12 +129,23 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
-            const labelFlag = params.label ? ` --label "${params.label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(typeof params.label === "string" && params.label
+                ? ["--label", params.label]
+                : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -127,9 +173,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const data = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]) as GhIssueLike;
             const stakeholders = extractStakeholdersFromIssue(data);
             return jsonResult({ ok: true, data, stakeholders });
           } catch (err) {
@@ -174,16 +227,27 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
             return await stageWrite(summary, async () => {
               const labels = params.labels as string[] | undefined;
-              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-              const bodyStr = String(params.body ?? "");
+              const bodyStr = typeof params.body === "string" ? params.body : "";
+              const title = typeof params.title === "string" ? params.title : "";
               const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
               const stakeholders = Array.isArray(params.stakeholders)
                 ? (params.stakeholders as string[])
                 : [];
               const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-              const result = execSync(
-                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                [
+                  "issue",
+                  "create",
+                  "--repo",
+                  repo,
+                  "--title",
+                  title,
+                  ...(labels?.length ? ["--label", labels.join(",")] : []),
+                  "--body-file",
+                  "-",
+                ],
                 {
                   encoding: "utf-8",
                   input: enrichedBody,
@@ -196,12 +260,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
 
               if (issueNumber) {
                 const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                  encoding: "utf-8",
-                  input: metadataComment,
-                  timeout: 30000,
-                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                });
+                execFileSync(
+                  "gh",
+                  ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                  {
+                    encoding: "utf-8",
+                    input: metadataComment,
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                );
               }
 
               return {
@@ -243,21 +311,29 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            const issueNumber = assertIssueNumber(params.number);
+            const summary = `add comment to issue #${issueNumber} in ${repo}`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-              const originalBody = String(params.body ?? "");
+              const originalBody = typeof params.body === "string" ? params.body : "";
               const body =
                 prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
                   ? `${prefix}\n\n${originalBody}`
                   : originalBody;
 
-              const result = execSync(
-                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                 {
                   encoding: "utf-8",
                   input: body,
@@ -301,11 +377,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -339,30 +423,41 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
             const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
               if (closingComment || prefix) {
                 const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
                 if (commentBody) {
-                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                    encoding: "utf-8",
-                    input: commentBody,
-                    timeout: 30000,
-                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  });
+                  execFileSync(
+                    "gh",
+                    ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                    {
+                      encoding: "utf-8",
+                      input: commentBody,
+                      timeout: 30000,
+                      env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                    },
+                  );
                 }
               }
 
-              const closeOutput = execSync(
-                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+              const closeOutput = execFileSync(
+                "gh",
+                ["issue", "close", String(issueNumber), "--repo", repo, "--reason", closeReason],
                 {
                   encoding: "utf-8",
                   timeout: 30000,

--- a/extensions/cloudflow-support/src/cf-ops-tools.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -275,10 +276,21 @@ export function registerCfOpsTools(api: OpenClawPluginApi, logger: AuditLogger) 
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const { execSync } = await import("child_process");
-            const limit = (params.limit as number) || 5;
-            const result = execSync(
-              `gh run list --repo cloudwarriors-ai/cloudflow --limit ${limit} --json databaseId,displayTitle,status,conclusion,createdAt,updatedAt,headBranch`,
+            const rawLimit = typeof params.limit === "number" ? params.limit : Number(params.limit);
+            const limit = Number.isInteger(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 100) : 5;
+            // Explicit argv (NO shell): the LLM-controlled limit is a literal argv element.
+            const result = execFileSync(
+              "gh",
+              [
+                "run",
+                "list",
+                "--repo",
+                "cloudwarriors-ai/cloudflow",
+                "--limit",
+                String(limit),
+                "--json",
+                "databaseId,displayTitle,status,conclusion,createdAt,updatedAt,headBranch",
+              ],
               {
                 encoding: "utf-8",
                 timeout: 30000,

--- a/extensions/cloudflow-support/src/gh-tools.test.ts
+++ b/extensions/cloudflow-support/src/gh-tools.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the shell boundary so no real `gh` command ever runs and we can assert
-// exactly when (stage vs confirm) a mutation would fire.
-const execSyncMock = vi.fn();
-vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
+// Mock the process boundary so no real `gh` command ever runs and we can assert
+// exactly when (stage vs confirm) a mutation fires AND that LLM-controlled values
+// reach gh as literal argv elements (execFileSync = no shell), never a shell string.
+const execFileSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
 
 vi.mock("./helpers.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
@@ -68,21 +71,30 @@ function codeFromDelivery(): string | undefined {
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given subcommand token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
 describe("cloudflow gh reads", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendCfTextMock.mockReset();
   });
 
   it("list_issues returns parsed issue data (no staging)", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue(
+    execFileSyncMock.mockReturnValue(
       JSON.stringify([{ number: 42, title: "Deploy broke", state: "open" }]),
     );
     const payload = parse(await tools.cf_gh_list_issues.execute("t", { state: "open", limit: 1 }));
     expect(payload.ok).toBe(true);
     expect((payload.data as Array<Record<string, unknown>>)[0]?.number).toBe(42);
-    expect(String(execSyncMock.mock.calls[0]?.[0])).toContain("gh issue list");
+    expect(ghArgvContaining("list")).toBeDefined();
     expect(sendCfTextMock).not.toHaveBeenCalled();
   });
 
@@ -93,13 +105,13 @@ describe("cloudflow gh reads", () => {
     );
     expect(payload.ok).toBe(false);
     expect(String(payload.error)).toContain("not in allowed list");
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });
 
 describe("cloudflow gh writes are confirm-gated", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendCfTextMock.mockReset();
     process.env.CF_ZOOM_CHANNEL = CHANNEL;
   });
@@ -115,16 +127,16 @@ describe("cloudflow gh writes are confirm-gated", () => {
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(sendCfTextMock).toHaveBeenCalledTimes(1);
     expect(sendCfTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/cloudflow/issues/42");
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/cloudflow/issues/42");
     await tools.cf_gh_create_issue.execute("t", { title: "Deploy broke", body: "x" });
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     const reply = await tryExecuteConfirm({
@@ -133,25 +145,19 @@ describe("cloudflow gh writes are confirm-gated", () => {
       logger: noopLogger as never,
     });
 
-    const createCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue create"),
-    );
-    expect(createCalls.length).toBe(1);
+    expect(ghArgvContaining("create")).toBeDefined();
     expect(reply).toMatch(/✅ Done/);
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("closed");
+    execFileSyncMock.mockReturnValue("closed");
     await tools.cf_gh_close_issue.execute("t", { number: 7 });
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
-    const closeCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue close"),
-    );
-    expect(closeCalls.length).toBe(1);
+    expect(ghArgvContaining("close")).toBeDefined();
   });
 
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
@@ -161,6 +167,52 @@ describe("cloudflow gh writes are confirm-gated", () => {
     );
     expect(res.ok).toBe(false);
     expect(sendCfTextMock).not.toHaveBeenCalled();
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("cloudflow gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    sendCfTextMock.mockReset();
+    process.env.CF_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.CF_ZOOM_CHANNEL;
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.cf_gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.cf_gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(malicious);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.cf_gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.cf_gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/cloudflow-support/src/gh-tools.ts
+++ b/extensions/cloudflow-support/src/gh-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -23,12 +23,17 @@ function getAllowedRepos(config: PluginConfig): string[] {
 
 function assertAllowedRepo(repo: string, config: PluginConfig) {
   const allowed = getAllowedRepos(config);
-  if (!allowed.includes(repo))
+  if (!allowed.includes(repo)) {
     throw new Error(`Repo "${repo}" not in allowed list: ${allowed.join(", ")}`);
+  }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -38,6 +43,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 type GhIssueLike = {
@@ -92,12 +128,23 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
-            const labelFlag = params.label ? ` --label "${params.label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(typeof params.label === "string" && params.label
+                ? ["--label", params.label]
+                : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -122,9 +169,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const data = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]) as GhIssueLike;
             const stakeholders = extractStakeholdersFromIssue(data);
             return jsonResult({ ok: true, data, stakeholders });
           } catch (err) {
@@ -158,17 +212,31 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
             return await stageWrite(summary, async () => {
               const labels = params.labels as string[] | undefined;
-              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+              const title = typeof params.title === "string" ? params.title : "";
               const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
               const stakeholders = Array.isArray(params.stakeholders)
                 ? (params.stakeholders as string[])
                 : [];
-              const enrichedBody = upsertStakeholderBlock(String(params.body ?? ""), {
-                reporter,
-                stakeholders,
-              });
-              const result = execSync(
-                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              const enrichedBody = upsertStakeholderBlock(
+                typeof params.body === "string" ? params.body : "",
+                {
+                  reporter,
+                  stakeholders,
+                },
+              );
+              const result = execFileSync(
+                "gh",
+                [
+                  "issue",
+                  "create",
+                  "--repo",
+                  repo,
+                  "--title",
+                  title,
+                  ...(labels?.length ? ["--label", labels.join(",")] : []),
+                  "--body-file",
+                  "-",
+                ],
                 {
                   encoding: "utf-8",
                   input: enrichedBody,
@@ -179,12 +247,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
               const url = result.trim();
               const issueNumber = parseIssueNumberFromUrl(url);
               if (issueNumber) {
-                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                  encoding: "utf-8",
-                  input: formatStakeholderBlock({ reporter, stakeholders }),
-                  timeout: 30000,
-                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                });
+                execFileSync(
+                  "gh",
+                  ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                  {
+                    encoding: "utf-8",
+                    input: formatStakeholderBlock({ reporter, stakeholders }),
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                );
               }
               return {
                 ok: true,
@@ -221,20 +293,28 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            const issueNumber = assertIssueNumber(params.number);
+            const summary = `add comment to issue #${issueNumber} in ${repo}`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-              const originalBody = String(params.body ?? "");
+              const originalBody = typeof params.body === "string" ? params.body : "";
               const body =
                 prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
                   ? `${prefix}\n\n${originalBody}`
                   : originalBody;
-              const result = execSync(
-                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                 {
                   encoding: "utf-8",
                   input: body,
@@ -275,11 +355,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -307,28 +395,40 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
             const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
               if (closingComment || prefix) {
                 const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
-                if (commentBody)
-                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                    encoding: "utf-8",
-                    input: commentBody,
-                    timeout: 30000,
-                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  });
+                if (commentBody) {
+                  execFileSync(
+                    "gh",
+                    ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                    {
+                      encoding: "utf-8",
+                      input: commentBody,
+                      timeout: 30000,
+                      env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                    },
+                  );
+                }
               }
-              const closeOutput = execSync(
-                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+              const closeOutput = execFileSync(
+                "gh",
+                ["issue", "close", String(issueNumber), "--repo", repo, "--reason", closeReason],
                 {
                   encoding: "utf-8",
                   timeout: 30000,
@@ -355,8 +455,11 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
               const notifyErrors: Array<{ stakeholder: string; error: string }> = [];
               for (const target of uniqueTargets) {
                 const r = await sendStakeholderZoomDm({ toContact: target, message: dmMessage });
-                if (r.ok) notified.push(target);
-                else notifyErrors.push({ stakeholder: target, error: r.error ?? "unknown" });
+                if (r.ok) {
+                  notified.push(target);
+                } else {
+                  notifyErrors.push({ stakeholder: target, error: r.error ?? "unknown" });
+                }
               }
               return {
                 ok: true,

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.ts
@@ -1,14 +1,17 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./helpers.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./helpers.js";
 
 const EOA_ROOT = "/root/code/external-org-autopilot";
 
-function eoa(args: string, timeoutMs = 120000): unknown {
-  const result = execSync(`npx tsx src/cli.ts ${args}`, {
+// Run the EOA CLI with an explicit argv (NO shell): `npx tsx src/cli.ts <args...>`.
+// Each arg is passed literally, so LLM-controlled paths/ids cannot be interpreted as
+// shell syntax. Never reintroduce a shell string here.
+function eoa(args: string[], timeoutMs = 120000): unknown {
+  const result = execFileSync("npx", ["tsx", "src/cli.ts", ...args], {
     encoding: "utf-8",
     cwd: EOA_ROOT,
     timeout: timeoutMs,
@@ -19,6 +22,17 @@ function eoa(args: string, timeoutMs = 120000): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// Coerce an LLM-supplied param to a safe argv element (empty if absent/object).
+function argStr(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
 }
 
 export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger) {
@@ -33,7 +47,7 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`release validate ${params.releasePath}`);
+            const data = eoa(["release", "validate", argStr(params.releasePath)]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -56,7 +70,13 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`release lock ${params.releasePath} --out ${params.outPath}`);
+            const data = eoa([
+              "release",
+              "lock",
+              argStr(params.releasePath),
+              "--out",
+              argStr(params.outPath),
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -72,14 +92,18 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_onboard_project",
-        description: "Onboard a new customer project. Takes a release JSON and onboarding YAML. Returns {customerRepo, mirrorRepo}.",
+        description:
+          "Onboard a new customer project. Takes a release JSON and onboarding YAML. Returns {customerRepo, mirrorRepo}.",
         parameters: Type.Object({
           releasePath: Type.String({ description: "Path to the release JSON contract" }),
           onboardingPath: Type.String({ description: "Path to the onboarding YAML contract" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`customer onboard ${params.releasePath} ${params.onboardingPath}`, 300000);
+            const data = eoa(
+              ["customer", "onboard", argStr(params.releasePath), argStr(params.onboardingPath)],
+              300000,
+            );
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -101,7 +125,7 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`customer doctor ${params.customerRepoId}`);
+            const data = eoa(["customer", "doctor", argStr(params.customerRepoId)]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -117,13 +141,14 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_sync",
-        description: "Pull latest from customer repo. Returns {sourceSha, shadowMainSha, driftDetected}.",
+        description:
+          "Pull latest from customer repo. Returns {sourceSha, shadowMainSha, driftDetected}.",
         parameters: Type.Object({
           customerRepoId: Type.String({ description: "Customer repo UUID" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`sync pull ${params.customerRepoId}`, 180000);
+            const data = eoa(["sync", "pull", argStr(params.customerRepoId)], 180000);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -139,14 +164,20 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_ingest_issue",
-        description: "Ingest a single issue from the customer repo. Returns {issueMirrorId, baselineSha}.",
+        description:
+          "Ingest a single issue from the customer repo. Returns {issueMirrorId, baselineSha}.",
         parameters: Type.Object({
           customerRepoId: Type.String({ description: "Customer repo UUID" }),
           issueNumber: Type.Number({ description: "GitHub issue number to ingest" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`issue ingest ${params.customerRepoId} ${params.issueNumber}`);
+            const data = eoa([
+              "issue",
+              "ingest",
+              argStr(params.customerRepoId),
+              argStr(params.issueNumber),
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -169,8 +200,15 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const limitFlag = params.limit ? ` --limit ${params.limit}` : "";
-            const data = eoa(`issue ingest-batch ${params.customerRepoId}${limitFlag}`, 300000);
+            const data = eoa(
+              [
+                "issue",
+                "ingest-batch",
+                argStr(params.customerRepoId),
+                ...(params.limit != null ? ["--limit", argStr(params.limit)] : []),
+              ],
+              300000,
+            );
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -192,7 +230,7 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`run execute ${params.issueMirrorId} --detach`, 300000);
+            const data = eoa(["run", "execute", argStr(params.issueMirrorId), "--detach"], 300000);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -214,7 +252,7 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`run resume ${params.runId}`, 300000);
+            const data = eoa(["run", "resume", argStr(params.runId)], 300000);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -239,7 +277,14 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const data = eoa(
-              `smoke run ${params.releasePath} ${params.onboardingPath} ${params.issueNumber} --detach`,
+              [
+                "smoke",
+                "run",
+                argStr(params.releasePath),
+                argStr(params.onboardingPath),
+                argStr(params.issueNumber),
+                "--detach",
+              ],
               600000,
             );
             return jsonResult({ ok: true, data });
@@ -263,7 +308,7 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const data = eoa(`report generate ${params.customerRepoId}`, 180000);
+            const data = eoa(["report", "generate", argStr(params.customerRepoId)], 180000);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);

--- a/extensions/external-org-autopilot/src/eoa-state-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-state-tools.ts
@@ -1,13 +1,41 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { Type } from "@sinclair/typebox";
-import * as fs from "fs";
-import * as path from "path";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./helpers.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./helpers.js";
 
 const STATE_DIR = "/root/code/external-org-autopilot/.autopilot-state";
+
+// GitHub Actions run IDs are numeric. Validate so the value is a sane argv element.
+function assertRunId(value: unknown): string {
+  const s =
+    typeof value === "string" ? value.trim() : typeof value === "number" ? String(value) : "";
+  if (!/^\d+$/.test(s)) {
+    throw new Error(`Invalid workflow run ID: ${JSON.stringify(value)}`);
+  }
+  return s;
+}
+
+// owner/name. Reject anything that could alter a gh api path (extra slashes, traversal).
+function assertRepoSlug(value: unknown): string {
+  const s = typeof value === "string" ? value.trim() : "";
+  if (!/^[\w.-]+\/[\w.-]+$/.test(s)) {
+    throw new Error(`Invalid repo "${s}": expected owner/name.`);
+  }
+  return s;
+}
+
+// 7-40 char hex commit SHA. Reject anything that could alter the gh api path.
+function assertCommitSha(value: unknown): string {
+  const s = typeof value === "string" ? value.trim() : "";
+  if (!/^[0-9a-fA-F]{7,40}$/.test(s)) {
+    throw new Error(`Invalid commit SHA: ${JSON.stringify(value)}`);
+  }
+  return s;
+}
 
 export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogger) {
   // eoa_list_runs
@@ -17,7 +45,9 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         name: "eoa_list_runs",
         description: "List all autopilot runs. Optionally filter by mirrorRepoId.",
         parameters: Type.Object({
-          mirrorRepoId: Type.Optional(Type.String({ description: "Filter runs by mirror repo UUID" })),
+          mirrorRepoId: Type.Optional(
+            Type.String({ description: "Filter runs by mirror repo UUID" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
@@ -79,7 +109,8 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "eoa_get_evidence",
-        description: "Read a full evidence bundle by ID. Contains verdict, validation summary, runtime evidence, worker summary, and artifact links.",
+        description:
+          "Read a full evidence bundle by ID. Contains verdict, validation summary, runtime evidence, worker summary, and artifact links.",
         parameters: Type.Object({
           bundleId: Type.String({ description: "Evidence bundle UUID" }),
         }),
@@ -87,7 +118,10 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
           try {
             const filePath = path.join(STATE_DIR, "evidence-bundles", `${params.bundleId}.json`);
             if (!fs.existsSync(filePath)) {
-              return jsonResult({ ok: false, error: `Evidence bundle ${params.bundleId} not found` });
+              return jsonResult({
+                ok: false,
+                error: `Evidence bundle ${params.bundleId} not found`,
+              });
             }
             const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
             return jsonResult({ ok: true, data });
@@ -105,19 +139,27 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
     wrapToolWithAudit(
       {
         name: "eoa_get_workflow_status",
-        description: "Check a GitHub Actions workflow run status. Returns status, conclusion, and jobs.",
+        description:
+          "Check a GitHub Actions workflow run status. Returns status, conclusion, and jobs.",
         parameters: Type.Object({
           workflowRunId: Type.String({ description: "GitHub Actions workflow run ID" }),
           repo: Type.String({ description: "Shadow repo (owner/name) from the run JSON." }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const repo = params.repo as string;
-            if (!repo) {
-              return jsonResult({ ok: false, error: "repo is required (shadow repo from run JSON)" });
-            }
-            const result = execSync(
-              `gh run view ${params.workflowRunId} --repo ${repo} --json status,conclusion,jobs,name,createdAt,updatedAt`,
+            const repo = assertRepoSlug(params.repo);
+            const runId = assertRunId(params.workflowRunId);
+            const result = execFileSync(
+              "gh",
+              [
+                "run",
+                "view",
+                runId,
+                "--repo",
+                repo,
+                "--json",
+                "status,conclusion,jobs,name,createdAt,updatedAt",
+              ],
               {
                 encoding: "utf-8",
                 timeout: 30000,
@@ -147,17 +189,19 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = execSync(
-              `gh run view ${params.workflowRunId} --repo ${params.repo} --log`,
-              {
-                encoding: "utf-8",
-                timeout: 60000,
-                maxBuffer: 10 * 1024 * 1024,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
+            const repo = assertRepoSlug(params.repo);
+            const runId = assertRunId(params.workflowRunId);
+            const result = execFileSync("gh", ["run", "view", runId, "--repo", repo, "--log"], {
+              encoding: "utf-8",
+              timeout: 60000,
+              maxBuffer: 10 * 1024 * 1024,
+              env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+            });
             // Truncate if very large
-            const output = result.length > 50000 ? result.slice(-50000) + "\n...[truncated to last 50k chars]" : result;
+            const output =
+              result.length > 50000
+                ? result.slice(-50000) + "\n...[truncated to last 50k chars]"
+                : result;
             return jsonResult({ ok: true, data: output });
           } catch (err) {
             return errorResult(err);
@@ -180,8 +224,18 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const result = execSync(
-              `gh api repos/${params.repo}/commits/${params.sha} --jq '.files[] | {filename, status, additions, deletions, patch}'`,
+            const repo = assertRepoSlug(params.repo);
+            const sha = assertCommitSha(params.sha);
+            // argv: the path is one literal element and --jq gets the expression
+            // verbatim (the shell single-quotes were quoting, not part of the value).
+            const result = execFileSync(
+              "gh",
+              [
+                "api",
+                `repos/${repo}/commits/${sha}`,
+                "--jq",
+                ".files[] | {filename, status, additions, deletions, patch}",
+              ],
               {
                 encoding: "utf-8",
                 timeout: 30000,

--- a/extensions/external-org-autopilot/src/gh-tools.test.ts
+++ b/extensions/external-org-autopilot/src/gh-tools.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the process boundary so no real `gh` command ever runs and we can assert that
+// LLM-controlled values reach gh as literal argv elements (execFileSync = no shell),
+// never a shell string. external-org-autopilot gh writes are NOT confirm-gated — they
+// execute immediately — so injection safety here rests entirely on argv (no shell).
+const execFileSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+vi.mock("./helpers.js", () => ({
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+// Stakeholder/DM helpers are not under test here — stub to no-ops.
+vi.mock("./stakeholders.js", () => ({
+  buildStakeholderWorkPrefix: () => "",
+  extractStakeholdersFromIssue: () => ({ stakeholders: [], reporter: undefined }),
+  formatStakeholderBlock: () => "",
+  parseIssueNumberFromUrl: () => 42,
+  resolveStakeholderDmTarget: () => undefined,
+  upsertStakeholderBlock: (body: string) => body,
+}));
+vi.mock("./zoom-dm.js", () => ({ sendStakeholderZoomDm: async () => ({ ok: true }) }));
+
+import { registerGhTools } from "./gh-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const REPO = "cloudwarriors-ai/external-org-autopilot";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerGhTools(api, noopLogger as never, { eoaRepos: [REPO] });
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
+describe("external-org-autopilot gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.eoa_gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.eoa_gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(malicious);
+  });
+
+  it("create passes a metachar title as ONE verbatim argv element (executes immediately)", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue(
+      "https://github.com/cloudwarriors-ai/external-org-autopilot/issues/9",
+    );
+    const title = 'Crash "$(rm -rf /)" `id`';
+    await tools.eoa_gh_create_issue.execute("t", { title, body: "x" });
+    const argv = ghArgvContaining("create");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(title);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.eoa_gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.eoa_gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks repositories outside the allowlist (no shell-out)", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.eoa_gh_list_issues.execute("t", { repo: "evil/repo" }));
+    expect(res.ok).toBe(false);
+    expect(String(res.error)).toContain("not in allowed list");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/external-org-autopilot/src/gh-tools.ts
+++ b/extensions/external-org-autopilot/src/gh-tools.ts
@@ -1,9 +1,9 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./helpers.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./helpers.js";
 import {
   buildStakeholderWorkPrefix,
   extractStakeholdersFromIssue,
@@ -27,8 +27,12 @@ function assertAllowedRepo(repo: string, config: PluginConfig) {
   }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -38,6 +42,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 type GhIssueLike = {
@@ -77,10 +112,15 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "eoa_gh_list_issues",
-        description: "List GitHub issues from the external-org-autopilot repo. Returns title, number, state, labels, assignees.",
+        description:
+          "List GitHub issues from the external-org-autopilot repo. Returns title, number, state, labels, assignees.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
-          state: Type.Optional(Type.String({ description: "Filter: open, closed, all (default: open)" })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
+          state: Type.Optional(
+            Type.String({ description: "Filter: open, closed, all (default: open)" }),
+          ),
           label: Type.Optional(Type.String({ description: "Filter by label" })),
           limit: Type.Optional(Type.Number({ description: "Max results (default 30)" })),
         }),
@@ -88,12 +128,23 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
-            const labelFlag = params.label ? ` --label "${params.label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(typeof params.label === "string" && params.label
+                ? ["--label", params.label]
+                : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -109,18 +160,28 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "eoa_gh_get_issue",
-        description: "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
+        description:
+          "Get details of a specific GitHub issue including comments and parsed stakeholder metadata.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const data = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]) as GhIssueLike;
             const stakeholders = extractStakeholdersFromIssue(data);
             return jsonResult({ ok: true, data, stakeholders });
           } catch (err) {
@@ -137,9 +198,12 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "eoa_gh_create_issue",
-        description: "Create a new GitHub issue in the EOA repo. Persists reporter/stakeholders in a metadata block.",
+        description:
+          "Create a new GitHub issue in the EOA repo. Persists reporter/stakeholders in a metadata block.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
           title: Type.String({ description: "Issue title" }),
           body: Type.String({ description: "Issue body (markdown)" }),
           labels: Type.Optional(Type.Array(Type.String(), { description: "Labels to apply" })),
@@ -155,16 +219,27 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
             const labels = params.labels as string[] | undefined;
-            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-            const bodyStr = String(params.body ?? "");
+            const title = typeof params.title === "string" ? params.title : "";
+            const bodyStr = typeof params.body === "string" ? params.body : "";
             const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
             const stakeholders = Array.isArray(params.stakeholders)
               ? (params.stakeholders as string[])
               : [];
             const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-            const result = execSync(
-              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+            const result = execFileSync(
+              "gh",
+              [
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                ...(labels?.length ? ["--label", labels.join(",")] : []),
+                "--body-file",
+                "-",
+              ],
               {
                 encoding: "utf-8",
                 input: enrichedBody,
@@ -177,8 +252,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
 
             if (issueNumber) {
               const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-              execSync(
-                `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+              execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                 {
                   encoding: "utf-8",
                   input: metadataComment,
@@ -210,9 +286,12 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "eoa_gh_add_comment",
-        description: "Add a comment to an existing GitHub issue. Auto-mentions stored stakeholders.",
+        description:
+          "Add a comment to an existing GitHub issue. Auto-mentions stored stakeholders.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
           body: Type.String({ description: "Comment body (markdown)" }),
         }),
@@ -220,19 +299,27 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const issue = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const issue = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,assignees,comments",
+            ]) as GhIssueLike;
             const extracted = extractStakeholdersFromIssue(issue);
             const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-            const originalBody = String(params.body ?? "");
+            const originalBody = typeof params.body === "string" ? params.body : "";
             const body =
               prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
                 ? `${prefix}\n\n${originalBody}`
                 : originalBody;
 
-            const result = execSync(
-              `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+            const result = execFileSync(
+              "gh",
+              ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
               {
                 encoding: "utf-8",
                 input: body,
@@ -263,18 +350,28 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
         description: "Search GitHub issues by keyword in external-org-autopilot repos.",
         parameters: Type.Object({
           query: Type.String({ description: "Search query" }),
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
           limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -290,31 +387,45 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
     wrapToolWithAudit(
       {
         name: "eoa_gh_close_issue",
-        description: "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
+        description:
+          "Close a GitHub issue, mention stakeholders in a closing comment, and DM stakeholders on Zoom.",
         parameters: Type.Object({
-          repo: Type.Optional(Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." })),
+          repo: Type.Optional(
+            Type.String({ description: "Repo (owner/name). Defaults to primary EOA repo." }),
+          ),
           number: Type.Number({ description: "Issue number" }),
-          comment: Type.Optional(Type.String({ description: "Closing update comment to post before close." })),
-          reason: Type.Optional(Type.String({ description: "Close reason: completed or not_planned." })),
+          comment: Type.Optional(
+            Type.String({ description: "Closing update comment to post before close." }),
+          ),
+          reason: Type.Optional(
+            Type.String({ description: "Close reason: completed or not_planned." }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
 
-            const issue = gh(
-              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-            ) as GhIssueLike;
+            const issue = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,assignees,comments",
+            ]) as GhIssueLike;
             const extracted = extractStakeholdersFromIssue(issue);
             const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
             if (closingComment || prefix) {
               const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
               if (commentBody) {
-                execSync(
-                  `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+                execFileSync(
+                  "gh",
+                  ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                   {
                     encoding: "utf-8",
                     input: commentBody,
@@ -325,8 +436,9 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
               }
             }
 
-            const closeOutput = execSync(
-              `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+            const closeOutput = execFileSync(
+              "gh",
+              ["issue", "close", String(issueNumber), "--repo", repo, "--reason", closeReason],
               {
                 encoding: "utf-8",
                 timeout: 30000,

--- a/extensions/pulsebot/src/correlation-tools.test.ts
+++ b/extensions/pulsebot/src/correlation-tools.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { AuditLogger } from "./audit.js";
 import { registerCorrelationTools } from "./correlation-tools.js";
 
-const { execSyncMock } = vi.hoisted(() => ({ execSyncMock: vi.fn() }));
+const { execFileSyncMock } = vi.hoisted(() => ({ execFileSyncMock: vi.fn() }));
 
 vi.mock("child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("child_process")>();
   return {
     ...actual,
-    execSync: execSyncMock,
+    execFileSync: execFileSyncMock,
   };
 });
 
@@ -42,7 +41,7 @@ describe("pulsebot correlation tool", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
     process.env.DEV_TOOLS_API = "test-token";
@@ -65,7 +64,7 @@ describe("pulsebot correlation tool", () => {
       ok: true,
       json: async () => ({ logs: "start\nerror timeout in worker\ndone" }),
     });
-    execSyncMock.mockReturnValue(
+    execFileSyncMock.mockReturnValue(
       JSON.stringify([{ number: 77, title: "Timeout in worker pool", state: "open" }]),
     );
 
@@ -80,7 +79,7 @@ describe("pulsebot correlation tool", () => {
     expect(Array.isArray(payload.ghIssues)).toBe(true);
     expect((payload.ghIssues as Array<Record<string, unknown>>)[0]?.number).toBe(77);
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(execSyncMock).toHaveBeenCalledOnce();
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
   });
 
   it("continues when gh search fails", async () => {
@@ -93,7 +92,7 @@ describe("pulsebot correlation tool", () => {
       ok: true,
       json: async () => ({ logs: "timeout\ntimeout\nok" }),
     });
-    execSyncMock.mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       throw new Error("/bin/sh: 1: gh: not found");
     });
 

--- a/extensions/pulsebot/src/correlation-tools.ts
+++ b/extensions/pulsebot/src/correlation-tools.ts
@@ -1,16 +1,20 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { jsonResult, errorResult } from "./pp-api.js";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { jsonResult, errorResult } from "./pp-api.js";
 
 const DEVTOOLS_BASE = () => process.env.DEVTOOLS_API_URL ?? "https://devtools-api.cloudwarriors.ai";
 const DEVTOOLS_TOKEN = () => process.env.DEV_TOOLS_API ?? "";
 
 type PluginConfig = { ppRepos?: string[] };
 
-export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+export function registerCorrelationTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  config: PluginConfig,
+) {
   api.registerTool(() =>
     wrapToolWithAudit(
       {
@@ -20,9 +24,19 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
           "Searches Docker logs via devtools API and GH issues for matching patterns, then returns correlated results.",
         parameters: Type.Object({
           pattern: Type.String({ description: "Error pattern or message to search for" }),
-          container: Type.Optional(Type.String({ description: "Container name to search logs in (default: searches PP containers)" })),
-          since: Type.Optional(Type.String({ description: "Log time range start (e.g. '1h', '2024-01-01T00:00:00Z')" })),
-          tail: Type.Optional(Type.Number({ description: "Number of log lines to search (default 500)" })),
+          container: Type.Optional(
+            Type.String({
+              description: "Container name to search logs in (default: searches PP containers)",
+            }),
+          ),
+          since: Type.Optional(
+            Type.String({
+              description: "Log time range start (e.g. '1h', '2024-01-01T00:00:00Z')",
+            }),
+          ),
+          tail: Type.Optional(
+            Type.Number({ description: "Number of log lines to search (default 500)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
@@ -36,7 +50,9 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
             const token = DEVTOOLS_TOKEN();
             if (token) {
               const qs = new URLSearchParams({ tail: String(tail) });
-              if (since) qs.set("since", since);
+              if (since) {
+                qs.set("since", since);
+              }
               try {
                 const resp = await fetch(
                   `${DEVTOOLS_BASE()}/api/v1/containers/${encodeURIComponent(container)}/logs?${qs}`,
@@ -44,7 +60,8 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
                 );
                 if (resp.ok) {
                   const data = (await resp.json()) as { logs?: string };
-                  const logText = typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
+                  const logText =
+                    typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
                   const lines = logText.split("\n");
                   const lowerPattern = pattern.toLowerCase();
                   logMatches = lines.filter((l: string) => l.toLowerCase().includes(lowerPattern));
@@ -58,9 +75,21 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
             let ghMatches: unknown = [];
             try {
               const repo = (config.ppRepos ?? ["cloudwarriors-ai/project-pulse"])[0];
-              const query = pattern.replace(/"/g, '\\"').slice(0, 100); // Truncate long patterns
-              const result = execSync(
-                `gh search issues "${query}" --repo ${repo} --limit 10 --json number,title,state,labels,createdAt`,
+              const query = pattern.slice(0, 100);
+              // Explicit argv (NO shell): the LLM-controlled query is passed literally.
+              const result = execFileSync(
+                "gh",
+                [
+                  "search",
+                  "issues",
+                  query,
+                  "--repo",
+                  repo,
+                  "--limit",
+                  "10",
+                  "--json",
+                  "number,title,state,labels,createdAt",
+                ],
                 {
                   encoding: "utf-8",
                   timeout: 15000,
@@ -78,7 +107,7 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
               container,
               logMatches: {
                 count: logMatches.length,
-                lines: logMatches.slice(0, 50), // Cap at 50 matches
+                lines: logMatches.slice(0, 50),
               },
               ghIssues: ghMatches,
             });

--- a/extensions/pulsebot/src/gh-tools.test.ts
+++ b/extensions/pulsebot/src/gh-tools.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the shell boundary so no real `gh` command ever runs and we can assert
-// exactly when (stage vs confirm) a mutation would fire.
-const execSyncMock = vi.fn();
-vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
+// Mock the process boundary so no real `gh` command ever runs and we can assert
+// exactly when (stage vs confirm) a mutation fires AND that LLM-controlled values
+// reach gh as literal argv elements (execFileSync = no shell), never a shell string.
+const execFileSyncMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
 
 vi.mock("./pp-api.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
@@ -68,27 +71,38 @@ function codeFromDelivery(): string | undefined {
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given subcommand token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
 describe("pulsebot gh reads", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendPulseTextMock.mockReset();
   });
 
   it("list_issues returns parsed issue data (no staging)", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue(
+    execFileSyncMock.mockReturnValue(
       JSON.stringify([{ number: 42, title: "OAuth login fails", state: "open" }]),
     );
     const payload = parse(await tools.gh_list_issues.execute("t", { state: "open", limit: 1 }));
     expect(payload.ok).toBe(true);
     expect((payload.data as Array<Record<string, unknown>>)[0]?.number).toBe(42);
-    expect(String(execSyncMock.mock.calls[0]?.[0])).toContain("gh issue list");
+    const argv = ghArgvContaining("list");
+    expect(argv).toBeDefined();
+    expect(argv).toContain("issue");
     expect(sendPulseTextMock).not.toHaveBeenCalled();
   });
 
   it("surfaces gh-not-found errors without throwing", async () => {
     const tools = buildTools();
-    execSyncMock.mockImplementation(() => {
+    execFileSyncMock.mockImplementation(() => {
       throw new Error("/bin/sh: 1: gh: not found");
     });
     const payload = parse(await tools.gh_search_issues.execute("t", { query: "oauth timeout" }));
@@ -103,13 +117,13 @@ describe("pulsebot gh reads", () => {
     );
     expect(payload.ok).toBe(false);
     expect(String(payload.error)).toContain("not in allowed list");
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
   });
 });
 
 describe("pulsebot gh writes are confirm-gated", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendPulseTextMock.mockReset();
     process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
   });
@@ -126,16 +140,16 @@ describe("pulsebot gh writes are confirm-gated", () => {
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
+    expect(execFileSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
     expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
     expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
     await tools.gh_create_issue.execute("t", { title: "Crash", body: "x" });
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     const reply = await tryExecuteConfirm({
@@ -144,26 +158,21 @@ describe("pulsebot gh writes are confirm-gated", () => {
       logger: noopLogger as never,
     });
 
-    const createCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue create"),
-    );
-    expect(createCalls.length).toBe(1);
+    expect(ghArgvContaining("create")).toBeDefined();
     expect(reply).toMatch(/✅ Done/);
+    expect(reply).toContain("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("closed");
+    execFileSyncMock.mockReturnValue("closed");
     await tools.gh_close_issue.execute("t", { number: 7 });
     // Stage time: nothing shells out (not even the issue-view read inside the closure).
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
-    const closeCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue close"),
-    );
-    expect(closeCalls.length).toBe(1);
+    expect(ghArgvContaining("close")).toBeDefined();
   });
 
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
@@ -173,6 +182,66 @@ describe("pulsebot gh writes are confirm-gated", () => {
     );
     expect(res.ok).toBe(false);
     expect(sendPulseTextMock).not.toHaveBeenCalled();
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("pulsebot gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    sendPulseTextMock.mockReset();
+    process.env.PULSEBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.PULSEBOT_ZOOM_CHANNEL;
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    // The query is a single argv element, passed verbatim — not escaped, not split,
+    // not quote-wrapped. execFileSync gives it no shell, so it cannot be expanded.
+    expect(argv).toContain(malicious);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("create passes a metachar title as a verbatim argv element after CONFIRM", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
+    const title = 'Crash "$(rm -rf /)" `id`';
+    await tools.gh_create_issue.execute("t", { title, body: "x" });
+    const code = codeFromDelivery();
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    const argv = ghArgvContaining("create");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(title); // verbatim, unescaped
   });
 });

--- a/extensions/pulsebot/src/gh-tools.ts
+++ b/extensions/pulsebot/src/gh-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -28,8 +28,12 @@ function assertAllowedRepo(repo: string, config: PluginConfig) {
   }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -39,6 +43,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 type GhIssueLike = {
@@ -94,12 +129,23 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
-            const labelFlag = params.label ? ` --label "${params.label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(typeof params.label === "string" && params.label
+                ? ["--label", params.label]
+                : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -127,9 +173,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const data = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]) as GhIssueLike;
             const stakeholders = extractStakeholdersFromIssue(data);
             return jsonResult({ ok: true, data, stakeholders });
           } catch (err) {
@@ -174,16 +227,27 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
             return await stageWrite(summary, async () => {
               const labels = params.labels as string[] | undefined;
-              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-              const bodyStr = String(params.body ?? "");
+              const bodyStr = typeof params.body === "string" ? params.body : "";
+              const title = typeof params.title === "string" ? params.title : "";
               const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
               const stakeholders = Array.isArray(params.stakeholders)
                 ? (params.stakeholders as string[])
                 : [];
               const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-              const result = execSync(
-                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                [
+                  "issue",
+                  "create",
+                  "--repo",
+                  repo,
+                  "--title",
+                  title,
+                  ...(labels?.length ? ["--label", labels.join(",")] : []),
+                  "--body-file",
+                  "-",
+                ],
                 {
                   encoding: "utf-8",
                   input: enrichedBody,
@@ -196,12 +260,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
 
               if (issueNumber) {
                 const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                  encoding: "utf-8",
-                  input: metadataComment,
-                  timeout: 30000,
-                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                });
+                execFileSync(
+                  "gh",
+                  ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                  {
+                    encoding: "utf-8",
+                    input: metadataComment,
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                );
               }
 
               return {
@@ -243,21 +311,29 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            const issueNumber = assertIssueNumber(params.number);
+            const summary = `add comment to issue #${issueNumber} in ${repo}`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-              const originalBody = String(params.body ?? "");
+              const originalBody = typeof params.body === "string" ? params.body : "";
               const body =
                 prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
                   ? `${prefix}\n\n${originalBody}`
                   : originalBody;
 
-              const result = execSync(
-                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                 {
                   encoding: "utf-8",
                   input: body,
@@ -301,11 +377,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -339,30 +423,41 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
             const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
               if (closingComment || prefix) {
                 const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
                 if (commentBody) {
-                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                    encoding: "utf-8",
-                    input: commentBody,
-                    timeout: 30000,
-                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  });
+                  execFileSync(
+                    "gh",
+                    ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                    {
+                      encoding: "utf-8",
+                      input: commentBody,
+                      timeout: 30000,
+                      env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                    },
+                  );
                 }
               }
 
-              const closeOutput = execSync(
-                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+              const closeOutput = execFileSync(
+                "gh",
+                ["issue", "close", String(issueNumber), "--repo", repo, "--reason", closeReason],
                 {
                   encoding: "utf-8",
                   timeout: 30000,

--- a/extensions/scopelybot/src/correlation-tools.ts
+++ b/extensions/scopelybot/src/correlation-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -82,9 +82,21 @@ export function registerCorrelationTools(
             let ghMatches: unknown = [];
             try {
               const repo = (config.scopelyRepos ?? ["cloudwarriors-ai/scopely"])[0];
-              const query = pattern.replace(/"/g, '\\"').slice(0, 100);
-              const result = execSync(
-                `gh search issues "${query}" --repo ${repo} --limit 10 --json number,title,state,labels,createdAt`,
+              const query = pattern.slice(0, 100);
+              // Explicit argv (NO shell): the LLM-controlled query is passed literally.
+              const result = execFileSync(
+                "gh",
+                [
+                  "search",
+                  "issues",
+                  query,
+                  "--repo",
+                  repo,
+                  "--limit",
+                  "10",
+                  "--json",
+                  "number,title,state,labels,createdAt",
+                ],
                 {
                   encoding: "utf-8",
                   timeout: 15000,

--- a/extensions/scopelybot/src/gh-tools.test.ts
+++ b/extensions/scopelybot/src/gh-tools.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the process boundary so no real `gh` command ever runs and we can assert that
+// LLM-controlled values reach gh as literal argv elements (execFileSync = no shell),
+// never a shell string. scopelybot's gh writes are NOT confirm-gated — they execute
+// immediately — so injection safety here rests entirely on argv (no shell).
+const execFileSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+vi.mock("./scopely-api.js", () => ({
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+}));
+
+import { registerGhTools } from "./gh-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const REPO = "cloudwarriors-ai/scopely";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerGhTools(api, noopLogger as never, { scopelyRepos: [REPO] });
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
+describe("scopelybot gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.scopely_gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.scopely_gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(malicious);
+  });
+
+  it("create passes a metachar title as ONE verbatim argv element (executes immediately)", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/scopely/issues/9");
+    const title = 'Crash "$(rm -rf /)" `id`';
+    await tools.scopely_gh_create_issue.execute("t", { title, body: "x" });
+    const argv = ghArgvContaining("create");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(title);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.scopely_gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.scopely_gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks repositories outside the allowlist (no shell-out)", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.scopely_gh_list_issues.execute("t", { repo: "evil/repo" }));
+    expect(res.ok).toBe(false);
+    expect(String(res.error)).toContain("not in allowed list");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/scopelybot/src/gh-tools.ts
+++ b/extensions/scopelybot/src/gh-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -18,8 +18,12 @@ function assertAllowedRepo(repo: string, config: PluginConfig) {
   }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -29,6 +33,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
@@ -53,13 +88,22 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
             const label = typeof params.label === "string" ? params.label : "";
-            const labelFlag = label ? ` --label "${label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(label ? ["--label", label] : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -86,10 +130,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const issueNumber = Number(params.number);
-            const data = gh(
-              `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            );
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -119,10 +169,21 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
             const labels = params.labels as string[] | undefined;
-            const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
+            const title = typeof params.title === "string" ? params.title : "";
             const body = typeof params.body === "string" ? params.body : "";
-            const result = execSync(
-              `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+            const result = execFileSync(
+              "gh",
+              [
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                ...(labels?.length ? ["--label", labels.join(",")] : []),
+                "--body-file",
+                "-",
+              ],
               {
                 encoding: "utf-8",
                 input: body,
@@ -157,10 +218,11 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const body = typeof params.body === "string" ? params.body : "";
-            const result = execSync(
-              `gh issue comment ${issueNumber} --repo ${repo} --body-file -`,
+            const result = execFileSync(
+              "gh",
+              ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
               {
                 encoding: "utf-8",
                 input: body,
@@ -195,11 +257,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -232,7 +302,7 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const reason =
               typeof params.reason === "string" &&
               params.reason.trim().toLowerCase() === "not_planned"
@@ -241,16 +311,21 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
 
             if (closingComment) {
-              execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                encoding: "utf-8",
-                input: closingComment,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              });
+              execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                {
+                  encoding: "utf-8",
+                  input: closingComment,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
             }
 
-            const closeOutput = execSync(
-              `gh issue close ${issueNumber} --repo ${repo} --reason "${reason}"`,
+            const closeOutput = execFileSync(
+              "gh",
+              ["issue", "close", String(issueNumber), "--repo", repo, "--reason", reason],
               {
                 encoding: "utf-8",
                 timeout: 30000,

--- a/extensions/zoomwarriorssupportbot/src/correlation-tools.ts
+++ b/extensions/zoomwarriorssupportbot/src/correlation-tools.ts
@@ -1,13 +1,20 @@
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
-import { execSync } from "child_process";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 
 type PluginConfig = { zwsRepos?: string[] };
 
-const DEVTOOLS_BASE = () => process.env.ZWS_DEVTOOLS_API_URL ?? process.env.BIGHEAD_DEVTOOLS_API_URL ?? "http://bighead-devtools-api:9100";
-const DEVTOOLS_TOKEN = () => process.env.ZWS_DEV_TOOLS_API ?? process.env.BIGHEAD_DEV_TOOLS_API ?? process.env.DEV_TOOLS_API ?? "";
+const DEVTOOLS_BASE = () =>
+  process.env.ZWS_DEVTOOLS_API_URL ??
+  process.env.BIGHEAD_DEVTOOLS_API_URL ??
+  "http://bighead-devtools-api:9100";
+const DEVTOOLS_TOKEN = () =>
+  process.env.ZWS_DEV_TOOLS_API ??
+  process.env.BIGHEAD_DEV_TOOLS_API ??
+  process.env.DEV_TOOLS_API ??
+  "";
 
 function jsonResult(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
@@ -15,10 +22,16 @@ function jsonResult(data: unknown) {
 
 function errorResult(err: unknown) {
   const message = err instanceof Error ? err.message : String(err);
-  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }] };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
 }
 
-export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLogger, config: PluginConfig) {
+export function registerCorrelationTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  config: PluginConfig,
+) {
   api.registerTool(() =>
     wrapToolWithAudit(
       {
@@ -28,8 +41,14 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
           "Searches container logs via DevTools API and GitHub issues in parallel.",
         parameters: Type.Object({
           pattern: Type.String({ description: "Error pattern to search for (case-insensitive)" }),
-          container: Type.Optional(Type.String({ description: "Container to search logs in (default: zoomwarriors2-backend)" })),
-          repo: Type.Optional(Type.String({ description: "GitHub repo to search (default: primary ZW2 repo)" })),
+          container: Type.Optional(
+            Type.String({
+              description: "Container to search logs in (default: zoomwarriors2-backend)",
+            }),
+          ),
+          repo: Type.Optional(
+            Type.String({ description: "GitHub repo to search (default: primary ZW2 repo)" }),
+          ),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
@@ -50,7 +69,9 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
                 if (resp.ok) {
                   const logs = (await resp.json()) as string[];
                   const re = new RegExp(pattern, "i");
-                  logMatches = (Array.isArray(logs) ? logs : []).filter((l) => re.test(String(l))).slice(0, 50);
+                  logMatches = (Array.isArray(logs) ? logs : [])
+                    .filter((l) => re.test(l))
+                    .slice(0, 50);
                 }
               } catch {
                 // DevTools unavailable, continue with GH search
@@ -58,15 +79,30 @@ export function registerCorrelationTools(api: OpenClawPluginApi, logger: AuditLo
             }
 
             // Search GitHub issues
+            // Explicit argv (NO shell): the LLM-controlled query is passed literally.
             let ghIssues: unknown = [];
             try {
-              const escaped = pattern.replace(/"/g, '\\"');
-              ghIssues = JSON.parse(
-                execSync(
-                  `gh search issues "${escaped}" --repo ${repo} --limit 10 --json number,title,state,labels,updatedAt`,
-                  { encoding: "utf-8", timeout: 30000, env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" } },
-                ),
+              const query = pattern.slice(0, 100);
+              const result = execFileSync(
+                "gh",
+                [
+                  "search",
+                  "issues",
+                  query,
+                  "--repo",
+                  repo,
+                  "--limit",
+                  "10",
+                  "--json",
+                  "number,title,state,labels,updatedAt",
+                ],
+                {
+                  encoding: "utf-8",
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
               );
+              ghIssues = JSON.parse(result);
             } catch {
               // GH search may fail, continue
             }

--- a/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock the shell boundary so no real `gh` command ever runs and we can assert
-// exactly when (stage vs confirm) a mutation would fire.
-const execSyncMock = vi.fn();
-vi.mock("child_process", () => ({ execSync: (...args: unknown[]) => execSyncMock(...args) }));
+// Mock the process boundary so no real `gh` command ever runs and we can assert
+// exactly when (stage vs confirm) a mutation fires AND that LLM-controlled values
+// reach gh as literal argv elements (execFileSync = no shell), never a shell string.
+const execFileSyncMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
 
 vi.mock("./zws-api.js", () => ({
   jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
@@ -67,9 +70,18 @@ function codeFromDelivery(): string | undefined {
   return String(text ?? "").match(/CONFIRM (\d{4})/)?.[1];
 }
 
+// All gh invocations go through execFileSync("gh", argv, opts). Find the call whose
+// argv contains a given subcommand token.
+function ghArgvContaining(token: string): string[] | undefined {
+  const call = execFileSyncMock.mock.calls.find(
+    (c) => Array.isArray(c[1]) && (c[1] as string[]).includes(token),
+  );
+  return call?.[1] as string[] | undefined;
+}
+
 describe("zws gh writes are confirm-gated", () => {
   beforeEach(() => {
-    execSyncMock.mockReset();
+    execFileSyncMock.mockReset();
     sendZwsTextMock.mockReset();
     process.env.ZWS_ZOOM_CHANNEL = CHANNEL;
   });
@@ -86,16 +98,16 @@ describe("zws gh writes are confirm-gated", () => {
     expect(staged.staged).toBe(true);
     expect(staged.awaiting_confirmation).toBe(true);
     expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(execSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
+    expect(execFileSyncMock).not.toHaveBeenCalled(); // no mutation at stage time
     expect(sendZwsTextMock).toHaveBeenCalledTimes(1);
     expect(sendZwsTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
   });
 
   it("create_issue runs `gh issue create` only after CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
     await tools.zws_gh_create_issue.execute("t", { title: "Crash", body: "x" });
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     const reply = await tryExecuteConfirm({
@@ -104,27 +116,21 @@ describe("zws gh writes are confirm-gated", () => {
       logger: noopLogger as never,
     });
 
-    const createCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue create"),
-    );
-    expect(createCalls.length).toBe(1);
+    expect(ghArgvContaining("create")).toBeDefined();
     expect(reply).toMatch(/✅ Done/);
     expect(reply).toContain("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
   });
 
   it("close_issue stages and does not close until CONFIRM", async () => {
     const tools = buildTools();
-    execSyncMock.mockReturnValue("closed");
+    execFileSyncMock.mockReturnValue("closed");
     await tools.zws_gh_close_issue.execute("t", { number: 7 });
     // Stage time: nothing shells out (not even the issue-view read inside the closure).
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
     await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
-    const closeCalls = execSyncMock.mock.calls.filter((c) =>
-      String(c[0]).includes("gh issue close"),
-    );
-    expect(closeCalls.length).toBe(1);
+    expect(ghArgvContaining("close")).toBeDefined();
   });
 
   it("an unknown repo is rejected at stage time (no staging, no prompt)", async () => {
@@ -138,6 +144,66 @@ describe("zws gh writes are confirm-gated", () => {
     );
     expect(res.ok).toBe(false);
     expect(sendZwsTextMock).not.toHaveBeenCalled();
-    expect(execSyncMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("zws gh tools are injection-safe (execFileSync, no shell)", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    sendZwsTextMock.mockReset();
+    process.env.ZWS_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.ZWS_ZOOM_CHANNEL;
+  });
+
+  it("every gh call passes argv to execFileSync, not a shell string", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    await tools.zws_gh_list_issues.execute("t", {});
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("gh");
+    expect(Array.isArray(argv)).toBe(true);
+    expect((argv as unknown[]).every((a) => typeof a === "string")).toBe(true);
+  });
+
+  it("search passes a shell-metachar query as ONE verbatim argv element", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("[]");
+    const malicious = '"; rm -rf / #$(whoami)`id`';
+    await tools.zws_gh_search_issues.execute("t", { query: malicious });
+    const argv = ghArgvContaining("issues");
+    expect(argv).toBeDefined();
+    // The query is a single argv element, passed verbatim — not escaped, not split,
+    // not quote-wrapped. execFileSync gives it no shell, so it cannot be expanded.
+    expect(argv).toContain(malicious);
+  });
+
+  it("get_issue rejects a non-integer issue number and never shells out", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.zws_gh_get_issue.execute("t", { number: "7 $(whoami)" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("list_issues rejects an invalid state value", async () => {
+    const tools = buildTools();
+    const res = parse(await tools.zws_gh_list_issues.execute("t", { state: "open; rm -rf /" }));
+    expect(res.ok).toBe(false);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("create passes a metachar title as a verbatim argv element after CONFIRM", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
+    const title = 'Crash "$(rm -rf /)" `id`';
+    await tools.zws_gh_create_issue.execute("t", { title, body: "x" });
+    const code = codeFromDelivery();
+    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    const argv = ghArgvContaining("create");
+    expect(argv).toBeDefined();
+    expect(argv).toContain(title); // verbatim, unescaped
   });
 });

--- a/extensions/zoomwarriorssupportbot/src/gh-tools.ts
+++ b/extensions/zoomwarriorssupportbot/src/gh-tools.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "node:child_process";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
@@ -28,8 +28,12 @@ function assertAllowedRepo(repo: string, config: PluginConfig) {
   }
 }
 
-function gh(args: string): unknown {
-  const result = execSync(`gh ${args}`, {
+// Run gh with an explicit argv (NO shell). Every element is passed literally, so
+// LLM-controlled values (issue numbers, search queries, labels, titles) cannot be
+// interpreted as shell syntax — `$(...)`, backticks, quotes, and `;` are inert.
+// Never reintroduce a shell string here.
+function gh(args: string[]): unknown {
+  const result = execFileSync("gh", args, {
     encoding: "utf-8",
     timeout: 30000,
     env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
@@ -39,6 +43,37 @@ function gh(args: string): unknown {
   } catch {
     return result.trim();
   }
+}
+
+// gh accepts only these issue states; reject anything else with a clear error
+// instead of shelling out to a guaranteed-failing invocation.
+function normalizeIssueState(value: unknown): string {
+  const s = typeof value === "string" ? value.trim().toLowerCase() : "open";
+  if (s === "open" || s === "closed" || s === "all") {
+    return s;
+  }
+  throw new Error(
+    `Invalid state "${typeof value === "string" ? value : ""}": must be open, closed, or all.`,
+  );
+}
+
+// Issue numbers flow into the gh argv. Coerce to a positive integer so a malformed
+// value fails fast with a clear error rather than reaching gh.
+function assertIssueNumber(value: unknown): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`Invalid issue number: ${JSON.stringify(value)}`);
+  }
+  return n;
+}
+
+// Clamp the gh --limit argv to a sane positive integer.
+function normalizeLimit(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    return fallback;
+  }
+  return Math.min(n, 200);
 }
 
 type GhIssueLike = {
@@ -94,12 +129,23 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const state = (params.state as string) || "open";
-            const limit = (params.limit as number) || 30;
-            const labelFlag = params.label ? ` --label "${params.label}"` : "";
-            const data = gh(
-              `issue list --repo ${repo} --state ${state} --limit ${limit}${labelFlag} --json number,title,state,labels,assignees,createdAt,updatedAt`,
-            );
+            const state = normalizeIssueState(params.state);
+            const limit = normalizeLimit(params.limit, 30);
+            const data = gh([
+              "issue",
+              "list",
+              "--repo",
+              repo,
+              "--state",
+              state,
+              "--limit",
+              String(limit),
+              ...(typeof params.label === "string" && params.label
+                ? ["--label", params.label]
+                : []),
+              "--json",
+              "number,title,state,labels,assignees,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -127,9 +173,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const data = gh(
-              `issue view ${params.number} --repo ${repo} --json number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt`,
-            ) as GhIssueLike;
+            const issueNumber = assertIssueNumber(params.number);
+            const data = gh([
+              "issue",
+              "view",
+              String(issueNumber),
+              "--repo",
+              repo,
+              "--json",
+              "number,url,title,body,state,labels,assignees,comments,createdAt,updatedAt,closedAt",
+            ]) as GhIssueLike;
             const stakeholders = extractStakeholdersFromIssue(data);
             return jsonResult({ ok: true, data, stakeholders });
           } catch (err) {
@@ -169,16 +222,27 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const summary = `create GitHub issue "${params.title as string}" in ${repo}`;
             return await stageWrite(summary, async () => {
               const labels = params.labels as string[] | undefined;
-              const labelFlag = labels?.length ? ` --label "${labels.join(",")}"` : "";
-              const bodyStr = String(params.body ?? "");
+              const bodyStr = typeof params.body === "string" ? params.body : "";
+              const title = typeof params.title === "string" ? params.title : "";
               const reporter = typeof params.reporter === "string" ? params.reporter : undefined;
               const stakeholders = Array.isArray(params.stakeholders)
                 ? (params.stakeholders as string[])
                 : [];
               const enrichedBody = upsertStakeholderBlock(bodyStr, { reporter, stakeholders });
 
-              const result = execSync(
-                `gh issue create --repo ${repo} --title "${(params.title as string).replace(/"/g, '\\"')}"${labelFlag} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                [
+                  "issue",
+                  "create",
+                  "--repo",
+                  repo,
+                  "--title",
+                  title,
+                  ...(labels?.length ? ["--label", labels.join(",")] : []),
+                  "--body-file",
+                  "-",
+                ],
                 {
                   encoding: "utf-8",
                   input: enrichedBody,
@@ -191,12 +255,16 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
 
               if (issueNumber) {
                 const metadataComment = formatStakeholderBlock({ reporter, stakeholders });
-                execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                  encoding: "utf-8",
-                  input: metadataComment,
-                  timeout: 30000,
-                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                });
+                execFileSync(
+                  "gh",
+                  ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                  {
+                    encoding: "utf-8",
+                    input: metadataComment,
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                );
               }
 
               return {
@@ -238,21 +306,29 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const summary = `add comment to issue #${Number(params.number)} in ${repo}`;
+            const issueNumber = assertIssueNumber(params.number);
+            const summary = `add comment to issue #${issueNumber} in ${repo}`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${params.number} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
-              const originalBody = String(params.body ?? "");
+              const originalBody = typeof params.body === "string" ? params.body : "";
               const body =
                 prefix && !/^\s*(\/cc|Stakeholders:)/im.test(originalBody)
                   ? `${prefix}\n\n${originalBody}`
                   : originalBody;
 
-              const result = execSync(
-                `gh issue comment ${params.number} --repo ${repo} --body-file -`,
+              const result = execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
                 {
                   encoding: "utf-8",
                   input: body,
@@ -296,11 +372,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config);
-            const limit = (params.limit as number) || 20;
-            const query = (params.query as string).replace(/"/g, '\\"');
-            const data = gh(
-              `search issues "${query}" --repo ${repo} --limit ${limit} --json number,title,state,labels,repository,createdAt,updatedAt`,
-            );
+            const limit = normalizeLimit(params.limit, 20);
+            const query = typeof params.query === "string" ? params.query : "";
+            const data = gh([
+              "search",
+              "issues",
+              query,
+              "--repo",
+              repo,
+              "--limit",
+              String(limit),
+              "--json",
+              "number,title,state,labels,repository,createdAt,updatedAt",
+            ]);
             return jsonResult({ ok: true, data });
           } catch (err) {
             return errorResult(err);
@@ -334,30 +418,41 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
           try {
             const repo = (params.repo as string) || getAllowedRepos(config)[0];
             assertAllowedRepo(repo, config); // validate now; mutation is deferred to confirm
-            const issueNumber = Number(params.number);
+            const issueNumber = assertIssueNumber(params.number);
             const closeReason = stringifyReason(params.reason);
             const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
             const summary = `close issue #${issueNumber} in ${repo} (${closeReason})`;
             return await stageWrite(summary, async () => {
-              const issue = gh(
-                `issue view ${issueNumber} --repo ${repo} --json number,url,title,body,assignees,comments`,
-              ) as GhIssueLike;
+              const issue = gh([
+                "issue",
+                "view",
+                String(issueNumber),
+                "--repo",
+                repo,
+                "--json",
+                "number,url,title,body,assignees,comments",
+              ]) as GhIssueLike;
               const extracted = extractStakeholdersFromIssue(issue);
               const prefix = buildStakeholderWorkPrefix(extracted.stakeholders);
               if (closingComment || prefix) {
                 const commentBody = [prefix, closingComment].filter(Boolean).join("\n\n").trim();
                 if (commentBody) {
-                  execSync(`gh issue comment ${issueNumber} --repo ${repo} --body-file -`, {
-                    encoding: "utf-8",
-                    input: commentBody,
-                    timeout: 30000,
-                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                  });
+                  execFileSync(
+                    "gh",
+                    ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                    {
+                      encoding: "utf-8",
+                      input: commentBody,
+                      timeout: 30000,
+                      env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                    },
+                  );
                 }
               }
 
-              const closeOutput = execSync(
-                `gh issue close ${issueNumber} --repo ${repo} --reason "${closeReason}"`,
+              const closeOutput = execFileSync(
+                "gh",
+                ["issue", "close", String(issueNumber), "--repo", repo, "--reason", closeReason],
                 {
                   encoding: "utf-8",
                   timeout: 30000,
@@ -391,8 +486,14 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
                   toContact: stakeholder,
                   message: dmMessage,
                 });
-                if (dmResult.ok) notified.push(stakeholder);
-                else notifyErrors.push({ stakeholder, error: dmResult.error ?? "unknown error" });
+                if (dmResult.ok) {
+                  notified.push(stakeholder);
+                } else {
+                  notifyErrors.push({
+                    stakeholder,
+                    error: dmResult.error ?? "unknown error",
+                  });
+                }
               }
 
               return {


### PR DESCRIPTION
## Summary

Closes a **CRITICAL shell command-injection** class across the CW support-bot fleet. Every bot built `gh`/CLI invocations as `execSync(\`gh ${arg}\`)` shell strings with LLM-controlled values (issue numbers, search queries, labels, titles, run IDs) interpolated in. `.replace(/"/g,'\\"')` does **not** stop `$(...)`/backtick/`;` expansion inside double quotes, so a crafted tool argument could execute arbitrary shell on the bot host.

Fix: replace shell strings with `execFileSync(bin, [argv...])` (no shell — every element is passed literally), plus fail-fast validation on numeric/enum/path params.

### Bots hardened
| Bot | Files |
|-----|-------|
| bigheadbot | gh-tools, correlation-tools |
| pulsebot | gh-tools, correlation-tools |
| zoomwarriorssupportbot | gh-tools, correlation-tools |
| cloudflow-support | gh-tools, cf-ops-tools (`gh run list`) |
| scopelybot | gh-tools, correlation-tools |
| external-org-autopilot | gh-tools, eoa-state-tools (`gh run`/`gh api`), eoa-cli-tools (`npx tsx src/cli.ts`) |

### Validators added
- `assertIssueNumber` — positive-integer issue numbers
- `normalizeIssueState` — `open`/`closed`/`all` only
- `normalizeLimit` — clamped positive integer
- `assertRepoSlug` / `assertCommitSha` / `assertRunId` (eoa) — reject values that could alter a `gh api` path

No shell `execSync` with LLM-reachable input remains in `extensions/`. (`2fa-github/ngrok-manager` retains an operator-config `execSync` — not LLM-reachable; out of this fleet's scope.)

## Verification
- `node scripts/run-vitest.mjs` across all 6 bots: **142/142 pass** (incl. new injection-safety tests asserting metachar inputs reach `gh` as one verbatim argv element, and that non-integer issue numbers / invalid states are rejected before any shell-out).
- oxlint (extensions config) clean on all changed hunks. Pre-existing unrelated lint debt (cf-ops curly, eoa-state `restrict-template` in untouched state-file-read tools) left as-is.
- `tsgo:extensions`: **0 new type errors** (66 TS2345 before == after — all the pre-existing `wrapToolWithAudit` factory-signature mismatch; none touch the new code).

## Not in this PR (follow-up)
Adversarial review (codex) also surfaced, in the confirm-gate: pending actions keyed by code alone (cross-channel confirm) + deterministic 4-digit codes, and a SQL-guard CTE bypass in bigheadbot devtools. Tracked separately — distinct concern from injection.
