### PR TITLE
fix(zoom): fail-closed webhook intake, upload size cap + TTL, docx path confinement

### DIFF
--- a/extensions/zoom/src/monitor.ts
+++ b/extensions/zoom/src/monitor.ts
@@ -1,16 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { Request, Response } from "express";
 import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import { createZoomConversationStoreFs } from "./conversation-store-fs.js";
 import type { ZoomConversationStore } from "./conversation-store.js";
-import { formatUnknownError } from "./errors.js";
 import { createZoomMessageHandler } from "./monitor-handler.js";
 import type { ZoomMonitorLogger } from "./monitor-types.js";
 import { getZoomRuntime } from "./runtime.js";
 import { resolveZoomCredentials } from "./token.js";
-import type { ZoomConfig, ZoomCredentials } from "./types.js";
+import type { ZoomConfig, ZoomWebhookEvent } from "./types.js";
 import { createUploadRoutes } from "./upload-handler.js";
-import { resolveZoomUploadDir } from "./upload-path.js";
-import { handleZoomChallenge, verifyZoomWebhook } from "./webhook.js";
+import { isWithinUploadDir, resolveZoomUploadDir, UPLOAD_TTL_MS } from "./upload-path.js";
+import { createZoomWebhookRequestHandler } from "./webhook.js";
 
 export type MonitorZoomOpts = {
   cfg: OpenClawConfig;
@@ -39,6 +40,14 @@ export async function monitorZoomProvider(opts: MonitorZoomOpts): Promise<Monito
   if (!creds) {
     log.error("zoom credentials not configured");
     return { app: null, shutdown: async () => {} };
+  }
+  if (!creds.webhookSecretToken) {
+    // Loud at startup, enforced per-request: the webhook handler is fail-closed
+    // and will 401 everything until the secret is configured.
+    log.error(
+      "ZOOM_WEBHOOK_SECRET_TOKEN is not set — all inbound webhooks will be REJECTED (fail-closed). " +
+        "Set channels.zoom.webhookSecretToken or the env var to accept Zoom traffic.",
+    );
   }
 
   const runtime: RuntimeEnv = opts.runtime ?? {
@@ -99,70 +108,57 @@ export async function monitorZoomProvider(opts: MonitorZoomOpts): Promise<Monito
   expressApp.get("/zoom/file", uploadRoutes.handleGet);
   expressApp.post("/zoom/file", express.json({ limit: "15mb" }), uploadRoutes.handlePost);
 
-  // Serve uploaded files
+  // Serve uploaded files. Gated: path must resolve inside the uploads dir, the
+  // file must be younger than UPLOAD_TTL_MS (a download URL is a bearer secret —
+  // leaked links must expire), and dotfiles are denied.
   const uploadDir = resolveZoomUploadDir();
-  expressApp.use("/zoom/uploads", express.static(uploadDir));
-
-  // Webhook endpoint
-  expressApp.post(webhookPath, async (req: Request, res: Response) => {
-    try {
-      const rawBody = (req as Request & { rawBody?: string }).rawBody ?? JSON.stringify(req.body);
-      const signature = req.headers["x-zm-signature"] as string | undefined;
-      const timestamp = req.headers["x-zm-request-timestamp"] as string | undefined;
-
-      // Handle URL validation challenge
-      if (req.body?.event === "endpoint.url_validation") {
-        const plainToken = req.body.payload?.plainToken;
-        if (plainToken && creds.webhookSecretToken) {
-          const challenge = handleZoomChallenge({
-            plainToken,
-            secret: creds.webhookSecretToken,
-          });
-          log.debug("responding to URL validation challenge");
-          res.status(200).json(challenge);
-          return;
-        }
-        log.warn("URL validation received but missing plainToken or secret");
-        res.status(400).json({ error: "missing challenge data" });
+  expressApp.use(
+    "/zoom/uploads",
+    (req: Request, res: Response, next: () => void) => {
+      let rel: string;
+      try {
+        rel = decodeURIComponent(req.path.replace(/^\/+/, ""));
+      } catch {
+        res.status(404).end();
         return;
       }
-
-      // Verify webhook signature if secret is configured
-      if (creds.webhookSecretToken) {
-        if (!signature || !timestamp) {
-          log.warn("missing webhook signature headers");
-          res.status(401).json({ error: "missing signature" });
-          return;
-        }
-
-        const valid = verifyZoomWebhook({
-          payload: rawBody,
-          signature,
-          timestamp,
-          secret: creds.webhookSecretToken,
-        });
-
-        if (!valid) {
-          log.warn("invalid webhook signature");
-          res.status(401).json({ error: "invalid signature" });
-          return;
-        }
+      const resolved = path.resolve(uploadDir, rel);
+      if (!isWithinUploadDir(resolved)) {
+        res.status(404).end();
+        return;
       }
-
-      // Acknowledge webhook immediately
-      res.status(200).json({ status: "ok" });
-
-      // Process message asynchronously
-      await handleMessage(req.body);
-    } catch (err) {
-      log.error(
-        "webhook handler failed: " +
-          (err instanceof Error ? err.stack || err.message : String(err)),
-      );
-      if (!res.headersSent) {
-        res.status(500).json({ error: "internal error" });
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(resolved);
+      } catch {
+        res.status(404).end();
+        return;
       }
-    }
+      if (!stat.isFile() || Date.now() - stat.mtimeMs > UPLOAD_TTL_MS) {
+        res.status(404).end();
+        return;
+      }
+      next();
+    },
+    express.static(uploadDir, { dotfiles: "deny" }),
+  );
+
+  // Webhook endpoint. Fail-closed: rejects everything when no secret is set.
+  const handleWebhookRequest = createZoomWebhookRequestHandler({
+    webhookSecretToken: creds.webhookSecretToken,
+    log,
+    // The factory hands back the signature-verified request body; it is the
+    // Zoom webhook event shape the message handler expects.
+    handleMessage: (body) => handleMessage(body as ZoomWebhookEvent),
+  });
+  // Non-async express handler: handleWebhookRequest never rejects (it owns a
+  // catch-all and answers 500 itself), so void-ing the promise is safe and
+  // avoids the unhandled-rejection hazard of async endpoint handlers.
+  expressApp.post(webhookPath, (req: Request, res: Response) => {
+    void handleWebhookRequest(
+      Object.assign(req, { rawBody: (req as Request & { rawBody?: string }).rawBody }),
+      res,
+    );
   });
 
   // Health check endpoint

--- a/extensions/zoom/src/tools.ts
+++ b/extensions/zoom/src/tools.ts
@@ -2,13 +2,17 @@ import fs from "node:fs";
 import path from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-
 import { storePendingShare } from "./pending-shares.js";
-import { PREFILTER_CONFIG_PATH, DEFAULT_SYSTEM_PROMPT, DEFAULT_MODEL, readPrefilterConfig } from "./prefilter.js";
-import type { ZoomBodyItem, ZoomConfig } from "./types.js";
-import { createUploadToken } from "./upload-tokens.js";
-import { resolveZoomUploadDir } from "./upload-path.js";
+import {
+  PREFILTER_CONFIG_PATH,
+  DEFAULT_SYSTEM_PROMPT,
+  DEFAULT_MODEL,
+  readPrefilterConfig,
+} from "./prefilter.js";
 import { getRememberedZoomSessionReplyRoot } from "./thread-state.js";
+import type { ZoomBodyItem, ZoomConfig } from "./types.js";
+import { isWithinUploadDir, resolveZoomUploadDir } from "./upload-path.js";
+import { createUploadToken } from "./upload-tokens.js";
 
 function resolveSessionReplyMainMessageId(sessionKey?: string): string | undefined {
   const rememberedReplyRoot = getRememberedZoomSessionReplyRoot(sessionKey);
@@ -114,7 +118,9 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         "Send a direct message to a Zoom user (JID preferred; email/name best-effort). " +
         "Use this to redirect a conversation from a channel to a private DM.",
       parameters: Type.Object({
-        user_jid: Type.String({ description: "Recipient identifier: Zoom user JID (preferred), or email/name" }),
+        user_jid: Type.String({
+          description: "Recipient identifier: Zoom user JID (preferred), or email/name",
+        }),
         message: Type.String({ description: "Message text to send" }),
         heading: Type.Optional(Type.String({ description: "Message heading (default: OpenClaw)" })),
       }),
@@ -187,7 +193,9 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         const { lookupZoomUsers } = await import("./user-directory.js");
         const query = String(params.query ?? "").trim();
         const limitRaw = Number(params.limit ?? 5);
-        const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(20, Math.floor(limitRaw))) : 5;
+        const limit = Number.isFinite(limitRaw)
+          ? Math.max(1, Math.min(20, Math.floor(limitRaw)))
+          : 5;
 
         const hits = await lookupZoomUsers(query);
         const topHits = hits.slice(0, limit);
@@ -227,9 +235,7 @@ export function registerZoomTools(api: OpenClawPluginApi) {
             description: "Sender user email/ID (defaults to ZOOM_REPORT_USER)",
           }),
         ),
-        to_contact: Type.Optional(
-          Type.String({ description: "DM recipient email or JID" }),
-        ),
+        to_contact: Type.Optional(Type.String({ description: "DM recipient email or JID" })),
         to_channel: Type.Optional(
           Type.String({ description: "Channel ID or channel JID (...@conference.xmpp.zoom.us)" }),
         ),
@@ -277,7 +283,9 @@ export function registerZoomTools(api: OpenClawPluginApi) {
           { description: "Users to mention in the message" },
         ),
         message: Type.String({ description: "Message text following mentions" }),
-        mention_all: Type.Optional(Type.Boolean({ description: "Also include @all mention (default: false)" })),
+        mention_all: Type.Optional(
+          Type.Boolean({ description: "Also include @all mention (default: false)" }),
+        ),
         from_user: Type.Optional(
           Type.String({ description: "Sender user email/ID (defaults to ZOOM_REPORT_USER)" }),
         ),
@@ -341,9 +349,7 @@ export function registerZoomTools(api: OpenClawPluginApi) {
       parameters: Type.Object({
         channel_jid: Type.String({ description: "The channel JID to post to" }),
         message: Type.String({ description: "Message text to post" }),
-        heading: Type.Optional(
-          Type.String({ description: "Message heading (default: OpenClaw)" }),
-        ),
+        heading: Type.Optional(Type.String({ description: "Message heading (default: OpenClaw)" })),
         share_button: Type.Optional(
           Type.Boolean({
             description:
@@ -370,7 +376,10 @@ export function registerZoomTools(api: OpenClawPluginApi) {
               content: [
                 {
                   type: "text" as const,
-                  text: JSON.stringify({ ok: false, error: "user_jid required when share_button is true" }),
+                  text: JSON.stringify({
+                    ok: false,
+                    error: "user_jid required when share_button is true",
+                  }),
                 },
               ],
             };
@@ -450,10 +459,20 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         "Send the URL to the user in your reply. Use when the user needs to provide a file.",
       parameters: Type.Object({
         user_jid: Type.String({ description: "The user's JID" }),
-        conversation_id: Type.String({ description: "Current conversation ID for routing the response" }),
-        label: Type.Optional(Type.String({ description: "Context label for the file name, e.g. issue number like 'PROJ-1234'" })),
-        is_direct: Type.Optional(Type.Boolean({ description: "Whether this is a DM conversation (default: true)" })),
-        channel_jid: Type.Optional(Type.String({ description: "Channel JID if in a channel conversation" })),
+        conversation_id: Type.String({
+          description: "Current conversation ID for routing the response",
+        }),
+        label: Type.Optional(
+          Type.String({
+            description: "Context label for the file name, e.g. issue number like 'PROJ-1234'",
+          }),
+        ),
+        is_direct: Type.Optional(
+          Type.Boolean({ description: "Whether this is a DM conversation (default: true)" }),
+        ),
+        channel_jid: Type.Optional(
+          Type.String({ description: "Channel JID if in a channel conversation" }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         const userJid = params.user_jid as string;
@@ -482,7 +501,12 @@ export function registerZoomTools(api: OpenClawPluginApi) {
           content: [
             {
               type: "text" as const,
-              text: JSON.stringify({ ok: true, uploadUrl, token, hint: "Send the link as plain text or [Upload File](url) — do NOT wrap in bold **. Zoom breaks URLs inside **bold**." }),
+              text: JSON.stringify({
+                ok: true,
+                uploadUrl,
+                token,
+                hint: "Send the link as plain text or [Upload File](url) — do NOT wrap in bold **. Zoom breaks URLs inside **bold**.",
+              }),
             },
           ],
         };
@@ -501,16 +525,18 @@ export function registerZoomTools(api: OpenClawPluginApi) {
     async execute() {
       const config = readPrefilterConfig();
       return {
-        content: [{
-          type: "text" as const,
-          text: JSON.stringify({
-            ok: true,
-            configPath: PREFILTER_CONFIG_PATH,
-            systemPrompt: config.systemPrompt,
-            model: config.model ?? process.env.ZOOM_PREFILTER_MODEL ?? DEFAULT_MODEL,
-            isDefault: config.systemPrompt === DEFAULT_SYSTEM_PROMPT,
-          }),
-        }],
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: true,
+              configPath: PREFILTER_CONFIG_PATH,
+              systemPrompt: config.systemPrompt,
+              model: config.model ?? process.env.ZOOM_PREFILTER_MODEL ?? DEFAULT_MODEL,
+              isDefault: config.systemPrompt === DEFAULT_SYSTEM_PROMPT,
+            }),
+          },
+        ],
       };
     },
   }));
@@ -523,8 +549,14 @@ export function registerZoomTools(api: OpenClawPluginApi) {
       "in observe mode. Changes take effect immediately on the next message — no restart needed. " +
       "The prompt should instruct the classifier to reply with exactly RESPOND or SKIP.",
     parameters: Type.Object({
-      system_prompt: Type.String({ description: "The new system prompt for message classification" }),
-      model: Type.Optional(Type.String({ description: "Override the LLM model (default: anthropic/claude-haiku-4.5)" })),
+      system_prompt: Type.String({
+        description: "The new system prompt for message classification",
+      }),
+      model: Type.Optional(
+        Type.String({
+          description: "Override the LLM model (default: anthropic/claude-haiku-4.5)",
+        }),
+      ),
     }),
     async execute(_id: string, params: Record<string, unknown>) {
       try {
@@ -536,10 +568,15 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         fs.writeFileSync(PREFILTER_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
 
         return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({ ok: true, message: "Prefilter config updated. Changes take effect on the next message." }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                message: "Prefilter config updated. Changes take effect on the next message.",
+              }),
+            },
+          ],
         };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -563,8 +600,31 @@ export function registerZoomTools(api: OpenClawPluginApi) {
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         const filePath = params.file_path as string;
+        // Confine to the uploads dir (same guard as docx_get_download): these are
+        // model-invoked tools, so an unconfined path means a prompt-injected agent
+        // can read/write arbitrary files on the host.
+        if (!isWithinUploadDir(filePath)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: "File is outside the zoom-uploads directory",
+                }),
+              },
+            ],
+          };
+        }
         if (!fs.existsSync(filePath)) {
-          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "File not found" }) }] };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ ok: false, error: "File not found" }),
+              },
+            ],
+          };
         }
         const { readDocxParagraphs } = await import("./docx-tools.js");
         const paragraphs = await readDocxParagraphs(filePath);
@@ -595,8 +655,30 @@ export function registerZoomTools(api: OpenClawPluginApi) {
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         const filePath = params.file_path as string;
+        // Confined like docx_read: also keeps the _modified output inside the
+        // uploads dir (destPath derives from the source dir).
+        if (!isWithinUploadDir(filePath)) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: "File is outside the zoom-uploads directory",
+                }),
+              },
+            ],
+          };
+        }
         if (!fs.existsSync(filePath)) {
-          return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "File not found" }) }] };
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ ok: false, error: "File not found" }),
+              },
+            ],
+          };
         }
         const replacements = params.replacements as Array<{ find: string; replace: string }>;
         const ext = path.extname(filePath);
@@ -607,10 +689,17 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         const { replaceInDocx } = await import("./docx-tools.js");
         const result = await replaceInDocx(filePath, destPath, replacements);
         return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({ ok: true, output_path: destPath, applied: result.applied, skipped: result.skipped }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: true,
+                output_path: destPath,
+                applied: result.applied,
+                skipped: result.skipped,
+              }),
+            },
+          ],
         };
       },
     };
@@ -630,9 +719,19 @@ export function registerZoomTools(api: OpenClawPluginApi) {
       async execute(_id: string, params: Record<string, unknown>) {
         const filePath = params.file_path as string;
         const uploadDir = resolveZoomUploadDir();
-        if (!filePath.startsWith(uploadDir) || !fs.existsSync(filePath)) {
+        // isWithinUploadDir (not startsWith): a prefix test would accept sibling
+        // dirs like "zoom-uploads-evil".
+        if (!isWithinUploadDir(filePath) || !fs.existsSync(filePath)) {
           return {
-            content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: "File not found or outside uploads directory" }) }],
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error: "File not found or outside uploads directory",
+                }),
+              },
+            ],
           };
         }
         const relative = path.relative(uploadDir, filePath);
@@ -640,7 +739,12 @@ export function registerZoomTools(api: OpenClawPluginApi) {
         const publicUrl = zoomCfg?.publicUrl ?? "https://molty-dev.cloudwarriors.ai";
         const downloadUrl = `${publicUrl}/zoom/uploads/${relative}`;
         return {
-          content: [{ type: "text" as const, text: JSON.stringify({ ok: true, download_url: downloadUrl }) }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ ok: true, download_url: downloadUrl }),
+            },
+          ],
         };
       },
     };

--- a/extensions/zoom/src/upload-guards.test.ts
+++ b/extensions/zoom/src/upload-guards.test.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Redirect the uploads dir (derived from os.homedir at module load) into a temp
+// dir so these tests never touch the real ~/.openclaw tree.
+const TEST_HOME = vi.hoisted(() => {
+  const fsh = require("node:fs") as typeof import("node:fs");
+  const osh = require("node:os") as typeof import("node:os");
+  const pathh = require("node:path") as typeof import("node:path");
+  return fsh.mkdtempSync(pathh.join(osh.tmpdir(), "zoom-upload-guards-"));
+});
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, default: { ...actual, homedir: () => TEST_HOME }, homedir: () => TEST_HOME };
+});
+
+// The upload handler routes the processed upload to the agent — mock the heavy
+// monitor-handler/channel-memory modules; we assert the routing call only.
+const routeMessageToAgentMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("./monitor-handler.js", () => ({
+  routeMessageToAgent: (...args: unknown[]) => routeMessageToAgentMock(...args),
+  createZoomMessageHandler: () => async () => {},
+}));
+vi.mock("./channel-memory.js", () => ({
+  copyDocToCustomer: async () => {},
+  ensureCustomerDir: async () => {},
+  resolveWorkspaceDirForAgent: () => "/tmp/ws",
+}));
+
+import { createUploadRoutes, MAX_UPLOAD_BYTES } from "./upload-handler.js";
+import { isWithinUploadDir, resolveZoomUploadDir } from "./upload-path.js";
+import { createUploadToken, peekUploadToken } from "./upload-tokens.js";
+
+const noopLog = {
+  info: () => {},
+  debug: () => {},
+  warn: () => {},
+  error: () => {},
+} as never;
+
+function makeRes() {
+  const out: { code: number; body?: unknown } = { code: 200 };
+  const res = {
+    status(code: number) {
+      out.code = code;
+      return res;
+    },
+    json(body: unknown) {
+      out.body = body;
+      return res;
+    },
+    headersSent: false,
+  };
+  return { res, out };
+}
+
+function tokenCtx() {
+  return {
+    conversationId: "conv-1",
+    userJid: "user@xmpp.zoom.us",
+    isDirect: true,
+  };
+}
+
+describe("isWithinUploadDir", () => {
+  const uploadDir = resolveZoomUploadDir();
+
+  it("accepts a file inside the uploads dir", () => {
+    expect(isWithinUploadDir(path.join(uploadDir, "tok123", "doc.docx"))).toBe(true);
+  });
+
+  it("rejects the uploads dir itself, outside paths, sibling-prefix dirs, and traversal", () => {
+    expect(isWithinUploadDir(uploadDir)).toBe(false);
+    expect(isWithinUploadDir("/etc/passwd")).toBe(false);
+    // A naive startsWith() check would accept this sibling directory.
+    expect(isWithinUploadDir(`${uploadDir}-evil/doc.docx`)).toBe(false);
+    expect(isWithinUploadDir(path.join(uploadDir, "..", "secrets.json"))).toBe(false);
+  });
+});
+
+describe("upload handlePost size cap", () => {
+  beforeEach(() => {
+    routeMessageToAgentMock.mockClear();
+  });
+  afterEach(() => {
+    fs.rmSync(resolveZoomUploadDir(), { recursive: true, force: true });
+  });
+
+  function buildRoutes() {
+    return createUploadRoutes({ cfg: {}, log: noopLog } as never);
+  }
+
+  it("rejects an oversize file with 413 BEFORE consuming the token, writes nothing", async () => {
+    const routes = buildRoutes();
+    const token = createUploadToken(tokenCtx());
+    const oversize = Buffer.alloc(MAX_UPLOAD_BYTES + 1).toString("base64");
+    const { res, out } = makeRes();
+
+    await routes.handlePost(
+      {
+        body: {
+          token,
+          filename: "big.bin",
+          mimeType: "application/octet-stream",
+          size: 1,
+          data: oversize,
+        },
+      } as never,
+      res as never,
+    );
+
+    expect(out.code).toBe(413);
+    // Token survives the rejected attempt — the user keeps their upload link.
+    expect(peekUploadToken(token)).toBeDefined();
+    // Nothing was written to disk for this token.
+    expect(fs.existsSync(path.join(resolveZoomUploadDir(), token))).toBe(false);
+    expect(routeMessageToAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a small file: writes under the uploads dir, consumes the token, routes to the agent", async () => {
+    const routes = buildRoutes();
+    const token = createUploadToken(tokenCtx());
+    const data = Buffer.from("hello upload").toString("base64");
+    const { res, out } = makeRes();
+
+    await routes.handlePost(
+      { body: { token, filename: "note.txt", mimeType: "text/plain", size: 12, data } } as never,
+      res as never,
+    );
+
+    expect(out.code).toBe(200);
+    expect(out.body).toMatchObject({ ok: true });
+    const tokenDir = path.join(resolveZoomUploadDir(), token);
+    const files = fs.readdirSync(tokenDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/note\.txt$/);
+    // Single-use: the token is consumed.
+    expect(peekUploadToken(token)).toBeUndefined();
+    expect(routeMessageToAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid token with 401 and writes nothing", async () => {
+    const routes = buildRoutes();
+    const { res, out } = makeRes();
+    await routes.handlePost(
+      {
+        body: {
+          token: "not-a-real-token",
+          filename: "x.txt",
+          mimeType: "text/plain",
+          size: 1,
+          data: Buffer.from("x").toString("base64"),
+        },
+      } as never,
+      res as never,
+    );
+    expect(out.code).toBe(401);
+    expect(routeMessageToAgentMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/zoom/src/upload-handler.ts
+++ b/extensions/zoom/src/upload-handler.ts
@@ -1,33 +1,65 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { spawnSync } from "node:child_process";
 import type { Request, Response } from "express";
-
-import type { ZoomMessageHandlerDeps } from "./monitor-handler.js";
-import { routeMessageToAgent } from "./monitor-handler.js";
 import {
   copyDocToCustomer,
   ensureCustomerDir,
   resolveWorkspaceDirForAgent,
 } from "./channel-memory.js";
+import type { ZoomMessageHandlerDeps } from "./monitor-handler.js";
+import { routeMessageToAgent } from "./monitor-handler.js";
 import { getUploadErrorHtml, getUploadPageHtml } from "./upload-page.js";
-import { resolveZoomUploadDir } from "./upload-path.js";
+import { resolveZoomUploadDir, UPLOAD_TTL_MS } from "./upload-path.js";
 import { consumeUploadToken, peekUploadToken } from "./upload-tokens.js";
 
 const UPLOAD_DIR = resolveZoomUploadDir();
+// Server-side cap matching the advertised limit. The express body limit (15mb)
+// is NOT the enforcement point — base64 overhead would let ~11MB files through,
+// and client-side JS checks are trivially bypassed by POSTing JSON directly.
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const MAX_PREVIEW_BYTES = 2000;
 const MAX_PDF_PREVIEW_CHARS = 3000;
 const MAX_PDF_PREVIEW_LINES = 40;
 const DEFAULT_EXEC_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
-const PDFTOTEXT_CANDIDATES = Array.from(new Set([
-  process.env.PDFTOTEXT_BIN,
-  "/usr/bin/pdftotext",
-  "/usr/local/bin/pdftotext",
-  "pdftotext",
-].filter((entry): entry is string => Boolean(entry))));
+const PDFTOTEXT_CANDIDATES = Array.from(
+  new Set(
+    [
+      process.env.PDFTOTEXT_BIN,
+      "/usr/bin/pdftotext",
+      "/usr/local/bin/pdftotext",
+      "pdftotext",
+    ].filter((entry): entry is string => Boolean(entry)),
+  ),
+);
 
 function ensureDir(dir: string): void {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+}
+
+// Uploads are transient (the durable copy lives in the customer dir). Prune
+// token-dirs older than the TTL on each authorized upload — bounded cost (one
+// readdir per upload), no timer lifecycle to manage, and keeps the serve-side
+// TTL gate (monitor.ts) and on-disk state in agreement.
+function pruneExpiredUploads(): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(UPLOAD_DIR, { withFileTypes: true });
+  } catch {
+    return; // uploads dir may not exist yet
+  }
+  const cutoff = Date.now() - UPLOAD_TTL_MS;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dirPath = path.join(UPLOAD_DIR, entry.name);
+    try {
+      if (fs.statSync(dirPath).mtimeMs < cutoff) {
+        fs.rmSync(dirPath, { recursive: true, force: true });
+      }
+    } catch {
+      // best-effort cleanup; never fail an upload over it
+    }
+  }
 }
 
 export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
@@ -36,7 +68,10 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
   function handleGet(req: Request, res: Response): void {
     const token = req.query.token as string | undefined;
     if (!token || !peekUploadToken(token)) {
-      res.status(400).type("html").send(getUploadErrorHtml("This upload link is invalid or has expired."));
+      res
+        .status(400)
+        .type("html")
+        .send(getUploadErrorHtml("This upload link is invalid or has expired."));
       return;
     }
     res.type("html").send(getUploadPageHtml(token));
@@ -51,11 +86,27 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
         return;
       }
 
+      // Decode and enforce the size cap BEFORE consuming the single-use token,
+      // so an oversize attempt doesn't burn the user's upload link.
+      const base64Match = String(data).match(/^data:[^;]*;base64,(.*)$/);
+      const fileBuffer = base64Match
+        ? Buffer.from(base64Match[1], "base64")
+        : Buffer.from(String(data), "base64");
+      if (fileBuffer.length > MAX_UPLOAD_BYTES) {
+        res.status(413).json({
+          ok: false,
+          error: `File exceeds the ${Math.floor(MAX_UPLOAD_BYTES / (1024 * 1024))} MB limit.`,
+        });
+        return;
+      }
+
       const ctx = consumeUploadToken(token as string);
       if (!ctx) {
         res.status(401).json({ ok: false, error: "Invalid or expired upload token." });
         return;
       }
+
+      pruneExpiredUploads();
 
       const tokenDir = path.join(UPLOAD_DIR, token as string);
       ensureDir(tokenDir);
@@ -66,15 +117,9 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
       const ext = path.extname(origName);
       const base = path.basename(origName, ext);
       const labelSlug = ctx.label ? ctx.label.replace(/[^a-zA-Z0-9_-]/g, "_") : "";
-      const safeName = labelSlug
-        ? `${labelSlug}_${date}_${base}${ext}`
-        : `${date}_${base}${ext}`;
+      const safeName = labelSlug ? `${labelSlug}_${date}_${base}${ext}` : `${date}_${base}${ext}`;
       const filePath = path.join(tokenDir, safeName);
 
-      const base64Match = String(data).match(/^data:[^;]*;base64,(.*)$/);
-      const fileBuffer = base64Match
-        ? Buffer.from(base64Match[1], "base64")
-        : Buffer.from(String(data), "base64");
       fs.writeFileSync(filePath, fileBuffer);
 
       const sizeKB = Math.round((size as number) / 1024);
@@ -96,7 +141,10 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
               encoding: "utf-8",
               timeout: 8000,
               maxBuffer: 2 * 1024 * 1024,
-              env: { ...process.env, PATH: [process.env.PATH, DEFAULT_EXEC_PATH].filter(Boolean).join(":") },
+              env: {
+                ...process.env,
+                PATH: [process.env.PATH, DEFAULT_EXEC_PATH].filter(Boolean).join(":"),
+              },
             });
             if (result.status === 0 && result.stdout) {
               pdfText = String(result.stdout);
@@ -111,7 +159,9 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
               `signal=${result.signal ?? "none"}`,
               err ? `error=${err}` : "",
               stderr ? `stderr=${stderr}` : "",
-            ].filter(Boolean).join(" ");
+            ]
+              .filter(Boolean)
+              .join(" ");
           } catch (err) {
             extractionDetails = `bin=${bin} threw=${String(err)}`;
           }
@@ -124,9 +174,10 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
           const preview = lines.join("\n");
           const truncatedByChars = normalized.length > sliced.length;
           const truncatedByLines = sliced.split("\n").length > lines.length;
-          const truncated = (truncatedByChars || truncatedByLines)
-            ? `\n\n_(truncated — full PDF is ${sizeKB}KB, use \`exec pdftotext \"${filePath}\" -\` for full text)_`
-            : "";
+          const truncated =
+            truncatedByChars || truncatedByLines
+              ? `\n\n_(truncated — full PDF is ${sizeKB}KB, use \`exec pdftotext \"${filePath}\" -\` for full text)_`
+              : "";
           const totalLines = normalized.split("\n").length;
           agentText = `[FILE_UPLOAD pdf] ${safeName} (${sizeKB}KB, ${totalLines} text lines) saved to ${filePath}\n\nPreview (first ${lines.length} lines):\n${preview}${truncated}`;
         } else {
@@ -144,8 +195,9 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
       ) {
         const { readDocxParagraphs } = await import("./docx-tools.js");
         const paragraphs = await readDocxParagraphs(filePath);
-        const preview = paragraphs.slice(0, 10)
-          .map(p => `[${p.index}${p.style ? ` ${p.style}` : ""}] ${p.text}`)
+        const preview = paragraphs
+          .slice(0, 10)
+          .map((p) => `[${p.index}${p.style ? ` ${p.style}` : ""}] ${p.text}`)
           .join("\n");
         agentText = `[FILE_UPLOAD docx] ${safeName} (${sizeKB}KB, ${paragraphs.length} paragraphs) saved to ${filePath}\n\nPreview (first 10 paragraphs):\n${preview}`;
       } else if (
@@ -156,7 +208,10 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
       ) {
         const preview = fileBuffer.subarray(0, MAX_PREVIEW_BYTES).toString("utf-8");
         const lines = preview.split("\n");
-        const truncated = fileBuffer.length > MAX_PREVIEW_BYTES ? `\n\n_(truncated — full file is ${sizeKB}KB, use \`exec cat ${filePath}\` to read more)_` : "";
+        const truncated =
+          fileBuffer.length > MAX_PREVIEW_BYTES
+            ? `\n\n_(truncated — full file is ${sizeKB}KB, use \`exec cat ${filePath}\` to read more)_`
+            : "";
         agentText = `[FILE_UPLOAD document] ${safeName} (${mime}, ${sizeKB}KB, ${fileBuffer.toString("utf-8").split("\n").length} lines) saved to ${filePath}\n\nPreview (first ${lines.length} lines):\n${preview}${truncated}`;
       } else {
         agentText = `[FILE_UPLOAD] ${safeName} (${mime}, ${sizeKB}KB) saved to ${filePath}`;
@@ -164,7 +219,11 @@ export function createUploadRoutes(deps: ZoomMessageHandlerDeps) {
 
       // Copy uploaded file to the customer directory if we have a channel context
       if (ctx.channelName) {
-        const slug = ctx.channelName.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "unknown";
+        const slug =
+          ctx.channelName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-|-$/g, "") || "unknown";
         try {
           const workspaceDir = resolveWorkspaceDirForAgent(cfg, ctx.agentId);
           await ensureCustomerDir(slug, ctx.channelName, ctx.channelJid, workspaceDir);

--- a/extensions/zoom/src/upload-path.ts
+++ b/extensions/zoom/src/upload-path.ts
@@ -8,3 +8,19 @@ import path from "node:path";
 export function resolveZoomUploadDir(): string {
   return path.resolve(os.homedir(), ".openclaw", "media", "zoom-uploads");
 }
+
+// Uploads are transient hand-off artifacts (the durable copy goes to the customer
+// dir). After this window they are no longer served and get pruned on the next
+// upload. Bounds both disk growth and how long a leaked download URL stays live.
+export const UPLOAD_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * True only when filePath resolves to a location strictly inside the uploads dir.
+ * Canonical resolve + relative check — a plain startsWith prefix test would accept
+ * sibling dirs like "zoom-uploads-evil" and traversal via "..".
+ */
+export function isWithinUploadDir(filePath: string): boolean {
+  const uploadDir = resolveZoomUploadDir();
+  const rel = path.relative(uploadDir, path.resolve(filePath));
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}

--- a/extensions/zoom/src/webhook.test.ts
+++ b/extensions/zoom/src/webhook.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { verifyZoomWebhook, handleZoomChallenge } from "./webhook.js";
+import { describe, it, expect, vi } from "vitest";
+import {
+  createZoomWebhookRequestHandler,
+  handleZoomChallenge,
+  verifyZoomWebhook,
+} from "./webhook.js";
 
 describe("verifyZoomWebhook", () => {
   const secret = "test-secret-token";
@@ -81,5 +85,133 @@ describe("handleZoomChallenge", () => {
     const result2 = handleZoomChallenge({ plainToken, secret: "secret2" });
 
     expect(result1.encryptedToken).not.toBe(result2.encryptedToken);
+  });
+});
+
+describe("createZoomWebhookRequestHandler (fail-closed intake)", () => {
+  const secret = "test-secret-token";
+  const noopLog = { debug: () => {}, warn: () => {}, error: () => {} };
+
+  function makeRes() {
+    const out: { code?: number; body?: unknown } = {};
+    return {
+      res: {
+        status(code: number) {
+          out.code = code;
+          return { json: (body: unknown) => void (out.body = body) };
+        },
+      },
+      out,
+    };
+  }
+
+  function sign(payload: string, timestamp: string): string {
+    const crypto = require("node:crypto");
+    const hash = crypto
+      .createHmac("sha256", secret)
+      .update(`v0:${timestamp}:${payload}`)
+      .digest("hex");
+    return `v0=${hash}`;
+  }
+
+  it("rejects EVERY request with 401 when no secret is configured (fail-closed)", async () => {
+    const handleMessage = vi.fn();
+    const handler = createZoomWebhookRequestHandler({
+      webhookSecretToken: undefined,
+      log: noopLog,
+      handleMessage,
+    });
+    const { res, out } = makeRes();
+    // Even a correctly-shaped, signed-looking request must be rejected.
+    const payload = '{"event":"bot_notification"}';
+    await handler(
+      {
+        body: { event: "bot_notification" },
+        headers: { "x-zm-signature": "v0=deadbeef", "x-zm-request-timestamp": "123" },
+        rawBody: payload,
+      },
+      res,
+    );
+    expect(out.code).toBe(401);
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("accepts a correctly signed request and dispatches it", async () => {
+    const handleMessage = vi.fn().mockResolvedValue(undefined);
+    const handler = createZoomWebhookRequestHandler({
+      webhookSecretToken: secret,
+      log: noopLog,
+      handleMessage,
+    });
+    const { res, out } = makeRes();
+    const payload = '{"event":"bot_notification"}';
+    const timestamp = "1234567890";
+    await handler(
+      {
+        body: { event: "bot_notification" },
+        headers: {
+          "x-zm-signature": sign(payload, timestamp),
+          "x-zm-request-timestamp": timestamp,
+        },
+        rawBody: payload,
+      },
+      res,
+    );
+    expect(out.code).toBe(200);
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a bad signature and does not dispatch", async () => {
+    const handleMessage = vi.fn();
+    const handler = createZoomWebhookRequestHandler({
+      webhookSecretToken: secret,
+      log: noopLog,
+      handleMessage,
+    });
+    const { res, out } = makeRes();
+    await handler(
+      {
+        body: { event: "bot_notification" },
+        headers: { "x-zm-signature": "v0=wrong", "x-zm-request-timestamp": "1234567890" },
+        rawBody: '{"event":"bot_notification"}',
+      },
+      res,
+    );
+    expect(out.code).toBe(401);
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects when signature headers are missing", async () => {
+    const handleMessage = vi.fn();
+    const handler = createZoomWebhookRequestHandler({
+      webhookSecretToken: secret,
+      log: noopLog,
+      handleMessage,
+    });
+    const { res, out } = makeRes();
+    await handler({ body: { event: "bot_notification" }, headers: {}, rawBody: "{}" }, res);
+    expect(out.code).toBe(401);
+    expect(handleMessage).not.toHaveBeenCalled();
+  });
+
+  it("answers the URL validation challenge when the secret is configured", async () => {
+    const handler = createZoomWebhookRequestHandler({
+      webhookSecretToken: secret,
+      log: noopLog,
+      handleMessage: vi.fn(),
+    });
+    const { res, out } = makeRes();
+    await handler(
+      {
+        body: { event: "endpoint.url_validation", payload: { plainToken: "abc" } },
+        headers: {},
+        rawBody: "{}",
+      },
+      res,
+    );
+    expect(out.code).toBe(200);
+    expect((out.body as { encryptedToken: string }).encryptedToken).toBe(
+      handleZoomChallenge({ plainToken: "abc", secret }).encryptedToken,
+    );
   });
 });

--- a/extensions/zoom/src/webhook.ts
+++ b/extensions/zoom/src/webhook.ts
@@ -51,10 +51,10 @@ export function verifyZoomWebhook(params: {
  *
  * https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint
  */
-export function handleZoomChallenge(params: {
+export function handleZoomChallenge(params: { plainToken: string; secret: string }): {
   plainToken: string;
-  secret: string;
-}): { plainToken: string; encryptedToken: string } {
+  encryptedToken: string;
+} {
   const { plainToken, secret } = params;
 
   const encryptedToken = createHmac("sha256", secret).update(plainToken).digest("hex");
@@ -62,5 +62,104 @@ export function handleZoomChallenge(params: {
   return {
     plainToken,
     encryptedToken,
+  };
+}
+
+// Minimal request/response shapes so the handler is unit-testable without express.
+type WebhookRequest = {
+  body?: { event?: string; payload?: { plainToken?: string } } & Record<string, unknown>;
+  headers: Record<string, string | string[] | undefined>;
+  rawBody?: string;
+};
+type WebhookResponse = {
+  status: (code: number) => { json: (body: unknown) => void };
+  headersSent?: boolean;
+};
+// debug is optional to match the runtime child logger's shape.
+type WebhookLogger = {
+  debug?: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+/**
+ * Webhook intake handler — FAIL-CLOSED. Without a configured webhookSecretToken
+ * every request is rejected 401: this endpoint is internet-facing (the zoom
+ * plugin runs its own express listener behind a public reverse proxy) and an
+ * unsigned webhook would otherwise drive the full button/command tree and
+ * upload-token minting. A missing secret must never silently disable auth.
+ */
+export function createZoomWebhookRequestHandler(deps: {
+  webhookSecretToken: string | undefined;
+  log: WebhookLogger;
+  handleMessage: (body: unknown) => Promise<void>;
+}) {
+  const { webhookSecretToken, log, handleMessage } = deps;
+
+  return async function handleWebhookRequest(
+    req: WebhookRequest,
+    res: WebhookResponse,
+  ): Promise<void> {
+    try {
+      const rawBody = req.rawBody ?? JSON.stringify(req.body);
+      const signature = req.headers["x-zm-signature"] as string | undefined;
+      const timestamp = req.headers["x-zm-request-timestamp"] as string | undefined;
+
+      // Fail closed: no secret configured means no request can be authenticated.
+      if (!webhookSecretToken) {
+        log.error(
+          "webhook rejected: ZOOM_WEBHOOK_SECRET_TOKEN / channels.zoom.webhookSecretToken not configured (fail-closed)",
+        );
+        res.status(401).json({ error: "webhook secret not configured" });
+        return;
+      }
+
+      // Handle URL validation challenge
+      if (req.body?.event === "endpoint.url_validation") {
+        const plainToken = req.body.payload?.plainToken;
+        if (plainToken) {
+          const challenge = handleZoomChallenge({ plainToken, secret: webhookSecretToken });
+          log.debug?.("responding to URL validation challenge");
+          res.status(200).json(challenge);
+          return;
+        }
+        log.warn("URL validation received but missing plainToken");
+        res.status(400).json({ error: "missing challenge data" });
+        return;
+      }
+
+      if (!signature || !timestamp) {
+        log.warn("missing webhook signature headers");
+        res.status(401).json({ error: "missing signature" });
+        return;
+      }
+
+      const valid = verifyZoomWebhook({
+        payload: rawBody,
+        signature,
+        timestamp,
+        secret: webhookSecretToken,
+      });
+
+      if (!valid) {
+        log.warn("invalid webhook signature");
+        res.status(401).json({ error: "invalid signature" });
+        return;
+      }
+
+      // Acknowledge webhook immediately
+      res.status(200).json({ status: "ok" });
+
+      // Process message asynchronously
+      await handleMessage(req.body);
+    } catch (err) {
+      log.error(
+        "webhook handler failed: " +
+          (err instanceof Error ? err.stack || err.message : String(err)),
+      );
+      if (!res.headersSent) {
+        res.status(500).json({ error: "internal error" });
+      }
+    }
   };
 }


### PR DESCRIPTION
## Summary

Closes the three P0 zoom trust-boundary findings from the production-readiness review. The zoom plugin runs its **own express listener on :4000, internet-facing via Traefik** — it is not behind gateway auth, so its intake must fail closed.

1. **Webhook fail-open → fail-closed.** `monitor.ts` previously *skipped signature verification entirely* when `ZOOM_WEBHOOK_SECRET_TOKEN` was unset (and `.env-template` ships it empty) — an unauthenticated webhook could drive the full button/command tree and mint upload tokens. New `createZoomWebhookRequestHandler` factory rejects **every** request 401 when no secret is configured, plus a loud startup error.
2. **Upload hardening.** Server-side `MAX_UPLOAD_BYTES` (10 MB) enforced **before** the single-use token is consumed (the old "10MB" check was client-JS only; real cap was the 15mb express JSON limit ≈ 11MB effective). Expired token-dirs pruned on each authorized upload (7-day TTL). `/zoom/uploads` static serve now gated: canonical path confinement, TTL expiry (download URLs are bearer secrets), `dotfiles: deny`.
3. **docx path confinement.** `docx_read`/`docx_replace` accepted arbitrary absolute paths; all three docx tools now use `isWithinUploadDir` — a canonical `path.resolve`+`relative` guard (the previous `startsWith` check in `docx_get_download` would accept sibling dirs like `zoom-uploads-evil`).

## Verification

- `node scripts/run-vitest.mjs extensions/zoom extensions/devtools` → **17 files / 116 tests passed** (includes 5 new fail-closed webhook intake tests + 5 new upload-guard tests: oversize 413 without burning the token, traversal/sibling-dir rejection, invalid-token 401).
- Full modified-surface run `extensions/{scopelybot,external-org-autopilot,devtools,zoom}` → **27 files / 180 tests passed**.
- `tsgo:extensions`: zero new errors in changed files (remaining `monitor.ts` TS2722s are the pre-existing optional `log.debug` pattern, present on development; `webhook.ts` clean).
- oxlint: changed-file errors fixed on authored lines (unused imports, non-async express handler); remaining hits are the documented pre-existing fleet baseline (curly style etc., same as PRs #44/#45).
- Fork CI context: check-lint/prod-types/test-types/boundaries/contracts/core-fast are perpetually red on this fork (see #42–#45); merge gate is the failing-check subset comparison vs the prior PR.
