### PR TITLE
fix(bots): channel-scope confirm-gate + CSPRNG codes across 5 bots

### DIFF
--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -74,7 +74,12 @@ const plugin = {
       if (ctx.channelId !== "zoom") return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
-      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
       return { handled: true, text: result ?? undefined };
     });
 

--- a/extensions/bigheadbot/src/bh-tools.test.ts
+++ b/extensions/bigheadbot/src/bh-tools.test.ts
@@ -113,7 +113,12 @@ describe("bigheadbot confirm-gated writes", () => {
     expect(code).toBeTruthy();
 
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets",
@@ -128,7 +133,12 @@ describe("bigheadbot confirm-gated writes", () => {
 
     const code = codeFromDelivery();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets/t9",
@@ -156,6 +166,7 @@ describe("bigheadbot confirm-gated writes", () => {
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(reply).toMatch(/No pending action/i);

--- a/extensions/bigheadbot/src/confirm.ts
+++ b/extensions/bigheadbot/src/confirm.ts
@@ -23,13 +23,15 @@ function successDetail(data: unknown): string {
 export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
+  conversationId: string;
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
-  const action = takePending(m[1]);
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
   if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }
   const start = Date.now();
   try {

--- a/extensions/bigheadbot/src/gated.ts
+++ b/extensions/bigheadbot/src/gated.ts
@@ -14,8 +14,6 @@ import { jsonResult } from "./bh-api.js";
 import { BIGHEADBOT_CHANNEL, getChannelThreadAnchor, sendBigheadText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 
-let codeSeed = 1;
-
 type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
@@ -28,16 +26,18 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // tool result the model sees is CODE-FREE; the model only learns a prompt was
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
-  const code = makeCode(codeSeed++ * 7919 + summary.length);
-  putPending({ code, summary, run });
-  const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
-    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
-
   // Read the channel at call time (not module load) so env that loads after import
   // — and test stubbing — both resolve correctly. Fall back to the bot's known
   // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
   const channel = process.env.BIGHEADBOT_ZOOM_CHANNEL ?? BIGHEADBOT_CHANNEL;
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
   if (channel) {
     await sendBigheadText(channel, prompt, getChannelThreadAnchor(channel));
     return jsonResult({

--- a/extensions/bigheadbot/src/gh-tools.test.ts
+++ b/extensions/bigheadbot/src/gh-tools.test.ts
@@ -113,6 +113,7 @@ describe("bigheadbot gh writes are confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -129,7 +130,12 @@ describe("bigheadbot gh writes are confirm-gated", () => {
     expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     expect(ghArgvContaining("close")).toBeDefined();
   });
 
@@ -145,6 +151,33 @@ describe("bigheadbot gh writes are confirm-gated", () => {
     expect(res.ok).toBe(false);
     expect(sendBigheadTextMock).not.toHaveBeenCalled();
     expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged write", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/bighead/issues/42");
+    await tools.bh_gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    const code = codeFromDelivery();
+
+    // Wrong channel: must be refused and must NOT consume the pending action.
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(ghArgvContaining("create")).toBeDefined();
   });
 });
 
@@ -201,7 +234,12 @@ describe("bigheadbot gh tools are injection-safe (execFileSync, no shell)", () =
     const title = 'Crash "$(rm -rf /)" `id`';
     await tools.bh_gh_create_issue.execute("t", { title, body: "x" });
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     const argv = ghArgvContaining("create");
     expect(argv).toBeDefined();
     expect(argv).toContain(title); // verbatim, unescaped

--- a/extensions/bigheadbot/src/pending-confirm.ts
+++ b/extensions/bigheadbot/src/pending-confirm.ts
@@ -1,9 +1,17 @@
 // In-memory, single-use, TTL store for pending bigheadbot write actions.
-// An action only runs after a human types `CONFIRM <code>` in the channel — the
-// LLM cannot fabricate that inbound message, so it cannot self-approve.
+// An action only runs after a human types `CONFIRM <code>` in the SAME channel the
+// prompt was posted to — the LLM cannot fabricate that inbound message, and a
+// CONFIRM from another channel/DM cannot consume it, so neither the model nor a
+// bystander in a different conversation can approve a staged write.
+
+import { randomInt } from "node:crypto";
 
 export type PendingAction = {
   code: string;
+  // The conversation the CONFIRM must come from. A staged write is bound to the
+  // channel where its prompt was delivered; a CONFIRM from any other channel/DM
+  // must NOT consume it (cross-channel confirm = privilege escalation).
+  conversationId: string;
   summary: string; // human-readable description, echoed + audited
   run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
   expiresAt: number;
@@ -15,16 +23,21 @@ const store = new Map<string, PendingAction>();
 function prune(): void {
   const now = Date.now();
   for (const [code, a] of store) {
-    if (a.expiresAt <= now) store.delete(code);
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
   }
 }
 
-// 4-digit code, unique within the live store. `seed` varies per call.
-export function makeCode(seed: number): string {
+// Unpredictable 4-digit code, unique within the live store. crypto.randomInt — a
+// confirm code is a security token, so it must NOT be derivable from call order or
+// summary length (the old deterministic seed was guessable).
+export function makeCode(): string {
   prune();
-  let code = String(1000 + (Math.abs(seed) % 9000));
-  let bump = 0;
-  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
   return code;
 }
 
@@ -33,11 +46,15 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
-// Retrieve and consume a pending action (one-time use).
-export function takePending(code: string): PendingAction | undefined {
+// Retrieve and consume a pending action (one-time use) — ONLY when the code exists
+// AND the confirming conversation matches the one it was staged for. A CONFIRM from
+// another channel returns undefined and leaves the action intact for the right one.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a) return undefined;
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
   store.delete(code);
   return a;
 }

--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -70,7 +70,12 @@ const plugin = {
       if (ctx.channelId !== "zoom") return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
-      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
       return { handled: true, text: result ?? undefined };
     });
 

--- a/extensions/cloudflow-support/src/cf-ops-tools.test.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.test.ts
@@ -112,6 +112,7 @@ describe("cloudflow cf_execute_op is confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -138,6 +139,7 @@ describe("cloudflow cf_execute_op is confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(reply).toMatch(/No pending action/i);

--- a/extensions/cloudflow-support/src/confirm.ts
+++ b/extensions/cloudflow-support/src/confirm.ts
@@ -23,13 +23,15 @@ function successDetail(data: unknown): string {
 export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
+  conversationId: string;
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
-  const action = takePending(m[1]);
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
   if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }
   const start = Date.now();
   try {

--- a/extensions/cloudflow-support/src/gated.ts
+++ b/extensions/cloudflow-support/src/gated.ts
@@ -14,8 +14,6 @@ import { CF_CHANNEL, getChannelThreadAnchor, sendCfText } from "./comfort.js";
 import { jsonResult } from "./helpers.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 
-let codeSeed = 1;
-
 type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
@@ -28,16 +26,18 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // tool result the model sees is CODE-FREE; the model only learns a prompt was
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
-  const code = makeCode(codeSeed++ * 7919 + summary.length);
-  putPending({ code, summary, run });
-  const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
-    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
-
   // Read the channel at call time (not module load) so env that loads after import
   // — and test stubbing — both resolve correctly. Fall back to the bot's known
   // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
   const channel = process.env.CF_ZOOM_CHANNEL ?? CF_CHANNEL;
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
   if (channel) {
     await sendCfText(channel, prompt, getChannelThreadAnchor(channel));
     return jsonResult({

--- a/extensions/cloudflow-support/src/gh-tools.test.ts
+++ b/extensions/cloudflow-support/src/gh-tools.test.ts
@@ -142,6 +142,7 @@ describe("cloudflow gh writes are confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -156,7 +157,12 @@ describe("cloudflow gh writes are confirm-gated", () => {
     expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     expect(ghArgvContaining("close")).toBeDefined();
   });
 
@@ -168,6 +174,33 @@ describe("cloudflow gh writes are confirm-gated", () => {
     expect(res.ok).toBe(false);
     expect(sendCfTextMock).not.toHaveBeenCalled();
     expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged write", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/cloudflow/issues/42");
+    await tools.cf_gh_create_issue.execute("t", { title: "Deploy broke", body: "x" });
+    const code = codeFromDelivery();
+
+    // Wrong channel: must be refused and must NOT consume the pending action.
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(ghArgvContaining("create")).toBeDefined();
   });
 });
 

--- a/extensions/cloudflow-support/src/pending-confirm.ts
+++ b/extensions/cloudflow-support/src/pending-confirm.ts
@@ -2,8 +2,11 @@
 // An action only runs after a human types `CONFIRM <code>` in the channel — the
 // LLM cannot fabricate that inbound message, so it cannot self-approve.
 
+import { randomInt } from "node:crypto";
+
 export type PendingAction = {
   code: string;
+  conversationId: string; // channel the CONFIRM must come from
   summary: string; // human-readable description, echoed + audited
   run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
   expiresAt: number;
@@ -15,16 +18,20 @@ const store = new Map<string, PendingAction>();
 function prune(): void {
   const now = Date.now();
   for (const [code, a] of store) {
-    if (a.expiresAt <= now) store.delete(code);
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
   }
 }
 
-// 4-digit code, unique within the live store. `seed` varies per call.
-export function makeCode(seed: number): string {
+// 4-digit code, unpredictable (CSPRNG), unique within the live store. A guessable
+// code lets the LLM fabricate a CONFIRM; randomInt closes that.
+export function makeCode(): string {
   prune();
-  let code = String(1000 + (Math.abs(seed) % 9000));
-  let bump = 0;
-  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
   return code;
 }
 
@@ -33,11 +40,16 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
-// Retrieve and consume a pending action (one-time use).
-export function takePending(code: string): PendingAction | undefined {
+// Retrieve and consume a pending action (one-time use). Channel-scoped: a CONFIRM
+// only fires an action staged for the SAME conversation, so a code leaked/observed
+// in one channel cannot trigger a write staged for another. A channel mismatch does
+// NOT consume the action — the rightful channel can still confirm it.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a) return undefined;
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
   store.delete(code);
   return a;
 }

--- a/extensions/pulsebot/index.ts
+++ b/extensions/pulsebot/index.ts
@@ -72,7 +72,12 @@ const plugin = {
       if (ctx.channelId !== "zoom") return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
-      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
       return { handled: true, text: result ?? undefined };
     });
 

--- a/extensions/pulsebot/src/confirm.ts
+++ b/extensions/pulsebot/src/confirm.ts
@@ -23,13 +23,15 @@ function successDetail(data: unknown): string {
 export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
+  conversationId: string;
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
-  const action = takePending(m[1]);
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
   if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }
   const start = Date.now();
   try {

--- a/extensions/pulsebot/src/gated.ts
+++ b/extensions/pulsebot/src/gated.ts
@@ -14,8 +14,6 @@ import { PULSEBOT_CHANNEL, getChannelThreadAnchor, sendPulseText } from "./comfo
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./pp-api.js";
 
-let codeSeed = 1;
-
 type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
@@ -28,16 +26,18 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // tool result the model sees is CODE-FREE; the model only learns a prompt was
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
-  const code = makeCode(codeSeed++ * 7919 + summary.length);
-  putPending({ code, summary, run });
-  const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
-    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
-
   // Read the channel at call time (not module load) so env that loads after import
   // — and test stubbing — both resolve correctly. Fall back to the bot's known
   // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
   const channel = process.env.PULSEBOT_ZOOM_CHANNEL ?? PULSEBOT_CHANNEL;
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
   if (channel) {
     await sendPulseText(channel, prompt, getChannelThreadAnchor(channel));
     return jsonResult({

--- a/extensions/pulsebot/src/gh-tools.test.ts
+++ b/extensions/pulsebot/src/gh-tools.test.ts
@@ -155,6 +155,7 @@ describe("pulsebot gh writes are confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -171,7 +172,12 @@ describe("pulsebot gh writes are confirm-gated", () => {
     expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     expect(ghArgvContaining("close")).toBeDefined();
   });
 
@@ -183,6 +189,33 @@ describe("pulsebot gh writes are confirm-gated", () => {
     expect(res.ok).toBe(false);
     expect(sendPulseTextMock).not.toHaveBeenCalled();
     expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged write", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/project-pulse/issues/77");
+    await tools.gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    const code = codeFromDelivery();
+
+    // Wrong channel: must be refused and must NOT consume the pending action.
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(ghArgvContaining("create")).toBeDefined();
   });
 });
 
@@ -239,7 +272,12 @@ describe("pulsebot gh tools are injection-safe (execFileSync, no shell)", () => 
     const title = 'Crash "$(rm -rf /)" `id`';
     await tools.gh_create_issue.execute("t", { title, body: "x" });
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     const argv = ghArgvContaining("create");
     expect(argv).toBeDefined();
     expect(argv).toContain(title); // verbatim, unescaped

--- a/extensions/pulsebot/src/pending-confirm.ts
+++ b/extensions/pulsebot/src/pending-confirm.ts
@@ -2,8 +2,11 @@
 // An action only runs after a human types `CONFIRM <code>` in the channel — the
 // LLM cannot fabricate that inbound message, so it cannot self-approve.
 
+import { randomInt } from "node:crypto";
+
 export type PendingAction = {
   code: string;
+  conversationId: string; // channel the CONFIRM must come from
   summary: string; // human-readable description, echoed + audited
   run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
   expiresAt: number;
@@ -15,16 +18,20 @@ const store = new Map<string, PendingAction>();
 function prune(): void {
   const now = Date.now();
   for (const [code, a] of store) {
-    if (a.expiresAt <= now) store.delete(code);
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
   }
 }
 
-// 4-digit code, unique within the live store. `seed` varies per call.
-export function makeCode(seed: number): string {
+// 4-digit code, unpredictable (CSPRNG), unique within the live store. A guessable
+// code lets the LLM fabricate a CONFIRM; randomInt closes that.
+export function makeCode(): string {
   prune();
-  let code = String(1000 + (Math.abs(seed) % 9000));
-  let bump = 0;
-  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
   return code;
 }
 
@@ -33,11 +40,16 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
-// Retrieve and consume a pending action (one-time use).
-export function takePending(code: string): PendingAction | undefined {
+// Retrieve and consume a pending action (one-time use). Channel-scoped: a CONFIRM
+// only fires an action staged for the SAME conversation, so a code leaked/observed
+// in one channel cannot trigger a write staged for another. A channel mismatch does
+// NOT consume the action — the rightful channel can still confirm it.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a) return undefined;
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
   store.delete(code);
   return a;
 }

--- a/extensions/pulsebot/src/pp-tools.test.ts
+++ b/extensions/pulsebot/src/pp-tools.test.ts
@@ -113,7 +113,12 @@ describe("pulsebot confirm-gated writes", () => {
     expect(code).toBeTruthy();
 
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets",
@@ -128,7 +133,12 @@ describe("pulsebot confirm-gated writes", () => {
 
     const code = codeFromDelivery();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets/t9",
@@ -156,6 +166,7 @@ describe("pulsebot confirm-gated writes", () => {
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(reply).toMatch(/No pending action/i);

--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -99,7 +99,12 @@ const plugin = {
       if (ctx.channelId !== "zoom") return;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return;
-      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
       // `handled: true` suppresses the coordinator so the CONFIRM cannot re-stage; the
       // result string (executed / "no pending action") is delivered threaded by core.
       console.log("[scopelybot] before_dispatch claimed CONFIRM (coordinator suppressed)");

--- a/extensions/scopelybot/src/deployment-config-tools.test.ts
+++ b/extensions/scopelybot/src/deployment-config-tools.test.ts
@@ -90,7 +90,12 @@ describe("deployment-config-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls[0];
     expect(path).toBe("/api/admin/vendors/zoom/project-types/4/deployment-types/");
     expect(opts.method).toBe("POST");
@@ -103,7 +108,12 @@ describe("deployment-config-tools", () => {
       await t.scopely_update_deployment_type_template.execute("x", { id: 3, sort_order: 9 }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/deployment-type-templates/3/");
     expect(opts.method).toBe("PATCH");

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -11,8 +11,6 @@ import { getChannelThreadAnchor, sendScopelyText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./scopely-api.js";
 
-let codeSeed = 1;
-
 type FetchResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
@@ -25,15 +23,17 @@ type FetchResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // tool result the model sees is CODE-FREE; the model only learns a prompt was
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => FetchResult) {
-  const code = makeCode(codeSeed++ * 7919 + summary.length);
-  putPending({ code, summary, run });
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly.
+  const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
   const prompt =
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly.
-  const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
   if (channel) {
     await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));
     return jsonResult({

--- a/extensions/scopelybot/src/org-tools.test.ts
+++ b/extensions/scopelybot/src/org-tools.test.ts
@@ -91,7 +91,12 @@ describe("org-tools", () => {
     });
     const code = codeOf(staged);
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls[0];
     expect(path).toBe("/api/auth/orgs/");
     expect(opts.method).toBe("POST");
@@ -107,7 +112,12 @@ describe("org-tools", () => {
     const staged = await t.scopely_update_org.execute("x", { org_id: 3, slug: "new-slug" });
     const code = codeOf(staged);
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/auth/orgs/3/");
     expect(opts.method).toBe("PATCH");
@@ -118,7 +128,12 @@ describe("org-tools", () => {
     const t = buildTools();
     const code = codeOf(await t.scopely_delete_org.execute("x", { org_id: 7 }));
     fetchMock.mockResolvedValue({ ok: true, status: 204, data: null });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/auth/orgs/7/",
       expect.objectContaining({ method: "DELETE" }),
@@ -131,7 +146,12 @@ describe("org-tools", () => {
       await t.scopely_add_org_domain.execute("x", { org_id: 7, domain: "Acme.COM" }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/auth/orgs/7/domains/");
     expect(JSON.parse(opts.body)).toEqual({ domain: "acme.com" });
@@ -143,7 +163,12 @@ describe("org-tools", () => {
       await t.scopely_remove_org_domain.execute("x", { org_id: 7, domain_id: 12 }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 204, data: null });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/auth/orgs/7/domains/12/",
       expect.objectContaining({ method: "DELETE" }),

--- a/extensions/scopelybot/src/pending-confirm.ts
+++ b/extensions/scopelybot/src/pending-confirm.ts
@@ -2,8 +2,11 @@
 // An action only runs after a human types `CONFIRM <code>` in the channel — the
 // LLM cannot fabricate that inbound message, so it cannot self-approve.
 
+import { randomInt } from "node:crypto";
+
 export type PendingAction = {
   code: string;
+  conversationId: string; // channel the CONFIRM must come from
   summary: string; // human-readable description, echoed + audited
   run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
   expiresAt: number;
@@ -15,16 +18,20 @@ const store = new Map<string, PendingAction>();
 function prune(): void {
   const now = Date.now();
   for (const [code, a] of store) {
-    if (a.expiresAt <= now) store.delete(code);
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
   }
 }
 
-// 4-digit code, unique within the live store. `seed` varies per call.
-export function makeCode(seed: number): string {
+// 4-digit code, unpredictable (CSPRNG), unique within the live store. A guessable
+// code lets the LLM fabricate a CONFIRM; randomInt closes that.
+export function makeCode(): string {
   prune();
-  let code = String(1000 + (Math.abs(seed) % 9000));
-  let bump = 0;
-  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
   return code;
 }
 
@@ -33,11 +40,16 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
-// Retrieve and consume a pending action (one-time use).
-export function takePending(code: string): PendingAction | undefined {
+// Retrieve and consume a pending action (one-time use). Channel-scoped: a CONFIRM
+// only fires an action staged for the SAME conversation, so a code leaked/observed
+// in one channel cannot trigger a write staged for another. A channel mismatch does
+// NOT consume the action — the rightful channel can still confirm it.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a) return undefined;
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
   store.delete(code);
   return a;
 }

--- a/extensions/scopelybot/src/pricing-tools.test.ts
+++ b/extensions/scopelybot/src/pricing-tools.test.ts
@@ -115,7 +115,12 @@ describe("pricing-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls[0];
     expect(path).toBe("/api/admin/pricing-defaults/");
     expect(opts.method).toBe("POST");
@@ -142,7 +147,12 @@ describe("pricing-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/vendors/zoom/project-types/7/pricing-items/");
     expect(opts.method).toBe("POST");
@@ -162,7 +172,12 @@ describe("pricing-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/vendors/zoom/project-types/7/pricing-items/42/");
     expect(opts.method).toBe("PATCH");
@@ -173,7 +188,12 @@ describe("pricing-tools", () => {
     const t = buildTools();
     const code = codeOf(await t.scopely_delete_currency.execute("x", { id: 9 }));
     fetchMock.mockResolvedValue({ ok: true, status: 204, data: null });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/admin/currencies/9/",
       expect.objectContaining({ method: "DELETE" }),

--- a/extensions/scopelybot/src/scoping-card-tools.test.ts
+++ b/extensions/scopelybot/src/scoping-card-tools.test.ts
@@ -96,7 +96,12 @@ describe("scoping-card-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls[0];
     expect(path).toBe("/api/admin/vendors/zoom/project-types/4/cards/");
     expect(opts.method).toBe("POST");
@@ -120,7 +125,12 @@ describe("scoping-card-tools", () => {
     expect(staged.message).toContain("REPLACE fields (1 total)");
     const code = staged.message.match(/CONFIRM (\d{4})/)?.[1];
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/admin/vendors/zoom/project-types/4/cards/11/",
       expect.objectContaining({ method: "PATCH" }),

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -129,6 +129,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "tester",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -159,6 +160,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "tester",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -177,6 +179,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${approveCode}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -193,6 +196,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${rejectCode}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -201,12 +205,40 @@ describe("user-maintenance-tools", () => {
     );
   });
 
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged write", async () => {
+    const tools = buildTools();
+    await tools.scopely_update_user.execute("t", { user_id: 7, role: "org_admin" });
+    const code = codeFromDelivery();
+
+    // Wrong channel: must be refused and must NOT consume the pending action.
+    fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("a wrong/expired code executes nothing (fail-closed)", async () => {
     buildTools();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(reply).toMatch(/No pending action/i);

--- a/extensions/scopelybot/src/user-maintenance-tools.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.ts
@@ -365,13 +365,15 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
 export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
+  conversationId: string;
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
-  const action = takePending(m[1]);
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
   if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }
   const start = Date.now();
   try {

--- a/extensions/scopelybot/src/vendor-config-tools.test.ts
+++ b/extensions/scopelybot/src/vendor-config-tools.test.ts
@@ -89,7 +89,12 @@ describe("vendor-config-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls[0];
     expect(path).toBe("/api/admin/vendors/");
     expect(opts.method).toBe("POST");
@@ -106,7 +111,12 @@ describe("vendor-config-tools", () => {
       await t.scopely_update_vendor.execute("x", { vendor_key: "zoom", status: "inactive" }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/vendors/zoom/");
     expect(opts.method).toBe("PATCH");
@@ -125,7 +135,12 @@ describe("vendor-config-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/admin/vendors/zoom/project-types/",
       expect.objectContaining({ method: "POST" }),
@@ -137,6 +152,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${delCode}`,
       actor: "t",
+      conversationId: "",
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -156,7 +172,12 @@ describe("vendor-config-tools", () => {
       }),
     );
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: "",
+      logger: noopLogger as never,
+    });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/vendors/zoom/terms/");
     expect(JSON.parse(opts.body)).toEqual({ scope: "field", key: "seats", label: "Licenses" });

--- a/extensions/zoomwarriorssupportbot/index.ts
+++ b/extensions/zoomwarriorssupportbot/index.ts
@@ -74,7 +74,12 @@ const plugin = {
       if (ctx.channelId !== "zoom") return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
-      const result = await tryExecuteConfirm({ text, actor: ctx.senderId ?? "", logger });
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
       return { handled: true, text: result ?? undefined };
     });
 

--- a/extensions/zoomwarriorssupportbot/src/confirm.ts
+++ b/extensions/zoomwarriorssupportbot/src/confirm.ts
@@ -23,13 +23,15 @@ function successDetail(data: unknown): string {
 export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
+  conversationId: string;
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
-  const action = takePending(m[1]);
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
   if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min) or already been used.`;
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }
   const start = Date.now();
   try {

--- a/extensions/zoomwarriorssupportbot/src/gated.ts
+++ b/extensions/zoomwarriorssupportbot/src/gated.ts
@@ -14,8 +14,6 @@ import { ZWS_CHANNEL, getChannelThreadAnchor, sendZwsText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./zws-api.js";
 
-let codeSeed = 1;
-
 type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
@@ -28,16 +26,18 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // tool result the model sees is CODE-FREE; the model only learns a prompt was
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
-  const code = makeCode(codeSeed++ * 7919 + summary.length);
-  putPending({ code, summary, run });
-  const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
-    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
-
   // Read the channel at call time (not module load) so env that loads after import
   // — and test stubbing — both resolve correctly. Fall back to the bot's known
   // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
   const channel = process.env.ZWS_ZOOM_CHANNEL ?? ZWS_CHANNEL;
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
   if (channel) {
     await sendZwsText(channel, prompt, getChannelThreadAnchor(channel));
     return jsonResult({

--- a/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/gh-tools.test.ts
@@ -113,6 +113,7 @@ describe("zws gh writes are confirm-gated", () => {
     const reply = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
 
@@ -129,7 +130,12 @@ describe("zws gh writes are confirm-gated", () => {
     expect(execFileSyncMock).not.toHaveBeenCalled();
 
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     expect(ghArgvContaining("close")).toBeDefined();
   });
 
@@ -145,6 +151,33 @@ describe("zws gh writes are confirm-gated", () => {
     expect(res.ok).toBe(false);
     expect(sendZwsTextMock).not.toHaveBeenCalled();
     expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged write", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/zoomwarriors2/issues/42");
+    await tools.zws_gh_create_issue.execute("t", { title: "Crash", body: "x" });
+    const code = codeFromDelivery();
+
+    // Wrong channel: must be refused and must NOT consume the pending action.
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(ghArgvContaining("create")).toBeDefined();
   });
 });
 
@@ -201,7 +234,12 @@ describe("zws gh tools are injection-safe (execFileSync, no shell)", () => {
     const title = 'Crash "$(rm -rf /)" `id`';
     await tools.zws_gh_create_issue.execute("t", { title, body: "x" });
     const code = codeFromDelivery();
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
     const argv = ghArgvContaining("create");
     expect(argv).toBeDefined();
     expect(argv).toContain(title); // verbatim, unescaped

--- a/extensions/zoomwarriorssupportbot/src/pending-confirm.ts
+++ b/extensions/zoomwarriorssupportbot/src/pending-confirm.ts
@@ -2,8 +2,11 @@
 // An action only runs after a human types `CONFIRM <code>` in the channel — the
 // LLM cannot fabricate that inbound message, so it cannot self-approve.
 
+import { randomInt } from "node:crypto";
+
 export type PendingAction = {
   code: string;
+  conversationId: string; // channel the CONFIRM must come from
   summary: string; // human-readable description, echoed + audited
   run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
   expiresAt: number;
@@ -15,16 +18,20 @@ const store = new Map<string, PendingAction>();
 function prune(): void {
   const now = Date.now();
   for (const [code, a] of store) {
-    if (a.expiresAt <= now) store.delete(code);
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
   }
 }
 
-// 4-digit code, unique within the live store. `seed` varies per call.
-export function makeCode(seed: number): string {
+// 4-digit code, unpredictable (CSPRNG), unique within the live store. A guessable
+// code lets the LLM fabricate a CONFIRM; randomInt closes that.
+export function makeCode(): string {
   prune();
-  let code = String(1000 + (Math.abs(seed) % 9000));
-  let bump = 0;
-  while (store.has(code)) code = String(1000 + (Math.abs(seed + ++bump) % 9000));
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
   return code;
 }
 
@@ -33,11 +40,16 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
-// Retrieve and consume a pending action (one-time use).
-export function takePending(code: string): PendingAction | undefined {
+// Retrieve and consume a pending action (one-time use). Channel-scoped: a CONFIRM
+// only fires an action staged for the SAME conversation, so a code leaked/observed
+// in one channel cannot trigger a write staged for another. A channel mismatch does
+// NOT consume the action — the rightful channel can still confirm it.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a) return undefined;
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
   store.delete(code);
   return a;
 }

--- a/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
@@ -113,7 +113,12 @@ describe("zws confirm-gated writes", () => {
     expect(code).toBeTruthy();
 
     fetchMock.mockResolvedValue({ ok: true, status: 201, data: { id: "t1" } });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets",
@@ -128,7 +133,12 @@ describe("zws confirm-gated writes", () => {
 
     const code = codeFromDelivery();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
-    await tryExecuteConfirm({ text: `CONFIRM ${code}`, actor: "t", logger: noopLogger as never });
+    await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "t",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
 
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/tickets/t9",
@@ -156,6 +166,7 @@ describe("zws confirm-gated writes", () => {
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(reply).toMatch(/No pending action/i);


### PR DESCRIPTION
## Summary

Follow-up to PR #44 (shell-injection hardening). Ports the **bigheadbot confirm-gate hardening** to the other four gated bots — **pulsebot, zoomwarriorssupportbot, cloudflow-support, scopelybot** — closing two confirm-gate vulnerabilities identified in the codex adversarial review:

- **B — cross-channel confirm escalation.** Pending write actions were keyed by code alone, so a `CONFIRM <code>` typed in *any* channel/DM could fire a write staged for a *different* channel. Now every staged action is bound to the conversation its prompt was posted to. `takePending(code, conversationId)` only consumes an action when the confirming channel matches; a CONFIRM from another channel is refused **and leaves the action intact** for the rightful channel.
- **C — guessable confirm codes.** `makeCode` used a deterministic seed (`codeSeed++ * 7919 + summary.length`), making the 4-digit code derivable from call order. Replaced with `crypto.randomInt(1000, 10000)` so the code is a real single-use security token.

Per-bot change is ~40 LOC, mirroring the already-merged bigheadbot reference (all five `pending-confirm.ts` are now identical modulo the header comment).

### Mechanism
- `gated.ts`: resolve `channel` first, then `putPending({ code, conversationId: channel, ... })`. Dropped the `codeSeed` counter.
- `pending-confirm.ts`: `PendingAction` gains `conversationId`; `makeCode()` is CSPRNG; `takePending(code, conversationId)` enforces the channel match without consuming on mismatch.
- `confirm.ts` / `user-maintenance-tools.ts`: `tryExecuteConfirm` takes `conversationId` and threads it to `takePending`.
- `index.ts`: `before_dispatch` passes `ctx.conversationId`.

`channel === ctx.conversationId` is the same channel identity the existing thread-anchor code already relies on (`getChannelThreadAnchor(channel)` pairs with `rememberChannelThreadAnchor(ctx.conversationId)`), so production confirms keep working; only cross-channel confirms are now rejected.

## Verification
- `node scripts/run-vitest.mjs` across all 5 bots: **141/141 pass** (24 test files), including a new "a CONFIRM from a DIFFERENT channel cannot fire the staged write" test per bot.
- `npm run tsgo:extensions`: **0 new type errors** (only the pre-existing fleet-wide `wrapToolWithAudit` factory `TS2345` remains).
- `oxfmt --check`: all 34 changed files correctly formatted.
- `oxlint` (oxlint.extensions): changed `pending-confirm.ts`/`gated.ts` hunks clean; remaining `curly` findings in `confirm.ts`/`index.ts` are pre-existing brace-less debt on unchanged lines (consistent with the merged bigheadbot reference).

## Scope note
34 files / >500 LOC, exceeding the usual gate — justified: a single security fix replicated verbatim across five structurally-identical bots. No new abstraction, no behavior change beyond the two findings.
