### PR TITLE
fix(fleet): fail-closed prod env contract + EOA confirm-gate

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -49,6 +49,32 @@ ZW2_URL=https://dev2.api.zoomwarriors.com
 ZW2_USERNAME=
 ZW2_PASSWORD=
 
+# Gateway auth token (no default — compose passes it straight through; the
+# consuming code fails closed when unset).
+OPENCLAW_GATEWAY_TOKEN=
+
+# Tesseract ETL backend. No prod fallback: unset = tesseract tools disabled.
+# Internal URL example: http://playground-backend:8000
+# External (browser-accessible) URL example: http://localhost:8130
+TESSERACT_URL=
+TESSERACT_EXTERNAL_URL=
+TESSERACT_USERNAME=
+TESSERACT_PASSWORD=
+
+# Bighead avatar API (BIGHEAD_API_URL defaults to the compose-internal
+# http://bighead:8000; the token has NO default — join tool fails closed).
+BIGHEAD_GATEWAY_TOKEN=
+
+# Confirm-gate channel bindings (Zoom channel JIDs). Each bot posts its
+# CONFIRM <code> prompt to its channel and only a reply FROM that channel can
+# fire the staged write. Unset = write staging disabled for that bot.
+SCOPELYBOT_ZOOM_CHANNEL=
+BIGHEADBOT_ZOOM_CHANNEL=
+PULSEBOT_ZOOM_CHANNEL=
+ZWS_ZOOM_CHANNEL=
+CF_ZOOM_CHANNEL=
+EOA_ZOOM_CHANNEL=
+
 # Zoom S2S OAuth (Team Chat App)
 ZOOM_CLIENT_ID=
 ZOOM_CLIENT_SECRET=
@@ -77,7 +103,8 @@ GITHUB_BOT_WEBHOOK_SECRET=
 ADMIN_USERS=
 
 # Secrets parameterized out of docker-compose.dev.yml (2026-06-04).
-# On the deploy host these must be set in .env; compose no longer hardcodes them.
+# On the deploy host these must be set in .env; compose no longer hardcodes
+# them and the template carries NO real values (2026-06-09).
 PEA_RELAY_TOKEN=
-DEA_ES_PASSWORD=tesseract_elastic_dev
-DEVTOOLS_LOCAL_KEY=devtools-local-key-2026
+DEA_ES_PASSWORD=
+DEVTOOLS_LOCAL_KEY=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -34,8 +34,10 @@ services:
     - PROJECT_PULSE_URL=${PROJECT_PULSE_URL}
     - PROJECT_PULSE_EMAIL=${PROJECT_PULSE_EMAIL}
     - PROJECT_PULSE_PASSWORD=${PROJECT_PULSE_PASSWORD}
-    - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-dev-token}
-    - CLAWDBOT_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN:-dev-token}
+    # No baked-in credential defaults: a missing var must fail closed in the
+    # consuming code, never silently authenticate with a placeholder.
+    - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+    - CLAWDBOT_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
     - BIGHEAD_API_URL=http://bighead:8000
     - ZW2_USERNAME=${ZW2_USERNAME}
     - ZW2_PASSWORD=${ZW2_PASSWORD}
@@ -50,29 +52,31 @@ services:
     - ZOOM_REPORT_CLIENT_SECRET=${ZOOM_REPORT_CLIENT_SECRET}
     - ZOOM_REPORT_USER=${ZOOM_REPORT_USER}
     - MENTION_PROXY=${MENTION_PROXY}
-    - TESSERACT_URL=${TESSERACT_URL:-https://api.tesseract.pscx.ai}
-    - TESSERACT_EXTERNAL_URL=${TESSERACT_EXTERNAL_URL:-https://api.tesseract.pscx.ai}
+    # No prod-URL fallback: an unconfigured deployment must NOT silently point
+    # at the production Tesseract backend. Unset = tesseract tools error out.
+    - TESSERACT_URL=${TESSERACT_URL}
+    - TESSERACT_EXTERNAL_URL=${TESSERACT_EXTERNAL_URL}
     - TESSERACT_USERNAME=${TESSERACT_USERNAME}
     - TESSERACT_PASSWORD=${TESSERACT_PASSWORD}
     - ADMIN_DOMAIN=${ADMIN_DOMAIN:-cloudwarriors.ai}
     - GH_TOKEN=${GITHUB_READ_ACCESS}
     - DEVTOOLS_API_URL=http://devtools-api:9100
-    - DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY:-devtools-local-key-2026}
+    - DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
     - CCMCP_DEVTOOLS_API_URL=http://devtools-api:9100
-    - CCMCP_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY:-devtools-local-key-2026}
+    - CCMCP_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
     - NODE_OPTIONS=--max-old-space-size=3072
     - CW_CHAT_RESPONDER_URL=http://zoom_knowledge_expert:8007
     - CW_CHAT_RESPONDER_TOKEN=
     - DEA_ES_URL=http://172.18.0.1:9200
     - DEA_ES_USER=elastic
-    - DEA_ES_PASSWORD=${DEA_ES_PASSWORD:-tesseract_elastic_dev}
+    - DEA_ES_PASSWORD=${DEA_ES_PASSWORD}
     - DEA_ES_INDEX=logs-noobbox.docker-events-default
-    - DEA_ZOOM_CHANNEL=14cb8d88bcf648a1b37fca3269bb26a9@conference.xmpp.zoom.us${CW_CHAT_RESPONDER_TOKEN}
+    - DEA_ZOOM_CHANNEL=14cb8d88bcf648a1b37fca3269bb26a9@conference.xmpp.zoom.us
     - PEA_ZOOM_CHANNEL=1846224734124413b325518f16272cf8@conference.xmpp.zoom.us
     - PEA_RELAY_TOKEN=${PEA_RELAY_TOKEN}
     - PEA_RELAY_URL=http://172.18.0.1:19201
     - ZKE_DEVTOOLS_API_URL=http://devtools-api:9100
-    - ZKE_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY:-devtools-local-key-2026}
+    - ZKE_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
     - SCOPELY_BASE_URL=${SCOPELY_BASE_URL:-https://vip.pscx.ai}
     - SCOPELY_URL=${SCOPELY_URL:-${SCOPELY_BASE_URL:-https://vip.pscx.ai}}
     - SCOPELY_EMAIL=${SCOPELY_EMAIL}
@@ -82,6 +86,14 @@ services:
     - SCOPELY_DEV_TOOLS_API=${SCOPELY_DEV_TOOLS_API}
     - SCOPELY_REPO_PATH=${SCOPELY_REPO_PATH:-/app/code/scopely}
     - SCOPELYBOT_ZOOM_CHANNEL=${SCOPELYBOT_ZOOM_CHANNEL}
+    # Confirm-gate channel bindings: each bot's staged writes post their CONFIRM
+    # prompt here and only a reply FROM this channel can fire them. Unset =
+    # write staging is disabled (fail-closed) for that bot.
+    - BIGHEADBOT_ZOOM_CHANNEL=${BIGHEADBOT_ZOOM_CHANNEL}
+    - PULSEBOT_ZOOM_CHANNEL=${PULSEBOT_ZOOM_CHANNEL}
+    - ZWS_ZOOM_CHANNEL=${ZWS_ZOOM_CHANNEL}
+    - CF_ZOOM_CHANNEL=${CF_ZOOM_CHANNEL}
+    - EOA_ZOOM_CHANNEL=${EOA_ZOOM_CHANNEL}
     - PASSTHROUGH_RUNNER_ENABLED=${PASSTHROUGH_RUNNER_ENABLED:-0}
     - PASSTHROUGH_ALERT_THRESHOLD=${PASSTHROUGH_ALERT_THRESHOLD:-2}
     - PASSTHROUGH_INTERVAL_MS=${PASSTHROUGH_INTERVAL_MS:-}

--- a/extensions/bighead/index.ts
+++ b/extensions/bighead/index.ts
@@ -5,12 +5,18 @@ import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 const plugin = {
   id: "bighead",
   name: "Bighead",
-  description: "Bighead AI avatar integration - send Rebecca to join Zoom meetings (multiworker, user-scoped sessions)",
+  description:
+    "Bighead AI avatar integration - send Rebecca to join Zoom meetings (multiworker, user-scoped sessions)",
   configSchema: emptyPluginConfigSchema(),
 
   register(api: OpenClawPluginApi) {
+    // "bighead" is the compose-internal service name — not reachable outside the
+    // deployment network, so a default host is safe. The token has NO default:
+    // a baked-in placeholder ("dev-token") could silently authenticate against a
+    // backend that ships the same placeholder. Fail closed instead.
     const bigheadUrl = () => process.env.BIGHEAD_API_URL ?? "http://bighead:8000";
-    const bigheadToken = () => process.env.BIGHEAD_GATEWAY_TOKEN ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? "dev-token";
+    const bigheadToken = () =>
+      process.env.BIGHEAD_GATEWAY_TOKEN ?? process.env.OPENCLAW_GATEWAY_TOKEN ?? "";
 
     // bighead_join_meeting - spawns a dedicated worker per session
     api.registerTool(() => ({
@@ -56,12 +62,29 @@ const plugin = {
         const displayName = (params.display_name as string) ?? undefined;
         const announcement = (params.announcement as string) ?? undefined;
 
+        const token = bigheadToken();
+        if (!token) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  ok: false,
+                  error:
+                    "BIGHEAD_GATEWAY_TOKEN (or OPENCLAW_GATEWAY_TOKEN) is not set — " +
+                    "refusing to call Bighead without a real token (fail-closed).",
+                }),
+              },
+            ],
+          };
+        }
+
         try {
           const resp = await fetch(`${bigheadUrl()}/api/sessions/start-by-email`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Authorization: `Bearer ${bigheadToken()}`,
+              Authorization: `Bearer ${token}`,
             },
             body: JSON.stringify({
               user_email: userEmail,
@@ -131,7 +154,12 @@ const plugin = {
 
           if (!resp.ok) {
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: data.error ?? `HTTP ${resp.status}` }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ ok: false, error: data.error ?? `HTTP ${resp.status}` }),
+                },
+              ],
             };
           }
 
@@ -141,7 +169,9 @@ const plugin = {
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           return {
-            content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+            content: [
+              { type: "text" as const, text: JSON.stringify({ ok: false, error: message }) },
+            ],
           };
         }
       },
@@ -176,7 +206,12 @@ const plugin = {
 
           if (!resp.ok) {
             return {
-              content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: data.error ?? `HTTP ${resp.status}` }) }],
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ ok: false, error: data.error ?? `HTTP ${resp.status}` }),
+                },
+              ],
             };
           }
 
@@ -186,7 +221,9 @@ const plugin = {
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           return {
-            content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+            content: [
+              { type: "text" as const, text: JSON.stringify({ ok: false, error: message }) },
+            ],
           };
         }
       },

--- a/extensions/devtools/src/api-client.ts
+++ b/extensions/devtools/src/api-client.ts
@@ -1,19 +1,28 @@
-const DEVTOOLS_BASE = process.env.DEVTOOLS_API_URL ?? "https://devtools-api.cloudwarriors.ai";
-const DEVTOOLS_TOKEN = process.env.DEV_TOOLS_API ?? "";
+// Read env at call time (not module load) so env that loads after import — and
+// test stubbing — both resolve correctly. No baked-in base-URL fallback: pointing
+// a missing-config deployment silently at the production devtools host (with
+// whatever token happens to be set) is exactly the failure mode we refuse.
+const DEVTOOLS_BASE = () => process.env.DEVTOOLS_API_URL ?? "";
+const DEVTOOLS_TOKEN = () => process.env.DEV_TOOLS_API ?? "";
 
 export async function devtoolsFetch(
   endpoint: string,
   options?: RequestInit,
 ): Promise<{ ok: boolean; status: number; data: unknown }> {
-  if (!DEVTOOLS_TOKEN) {
+  const base = DEVTOOLS_BASE();
+  const token = DEVTOOLS_TOKEN();
+  if (!base) {
+    return { ok: false, status: 0, data: { error: "DEVTOOLS_API_URL env var not set" } };
+  }
+  if (!token) {
     return { ok: false, status: 0, data: { error: "DEV_TOOLS_API env var not set" } };
   }
 
-  const resp = await fetch(`${DEVTOOLS_BASE}${endpoint}`, {
+  const resp = await fetch(`${base}${endpoint}`, {
     ...options,
     headers: {
       ...options?.headers,
-      Authorization: `Bearer ${DEVTOOLS_TOKEN}`,
+      Authorization: `Bearer ${token}`,
     },
   });
 

--- a/extensions/devtools/src/devtools-guards.test.ts
+++ b/extensions/devtools/src/devtools-guards.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { devtoolsFetch } from "./api-client.js";
+import { assertReadOnlySql, registerTools } from "./tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerTools(api);
+  return tools;
+}
+
+const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
+
+const fetchMock = vi.fn();
+
+describe("devtools env contract (fail-closed)", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    delete process.env.DEVTOOLS_API_URL;
+    delete process.env.DEV_TOOLS_API;
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DEVTOOLS_API_URL;
+    delete process.env.DEV_TOOLS_API;
+  });
+
+  it("refuses to call out when DEVTOOLS_API_URL is unset (no baked-in prod URL)", async () => {
+    process.env.DEV_TOOLS_API = "tok";
+    const res = await devtoolsFetch("/api/v1/containers");
+    expect(res.ok).toBe(false);
+    expect(JSON.stringify(res.data)).toContain("DEVTOOLS_API_URL");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to call out when DEV_TOOLS_API token is unset", async () => {
+    process.env.DEVTOOLS_API_URL = "http://devtools-api:9100";
+    const res = await devtoolsFetch("/api/v1/containers");
+    expect(res.ok).toBe(false);
+    expect(JSON.stringify(res.data)).toContain("DEV_TOOLS_API");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sends the bearer token to the configured base when both are set", async () => {
+    process.env.DEVTOOLS_API_URL = "http://devtools-api:9100";
+    process.env.DEV_TOOLS_API = "tok";
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({ fine: true }),
+    });
+    const res = await devtoolsFetch("/api/v1/containers");
+    expect(res.ok).toBe(true);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://devtools-api:9100/api/v1/containers");
+    expect(opts.headers.Authorization).toBe("Bearer tok");
+  });
+});
+
+describe("assertReadOnlySql", () => {
+  it("allows SELECT and WITH (tolerating one trailing semicolon)", () => {
+    expect(assertReadOnlySql("SELECT * FROM users")).toBeUndefined();
+    expect(assertReadOnlySql("  with x as (select 1) select * from x;  ")).toBeUndefined();
+  });
+
+  it("rejects non-read statements", () => {
+    for (const sql of [
+      "UPDATE users SET role='admin'",
+      "DELETE FROM users",
+      "INSERT INTO users VALUES (1)",
+      "DROP TABLE users",
+      "selecting", // word-boundary check: not a SELECT
+    ]) {
+      expect(assertReadOnlySql(sql), sql).toBeDefined();
+    }
+  });
+
+  it("rejects stacked statements", () => {
+    expect(assertReadOnlySql("SELECT 1; DROP TABLE users")).toBeDefined();
+  });
+});
+
+describe("devtools_db_query client-side guard", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.DEVTOOLS_API_URL = "http://devtools-api:9100";
+    process.env.DEV_TOOLS_API = "tok";
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DEVTOOLS_API_URL;
+    delete process.env.DEV_TOOLS_API;
+  });
+
+  it("returns an error for a mutating statement WITHOUT forwarding it", async () => {
+    const t = buildTools();
+    const res = parse(await t.devtools_db_query.execute("x", { sql: "DROP TABLE users" }));
+    expect(res.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards a SELECT to the query endpoint", async () => {
+    const t = buildTools();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => ({ rows: [] }),
+    });
+    const res = parse(await t.devtools_db_query.execute("x", { sql: "SELECT 1" }));
+    expect(res.ok).toBe(true);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/db/query");
+  });
+});

--- a/extensions/devtools/src/tools.ts
+++ b/extensions/devtools/src/tools.ts
@@ -8,7 +8,9 @@ function jsonResult(data: unknown) {
 
 function errorResult(err: unknown) {
   const message = err instanceof Error ? err.message : String(err);
-  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }] };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
 }
 
 export function registerTools(api: OpenClawPluginApi) {
@@ -22,7 +24,8 @@ export function registerTools(api: OpenClawPluginApi) {
     async execute() {
       try {
         const result = await devtoolsFetch("/api/v1/containers");
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, containers: result.data });
       } catch (err) {
         return errorResult(err);
@@ -38,8 +41,15 @@ export function registerTools(api: OpenClawPluginApi) {
       "Use devtools_list_containers first to find the container ID.",
     parameters: Type.Object({
       container_id: Type.String({ description: "The container ID or name" }),
-      tail: Type.Optional(Type.Number({ description: "Number of lines to return (default 200)", default: 200 })),
-      since: Type.Optional(Type.String({ description: "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')" })),
+      tail: Type.Optional(
+        Type.Number({ description: "Number of lines to return (default 200)", default: 200 }),
+      ),
+      since: Type.Optional(
+        Type.String({
+          description:
+            "Show logs since timestamp (e.g. '2024-01-01T00:00:00Z') or relative (e.g. '1h')",
+        }),
+      ),
       until: Type.Optional(Type.String({ description: "Show logs until timestamp" })),
     }),
     async execute(_id: string, params: Record<string, unknown>) {
@@ -53,7 +63,8 @@ export function registerTools(api: OpenClawPluginApi) {
         const result = await devtoolsFetch(
           `/api/v1/containers/${encodeURIComponent(containerId)}/logs?${queryParams.toString()}`,
         );
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, logs: result.data });
       } catch (err) {
         return errorResult(err);
@@ -68,14 +79,17 @@ export function registerTools(api: OpenClawPluginApi) {
       "List files and directories at a given path in the codebase. " +
       "Use this to browse the directory structure. Omit path to list the root.",
     parameters: Type.Object({
-      path: Type.Optional(Type.String({ description: "Directory path to list (defaults to root)" })),
+      path: Type.Optional(
+        Type.String({ description: "Directory path to list (defaults to root)" }),
+      ),
     }),
     async execute(_id: string, params: Record<string, unknown>) {
       try {
         const path = params.path as string | undefined;
         const endpoint = path ? `/api/v1/files/${encodeURIComponent(path)}` : "/api/v1/files";
         const result = await devtoolsFetch(endpoint);
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, files: result.data });
       } catch (err) {
         return errorResult(err);
@@ -96,7 +110,8 @@ export function registerTools(api: OpenClawPluginApi) {
       try {
         const path = params.path as string;
         const result = await devtoolsFetch(`/api/v1/files/${encodeURIComponent(path)}`);
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, content: result.data });
       } catch (err) {
         return errorResult(err);
@@ -114,7 +129,8 @@ export function registerTools(api: OpenClawPluginApi) {
     async execute() {
       try {
         const result = await devtoolsFetch("/api/v1/db/tables");
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, tables: result.data });
       } catch (err) {
         return errorResult(err);
@@ -134,8 +150,11 @@ export function registerTools(api: OpenClawPluginApi) {
     async execute(_id: string, params: Record<string, unknown>) {
       try {
         const tableName = params.table_name as string;
-        const result = await devtoolsFetch(`/api/v1/db/tables/${encodeURIComponent(tableName)}/schema`);
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        const result = await devtoolsFetch(
+          `/api/v1/db/tables/${encodeURIComponent(tableName)}/schema`,
+        );
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
         return jsonResult({ ok: true, columns: result.data });
       } catch (err) {
         return errorResult(err);
@@ -152,10 +171,14 @@ export function registerTools(api: OpenClawPluginApi) {
       "Use devtools_db_tables and devtools_db_table_schema first to understand the schema.",
     parameters: Type.Object({
       sql: Type.String({ description: "The SQL query to execute (SELECT or WITH only)" }),
-      params: Type.Optional(Type.Array(Type.Unknown(), { description: "Parameterized query values ($1, $2, etc.)" })),
+      params: Type.Optional(
+        Type.Array(Type.Unknown(), { description: "Parameterized query values ($1, $2, etc.)" }),
+      ),
     }),
     async execute(_id: string, params: Record<string, unknown>) {
       try {
+        const sqlError = assertReadOnlySql((params.sql as string) ?? "");
+        if (sqlError) return jsonResult({ ok: false, error: sqlError });
         const body: Record<string, unknown> = { sql: params.sql };
         if (params.params) body.params = params.params;
         const result = await devtoolsFetch("/api/v1/db/query", {
@@ -163,11 +186,28 @@ export function registerTools(api: OpenClawPluginApi) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
-        if (!result.ok) return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
-        return jsonResult({ ok: true, ...result.data as object });
+        if (!result.ok)
+          return jsonResult({ ok: false, error: `HTTP ${result.status}`, details: result.data });
+        return jsonResult({ ok: true, ...(result.data as object) });
       } catch (err) {
         return errorResult(err);
       }
     },
   }));
+}
+
+// Client-side defense-in-depth for devtools_db_query. The /db/query endpoint is
+// contractually read-only (SELECT/WITH only), but the tool must not forward a
+// non-read or stacked statement and rely on the backend to refuse it. Returns an
+// error string when the SQL is not a single read-only statement, else undefined.
+// Same guard as the per-bot devtools copies (bigheadbot/zws).
+export function assertReadOnlySql(sql: string): string | undefined {
+  const trimmed = sql.trim().replace(/;\s*$/, ""); // tolerate one trailing semicolon
+  if (!/^(select|with)\b/i.test(trimmed)) {
+    return "Only read-only SELECT or WITH queries are allowed.";
+  }
+  if (trimmed.includes(";")) {
+    return "Stacked/multiple statements are not allowed; submit a single SELECT/WITH query.";
+  }
+  return undefined;
 }

--- a/extensions/external-org-autopilot/index.ts
+++ b/extensions/external-org-autopilot/index.ts
@@ -1,11 +1,16 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { createAuditLogger } from "./src/audit.js";
-import { registerGhTools } from "./src/gh-tools.js";
+import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerEoaCliTools } from "./src/eoa-cli-tools.js";
 import { registerEoaStateTools } from "./src/eoa-state-tools.js";
-import { sendComfortMessage } from "./src/comfort.js";
+import { registerGhTools } from "./src/gh-tools.js";
 
 type PluginConfig = { eoaRepos?: string[] };
+
+// A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
+// before_dispatch gate and the comfort-skip use one shape.
+const CONFIRM_RE = /^CONFIRM\s+\d{4}\b/i;
 
 const plugin = {
   id: "external-org-autopilot",
@@ -27,19 +32,46 @@ const plugin = {
   register(api: OpenClawPluginApi, config?: PluginConfig) {
     const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
     const logger = createAuditLogger(workspaceDir);
-    const pluginConfig: PluginConfig = config ?? { eoaRepos: ["cloudwarriors-ai/external-org-autopilot"] };
+    const pluginConfig: PluginConfig = config ?? {
+      eoaRepos: ["cloudwarriors-ai/external-org-autopilot"],
+    };
 
     registerEoaCliTools(api, logger);
     registerEoaStateTools(api, logger);
     registerGhTools(api, logger, pluginConfig);
 
-    // Send comfort message when a message arrives in the EOA channel
+    // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
+    // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
+    // cannot suppress the coordinator) and runs before before_dispatch — if it
+    // consumed the pending action the before_dispatch handler would find nothing.
+    // So here we only (a) skip comfort for a CONFIRM reply and (b) stash the
+    // inbound message id so the confirm gate can thread its prompt.
     api.on("message_received", async (event, ctx) => {
-      if (ctx.channelId === "zoom" && ctx.conversationId) {
-        const messageId =
-          typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-        void sendComfortMessage(ctx.conversationId, messageId);
-      }
+      if (ctx.channelId !== "zoom" || !ctx.conversationId) return;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (CONFIRM_RE.test(text.trim())) return;
+      const messageId =
+        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
+      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      void sendComfortMessage(ctx.conversationId, messageId);
+    });
+
+    // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.
+    // before_dispatch is the awaited pre-dispatch seam that can suppress the agent —
+    // `handled: true` stops the message from reaching the coordinator (no spurious
+    // re-stage), and `text` is delivered threaded by core. The LLM is never in the
+    // execution path: it cannot fabricate the inbound CONFIRM.
+    api.on("before_dispatch", async (event, ctx) => {
+      if (ctx.channelId !== "zoom") return undefined;
+      const text = typeof event.content === "string" ? event.content : "";
+      if (!CONFIRM_RE.test(text.trim())) return undefined;
+      const result = await tryExecuteConfirm({
+        text,
+        actor: ctx.senderId ?? "",
+        conversationId: ctx.conversationId ?? "",
+        logger,
+      });
+      return { handled: true, text: result ?? undefined };
     });
 
     console.log("[external-org-autopilot] Registered 23 tools (11 CLI + 6 state + 6 GH)");

--- a/extensions/external-org-autopilot/src/comfort.ts
+++ b/extensions/external-org-autopilot/src/comfort.ts
@@ -1,4 +1,8 @@
-const EOA_CHANNEL = "2edb7334f4d6497997dfed97c42dc862@conference.xmpp.zoom.us";
+// The EOA Zoom channel JID. Exported so the confirm gate (gated.ts) can deliver
+// the CONFIRM prompt to the same channel deterministically when the
+// EOA_ZOOM_CHANNEL env override is not set — the code must never fall back to an
+// inline (LLM-relayed) prompt in production.
+export const EOA_CHANNEL = "2edb7334f4d6497997dfed97c42dc862@conference.xmpp.zoom.us";
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
@@ -69,4 +73,67 @@ export async function sendComfortMessage(
   } catch (err) {
     console.error("[eoa] comfort message failed:", err);
   }
+}
+
+// Generic text send to an EOA Zoom channel (reuses the bot token). Used by the
+// confirm gate to deterministically post the CONFIRM prompt (with the code).
+// Pass replyToMessageId to thread the message under the originating request.
+export async function sendEoaText(
+  channelJid: string,
+  text: string,
+  replyToMessageId?: string,
+): Promise<void> {
+  const botJid = process.env.ZOOM_BOT_JID ?? "";
+  const accountId = process.env.ZOOM_ACCOUNT_ID ?? "";
+  if (!channelJid || !botJid || !accountId) return;
+  const replyTo =
+    typeof replyToMessageId === "string" && replyToMessageId.trim().length > 0
+      ? replyToMessageId.trim()
+      : undefined;
+  try {
+    const token = await getToken();
+    const body: Record<string, unknown> = {
+      robot_jid: botJid,
+      to_jid: channelJid,
+      account_id: accountId,
+      content: { head: { text: "EOAutopilot" }, body: [{ type: "message", text }] },
+    };
+    if (replyTo) {
+      body.reply_to = replyTo;
+      body.reply_main_message_id = replyTo;
+    }
+    await fetch("https://api.zoom.us/v2/im/chat/messages", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error("[eoa] sendEoaText failed:", err);
+  }
+}
+
+// Per-channel thread anchor for confirm-prompt delivery. The confirm gate stages
+// inside the write tool, decoupled from the inbound message event, so it has no
+// direct handle on the originating message id. The message_received hook stashes
+// the latest inbound message id here (keyed by channel JID); stageWrite() reads it
+// to thread the deterministic CONFIRM prompt under the user's request instead of
+// posting it at channel root. In-memory, TTL-bounded; lost on restart is fine —
+// a missing anchor only degrades to a root-level (still deterministic) prompt.
+type ThreadAnchor = { messageId: string; expiresAt: number };
+const ANCHOR_TTL_MS = 6 * 60 * 60 * 1000; // 6h, matches the zoom reply-root TTL
+const threadAnchors = new Map<string, ThreadAnchor>();
+
+export function rememberChannelThreadAnchor(channelJid: string, messageId?: string): void {
+  if (!channelJid || !messageId) return;
+  threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
+}
+
+export function getChannelThreadAnchor(channelJid: string): string | undefined {
+  const entry = threadAnchors.get(channelJid);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    threadAnchors.delete(channelJid);
+    return undefined;
+  }
+  return entry.messageId;
 }

--- a/extensions/external-org-autopilot/src/confirm.ts
+++ b/extensions/external-org-autopilot/src/confirm.ts
@@ -1,0 +1,63 @@
+// Confirm-gate execution for EOA. A human `CONFIRM <code>` reply runs the staged
+// action. The LLM is never in the execution path: it cannot fabricate the inbound
+// CONFIRM, and the code never passed through it (delivered deterministically by
+// stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator (see hub-and-spoke-implementation-guide.md §7).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// A staged write's result data is produced only at confirm time (the mutation is
+// deferred). Surface a compact, useful tail (a run/bundle id or url) so the human
+// gets the actionable result back on confirm — without dumping the full body.
+function successDetail(data: unknown): string {
+  if (data && typeof data === "object") {
+    const d = data as Record<string, unknown>;
+    if (typeof d.url === "string" && d.url) return ` ${d.url}`;
+    const id = d.id ?? d.runId ?? d.evidenceBundleId;
+    if (typeof id === "string" || typeof id === "number") return ` (id ${id})`;
+  }
+  return "";
+}
+
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  conversationId: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "eoa_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.${successDetail(res.data)}`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "eoa_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.test.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the process boundary so no real CLI ever runs. The gate's core guarantee:
+// a gated tool's execute() must NOT invoke the EOA CLI — only a human CONFIRM
+// (via tryExecuteConfirm) may fire the staged run closure.
+const execFileSyncMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendEoaText — never through the tool result. Spy on the delivery.
+const sendEoaTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  EOA_CHANNEL: "eoa-fallback-channel@conference.xmpp.zoom.us",
+  sendEoaText: (...args: unknown[]) => sendEoaTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+}));
+
+import { tryExecuteConfirm } from "./confirm.js";
+import { registerEoaCliTools } from "./eoa-cli-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+const CHANNEL = "eoa-test-channel@conference.xmpp.zoom.us";
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerEoaCliTools(api, noopLogger as never);
+  return tools;
+}
+
+const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
+// The confirm code travels ONLY through the deterministic channel send, never
+// through the tool's return value. Pull it from the latest sendEoaText call.
+const codeFromDelivery = () =>
+  String(sendEoaTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
+
+const GATED: Record<string, Record<string, unknown>> = {
+  eoa_run_execute: { issueMirrorId: "mirror-uuid-1" },
+  eoa_run_resume: { runId: "run-uuid-2" },
+  eoa_smoke_test: { releasePath: "rel.json", onboardingPath: "onb.yaml", issueNumber: 7 },
+  eoa_onboard_project: { releasePath: "rel.json", onboardingPath: "onb.yaml" },
+};
+
+describe("eoa-cli-tools confirm gate", () => {
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+    sendEoaTextMock.mockReset();
+    process.env.EOA_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.EOA_ZOOM_CHANNEL;
+  });
+
+  it("ALL gated tools STAGE only — execute() never runs the CLI, result is code-free", async () => {
+    const t = buildTools();
+    for (const [name, args] of Object.entries(GATED)) {
+      const res = parse(await t[name].execute("x", args));
+      expect(res.staged, `${name} must stage`).toBe(true);
+      expect(JSON.stringify(res), `${name} result must be code-free`).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(execFileSyncMock, "no gated tool may run the CLI before CONFIRM").not.toHaveBeenCalled();
+  });
+
+  it("read/validate tools execute the CLI immediately (not gated)", async () => {
+    const t = buildTools();
+    execFileSyncMock.mockReturnValue('{"ok":true}');
+    await t.eoa_doctor.execute("x", { customerRepoId: "repo-uuid" });
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("npx");
+    expect(argv).toEqual(["tsx", "src/cli.ts", "customer", "doctor", "repo-uuid"]);
+  });
+
+  it("a CONFIRM from the EOA channel fires the staged run with literal argv", async () => {
+    const t = buildTools();
+    await t.eoa_run_execute.execute("x", { issueMirrorId: "mirror-uuid-1" });
+    const code = codeFromDelivery();
+    expect(code).toBeTruthy();
+
+    execFileSyncMock.mockReturnValue('{"run":{"id":"r1"},"evidenceBundleId":"e1"}');
+    const reply = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "tester",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/✅ Done/);
+    const [bin, argv] = execFileSyncMock.mock.calls[0];
+    expect(bin).toBe("npx");
+    expect(argv).toEqual(["tsx", "src/cli.ts", "run", "execute", "mirror-uuid-1", "--detach"]);
+  });
+
+  it("a CONFIRM from a DIFFERENT channel cannot fire the staged run", async () => {
+    const t = buildTools();
+    await t.eoa_run_resume.execute("x", { runId: "run-uuid-2" });
+    const code = codeFromDelivery();
+
+    const wrong = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "attacker",
+      conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
+      logger: noopLogger as never,
+    });
+    expect(wrong).toMatch(/different channel|expired|already been used/);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    // Right channel: the action is still there and fires.
+    execFileSyncMock.mockReturnValue('{"run":{"id":"r2"}}');
+    const right = await tryExecuteConfirm({
+      text: `CONFIRM ${code}`,
+      actor: "tester",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(right).toMatch(/✅ Done/);
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a wrong/expired code executes nothing (fail-closed)", async () => {
+    buildTools();
+    const reply = await tryExecuteConfirm({
+      text: "CONFIRM 0000",
+      actor: "tester",
+      conversationId: CHANNEL,
+      logger: noopLogger as never,
+    });
+    expect(reply).toMatch(/No pending action/i);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.ts
@@ -3,9 +3,12 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
 import { jsonResult, errorResult } from "./helpers.js";
 
-const EOA_ROOT = "/root/code/external-org-autopilot";
+// Env-driven so the deploy host can relocate the checkout; the default matches
+// the current production container layout.
+const EOA_ROOT = () => process.env.EOA_ROOT ?? "/root/code/external-org-autopilot";
 
 // Run the EOA CLI with an explicit argv (NO shell): `npx tsx src/cli.ts <args...>`.
 // Each arg is passed literally, so LLM-controlled paths/ids cannot be interpreted as
@@ -13,7 +16,7 @@ const EOA_ROOT = "/root/code/external-org-autopilot";
 function eoa(args: string[], timeoutMs = 120000): unknown {
   const result = execFileSync("npx", ["tsx", "src/cli.ts", ...args], {
     encoding: "utf-8",
-    cwd: EOA_ROOT,
+    cwd: EOA_ROOT(),
     timeout: timeoutMs,
     env: { ...process.env },
   });
@@ -93,21 +96,24 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
       {
         name: "eoa_onboard_project",
         description:
-          "Onboard a new customer project. Takes a release JSON and onboarding YAML. Returns {customerRepo, mirrorRepo}.",
+          "STAGE onboarding of a new customer project (creates repos — requires human " +
+          "CONFIRM <code> in the EOA channel before it runs). Takes a release JSON and " +
+          "onboarding YAML. Returns {customerRepo, mirrorRepo} on confirm.",
         parameters: Type.Object({
           releasePath: Type.String({ description: "Path to the release JSON contract" }),
           onboardingPath: Type.String({ description: "Path to the onboarding YAML contract" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
-          try {
-            const data = eoa(
-              ["customer", "onboard", argStr(params.releasePath), argStr(params.onboardingPath)],
-              300000,
-            );
-            return jsonResult({ ok: true, data });
-          } catch (err) {
-            return errorResult(err);
-          }
+          const releasePath = argStr(params.releasePath);
+          const onboardingPath = argStr(params.onboardingPath);
+          return stageWrite(
+            `onboard customer project (release=${releasePath}, onboarding=${onboardingPath})`,
+            async () => ({
+              ok: true,
+              status: 200,
+              data: eoa(["customer", "onboard", releasePath, onboardingPath], 300000),
+            }),
+          );
         },
       },
       logger,
@@ -224,17 +230,20 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_run_execute",
-        description: "Execute a fix run for an issue mirror. Returns {run, evidenceBundleId}.",
+        description:
+          "STAGE a fix run for an issue mirror (spawns an autonomous agent run — requires " +
+          "human CONFIRM <code> in the EOA channel before it starts). Returns " +
+          "{run, evidenceBundleId} on confirm.",
         parameters: Type.Object({
           issueMirrorId: Type.String({ description: "Issue mirror UUID" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
-          try {
-            const data = eoa(["run", "execute", argStr(params.issueMirrorId), "--detach"], 300000);
-            return jsonResult({ ok: true, data });
-          } catch (err) {
-            return errorResult(err);
-          }
+          const issueMirrorId = argStr(params.issueMirrorId);
+          return stageWrite(`execute fix run for issue mirror ${issueMirrorId}`, async () => ({
+            ok: true,
+            status: 200,
+            data: eoa(["run", "execute", issueMirrorId, "--detach"], 300000),
+          }));
         },
       },
       logger,
@@ -246,17 +255,20 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_run_resume",
-        description: "Resume a previously started run. Returns {run, evidenceBundleId}.",
+        description:
+          "STAGE resuming a previously started run (continues an autonomous agent run — " +
+          "requires human CONFIRM <code> in the EOA channel). Returns {run, evidenceBundleId} " +
+          "on confirm.",
         parameters: Type.Object({
           runId: Type.String({ description: "Run UUID to resume" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
-          try {
-            const data = eoa(["run", "resume", argStr(params.runId)], 300000);
-            return jsonResult({ ok: true, data });
-          } catch (err) {
-            return errorResult(err);
-          }
+          const runId = argStr(params.runId);
+          return stageWrite(`resume run ${runId}`, async () => ({
+            ok: true,
+            status: 200,
+            data: eoa(["run", "resume", runId], 300000),
+          }));
         },
       },
       logger,
@@ -268,29 +280,30 @@ export function registerEoaCliTools(api: OpenClawPluginApi, logger: AuditLogger)
     wrapToolWithAudit(
       {
         name: "eoa_smoke_test",
-        description: "Run a full pipeline smoke test. Returns the complete pipeline result.",
+        description:
+          "STAGE a full pipeline smoke test (onboards, ingests, and executes a run — " +
+          "requires human CONFIRM <code> in the EOA channel). Returns the complete " +
+          "pipeline result on confirm.",
         parameters: Type.Object({
           releasePath: Type.String({ description: "Path to release contract" }),
           onboardingPath: Type.String({ description: "Path to onboarding contract" }),
           issueNumber: Type.Number({ description: "Issue number to test" }),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
-          try {
-            const data = eoa(
-              [
-                "smoke",
-                "run",
-                argStr(params.releasePath),
-                argStr(params.onboardingPath),
-                argStr(params.issueNumber),
-                "--detach",
-              ],
-              600000,
-            );
-            return jsonResult({ ok: true, data });
-          } catch (err) {
-            return errorResult(err);
-          }
+          const releasePath = argStr(params.releasePath);
+          const onboardingPath = argStr(params.onboardingPath);
+          const issueNumber = argStr(params.issueNumber);
+          return stageWrite(
+            `run pipeline smoke test (release=${releasePath}, issue=${issueNumber})`,
+            async () => ({
+              ok: true,
+              status: 200,
+              data: eoa(
+                ["smoke", "run", releasePath, onboardingPath, issueNumber, "--detach"],
+                600000,
+              ),
+            }),
+          );
         },
       },
       logger,

--- a/extensions/external-org-autopilot/src/eoa-state-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-state-tools.ts
@@ -7,7 +7,11 @@ import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 import { jsonResult, errorResult } from "./helpers.js";
 
-const STATE_DIR = "/root/code/external-org-autopilot/.autopilot-state";
+// Env-driven so the deploy host can relocate the checkout/state; defaults match
+// the current production container layout (state lives inside the EOA checkout).
+const STATE_DIR = () =>
+  process.env.EOA_STATE_DIR ??
+  path.join(process.env.EOA_ROOT ?? "/root/code/external-org-autopilot", ".autopilot-state");
 
 // GitHub Actions run IDs are numeric. Validate so the value is a sane argv element.
 function assertRunId(value: unknown): string {
@@ -51,7 +55,7 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const runsDir = path.join(STATE_DIR, "autopilot-runs");
+            const runsDir = path.join(STATE_DIR(), "autopilot-runs");
             if (!fs.existsSync(runsDir)) {
               return jsonResult({ ok: true, data: [], message: "No runs directory found" });
             }
@@ -89,7 +93,7 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const filePath = path.join(STATE_DIR, "autopilot-runs", `${params.runId}.json`);
+            const filePath = path.join(STATE_DIR(), "autopilot-runs", `${params.runId}.json`);
             if (!fs.existsSync(filePath)) {
               return jsonResult({ ok: false, error: `Run ${params.runId} not found` });
             }
@@ -116,7 +120,7 @@ export function registerEoaStateTools(api: OpenClawPluginApi, logger: AuditLogge
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
-            const filePath = path.join(STATE_DIR, "evidence-bundles", `${params.bundleId}.json`);
+            const filePath = path.join(STATE_DIR(), "evidence-bundles", `${params.bundleId}.json`);
             if (!fs.existsSync(filePath)) {
               return jsonResult({
                 ok: false,

--- a/extensions/external-org-autopilot/src/gated.ts
+++ b/extensions/external-org-autopilot/src/gated.ts
@@ -1,0 +1,55 @@
+// Shared confirm-gate staging helper for EOA write tools.
+//
+// THE invariant: a gated tool's execute() must only STAGE — it calls stageWrite()
+// (which registers a pending action and delivers the CONFIRM prompt to the channel)
+// and never runs the EOA CLI mutation directly. The real mutation lives in the
+// `run` closure, fired ONLY by tryExecuteConfirm() (confirm.ts) when a human
+// replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message, so the
+// bot cannot self-trigger autopilot runs/onboarding. Tests assert the CLI is not
+// invoked during execute().
+//
+// Ported from the proven scopelybot/bigheadbot implementation (see
+// docs/reference/hub-and-spoke-implementation-guide.md §7).
+
+import { EOA_CHANNEL, getChannelThreadAnchor, sendEoaText } from "./comfort.js";
+import { jsonResult } from "./helpers.js";
+import { makeCode, putPending } from "./pending-confirm.js";
+
+type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
+
+// Stage a gated mutation. Does NOT execute — the real call fires only when a
+// human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
+//
+// The confirm prompt — INCLUDING the code — is delivered to the channel
+// deterministically here, threaded under the originating request. The code must
+// never travel back through the LLM coordinator: a small model fabricates,
+// rewrites, re-relays, and duplicates codes (observed live on scopelybot). So the
+// tool result the model sees is CODE-FREE; the model only learns a prompt was
+// posted and must stay silent.
+export async function stageWrite(summary: string, run: () => RunResult) {
+  // Read the channel at call time (not module load) so env that loads after import
+  // — and test stubbing — both resolve correctly. Fall back to the bot's known
+  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
+  const channel = process.env.EOA_ZOOM_CHANNEL ?? EOA_CHANNEL;
+  // Bind the staged action to that channel: only a CONFIRM from it can fire the
+  // action (takePending enforces the match). Code is unpredictable (crypto).
+  const code = makeCode();
+  putPending({ code, conversationId: channel, summary, run });
+  const prompt =
+    `⚠️ Confirm: ${summary}.\n` +
+    `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
+
+  if (channel) {
+    await sendEoaText(channel, prompt, getChannelThreadAnchor(channel));
+    return jsonResult({
+      staged: true,
+      awaiting_confirmation: true,
+      message:
+        "Confirm prompt was posted to the channel for the user. " +
+        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+    });
+  }
+  // No channel configured (dev/test only): fall back to returning the prompt
+  // inline so the gate still works outside the live deployment.
+  return jsonResult({ staged: true, message: prompt });
+}

--- a/extensions/external-org-autopilot/src/pending-confirm.ts
+++ b/extensions/external-org-autopilot/src/pending-confirm.ts
@@ -1,0 +1,60 @@
+// In-memory, single-use, TTL store for pending EOA write actions.
+// An action only runs after a human types `CONFIRM <code>` in the SAME channel the
+// prompt was posted to — the LLM cannot fabricate that inbound message, and a
+// CONFIRM from another channel/DM cannot consume it, so neither the model nor a
+// bystander in a different conversation can approve a staged write.
+
+import { randomInt } from "node:crypto";
+
+export type PendingAction = {
+  code: string;
+  // The conversation the CONFIRM must come from. A staged write is bound to the
+  // channel where its prompt was delivered; a CONFIRM from any other channel/DM
+  // must NOT consume it (cross-channel confirm = privilege escalation).
+  conversationId: string;
+  summary: string; // human-readable description, echoed + audited
+  run: () => Promise<{ ok: boolean; status: number; data: unknown }>;
+  expiresAt: number;
+};
+
+const TTL_MS = 5 * 60 * 1000; // 5 minutes
+const store = new Map<string, PendingAction>();
+
+function prune(): void {
+  const now = Date.now();
+  for (const [code, a] of store) {
+    if (a.expiresAt <= now) {
+      store.delete(code);
+    }
+  }
+}
+
+// Unpredictable 4-digit code, unique within the live store. crypto.randomInt — a
+// confirm code is a security token, so it must NOT be derivable from call order or
+// summary length.
+export function makeCode(): string {
+  prune();
+  let code = String(randomInt(1000, 10000));
+  while (store.has(code)) {
+    code = String(randomInt(1000, 10000));
+  }
+  return code;
+}
+
+export function putPending(a: Omit<PendingAction, "expiresAt">): void {
+  prune();
+  store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
+}
+
+// Retrieve and consume a pending action (one-time use) — ONLY when the code exists
+// AND the confirming conversation matches the one it was staged for. A CONFIRM from
+// another channel returns undefined and leaves the action intact for the right one.
+export function takePending(code: string, conversationId: string): PendingAction | undefined {
+  prune();
+  const a = store.get(code);
+  if (!a || a.conversationId !== conversationId) {
+    return undefined;
+  }
+  store.delete(code);
+  return a;
+}

--- a/extensions/scopelybot/src/deployment-config-tools.test.ts
+++ b/extensions/scopelybot/src/deployment-config-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 vi.mock("./scopely-api.js", () => ({
@@ -8,6 +8,16 @@ vi.mock("./scopely-api.js", () => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
   buildQuery: () => "",
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendScopelyText — never through the tool result. Spy on the delivery.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
 }));
 
 import { registerDeploymentConfigTools } from "./deployment-config-tools.js";
@@ -33,8 +43,11 @@ function buildTools(): Record<string, ToolDef> {
   return tools;
 }
 const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
-const codeOf = (res: { content: { text: string }[] }) =>
-  parse(res).message.match(/CONFIRM (\d{4})/)?.[1];
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+// codeOf(await stage(...)): the tool result is code-free by design; the code is
+// read from the channel delivery spy (sendScopelyText prompt, arg index 1).
+const codeOf = (_res: { content: { text: string }[] }) =>
+  String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
 
 const WRITE_ARGS: Record<string, Record<string, unknown>> = {
   scopely_create_deployment_type: {
@@ -56,7 +69,14 @@ const WRITE_ARGS: Record<string, Record<string, unknown>> = {
 };
 
 describe("deployment-config-tools", () => {
-  beforeEach(() => fetchMock.mockReset());
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  });
 
   it("read tools hit the correct BFF paths immediately", async () => {
     const t = buildTools();
@@ -93,7 +113,7 @@ describe("deployment-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls[0];
@@ -111,7 +131,7 @@ describe("deployment-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -26,6 +26,19 @@ export async function stageWrite(summary: string, run: () => FetchResult) {
   // Read the channel at call time (not module load) so env that loads after import
   // — and test stubbing — both resolve correctly.
   const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // 2026-06-05) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "SCOPELYBOT_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -34,19 +47,14 @@ export async function stageWrite(summary: string, run: () => FetchResult) {
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }
 
 // Build a request body from only the fields the caller actually supplied, so we

--- a/extensions/scopelybot/src/org-tools.test.ts
+++ b/extensions/scopelybot/src/org-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 vi.mock("./scopely-api.js", () => ({
@@ -13,6 +13,16 @@ vi.mock("./scopely-api.js", () => ({
     const s = qs.toString();
     return s ? `?${s}` : "";
   },
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendScopelyText — never through the tool result. Spy on the delivery.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
 }));
 
 import { registerOrgTools } from "./org-tools.js";
@@ -39,8 +49,11 @@ function buildTools(): Record<string, ToolDef> {
   return tools;
 }
 const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
-const codeOf = (res: { content: { text: string }[] }) =>
-  parse(res).message.match(/CONFIRM (\d{4})/)?.[1];
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+// codeOf(await stage(...)): the tool result is code-free by design; the code is
+// read from the channel delivery spy (sendScopelyText prompt, arg index 1).
+const codeOf = (_res: { content: { text: string }[] }) =>
+  String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
 
 const READ_TOOLS = ["scopely_list_orgs", "scopely_get_org", "scopely_list_org_domains"];
 const WRITE_TOOLS = [
@@ -52,7 +65,14 @@ const WRITE_TOOLS = [
 ];
 
 describe("org-tools", () => {
-  beforeEach(() => fetchMock.mockReset());
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  });
 
   it("read tools hit the correct BFF paths immediately", async () => {
     const t = buildTools();
@@ -94,7 +114,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls[0];
@@ -115,7 +135,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
@@ -131,7 +151,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -149,7 +169,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
@@ -166,7 +186,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(

--- a/extensions/scopelybot/src/pricing-tools.test.ts
+++ b/extensions/scopelybot/src/pricing-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 vi.mock("./scopely-api.js", () => ({
@@ -13,6 +13,16 @@ vi.mock("./scopely-api.js", () => ({
     const s = qs.toString();
     return s ? `?${s}` : "";
   },
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendScopelyText — never through the tool result. Spy on the delivery.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
 }));
 
 import { registerPricingTools } from "./pricing-tools.js";
@@ -38,8 +48,11 @@ function buildTools(): Record<string, ToolDef> {
   return tools;
 }
 const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
-const codeOf = (res: { content: { text: string }[] }) =>
-  parse(res).message.match(/CONFIRM (\d{4})/)?.[1];
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+// codeOf(await stage(...)): the tool result is code-free by design; the code is
+// read from the channel delivery spy (sendScopelyText prompt, arg index 1).
+const codeOf = (_res: { content: { text: string }[] }) =>
+  String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
 
 const WRITE_TOOLS: Record<string, Record<string, unknown>> = {
   scopely_create_pricing_default: {
@@ -73,7 +86,14 @@ const WRITE_TOOLS: Record<string, Record<string, unknown>> = {
 };
 
 describe("pricing-tools", () => {
-  beforeEach(() => fetchMock.mockReset());
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  });
 
   it("read tools hit the correct BFF paths immediately", async () => {
     const t = buildTools();
@@ -118,7 +138,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls[0];
@@ -150,7 +170,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
@@ -175,7 +195,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
@@ -191,7 +211,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(

--- a/extensions/scopelybot/src/scoping-card-tools.test.ts
+++ b/extensions/scopelybot/src/scoping-card-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 vi.mock("./scopely-api.js", () => ({
@@ -8,6 +8,16 @@ vi.mock("./scopely-api.js", () => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
   buildQuery: () => "",
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendScopelyText — never through the tool result. Spy on the delivery.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
 }));
 
 import { registerScopingCardTools } from "./scoping-card-tools.js";
@@ -33,11 +43,21 @@ function buildTools(): Record<string, ToolDef> {
   return tools;
 }
 const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
-const codeOf = (res: { content: { text: string }[] }) =>
-  parse(res).message.match(/CONFIRM (\d{4})/)?.[1];
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+// codeOf(await stage(...)): the tool result is code-free by design; the code is
+// read from the channel delivery spy (sendScopelyText prompt, arg index 1).
+const codeOf = (_res: { content: { text: string }[] }) =>
+  String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
 
 describe("scoping-card-tools", () => {
-  beforeEach(() => fetchMock.mockReset());
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  });
 
   it("read tools hit the correct nested BFF paths immediately", async () => {
     const t = buildTools();
@@ -99,7 +119,7 @@ describe("scoping-card-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls[0];
@@ -122,13 +142,16 @@ describe("scoping-card-tools", () => {
         fields: [{ key: "a", label: "A", field_type: "boolean" }],
       }),
     );
-    expect(staged.message).toContain("REPLACE fields (1 total)");
-    const code = staged.message.match(/CONFIRM (\d{4})/)?.[1];
+    expect(staged.staged).toBe(true);
+    // The replacement warning travels in the channel prompt, not the tool result.
+    const prompt = String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "");
+    expect(prompt).toContain("REPLACE fields (1 total)");
+    const code = prompt.match(/CONFIRM (\d{4})/)?.[1];
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -232,6 +232,19 @@ describe("user-maintenance-tools", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("staging FAILS CLOSED when SCOPELYBOT_ZOOM_CHANNEL is unset", async () => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+    const tools = buildTools();
+    const res = parse(
+      await tools.scopely_update_user.execute("t", { user_id: 7, role: "org_admin" }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/SCOPELYBOT_ZOOM_CHANNEL/);
+    // Nothing staged, nothing delivered, prod untouched.
+    expect(sendScopelyTextMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("a wrong/expired code executes nothing (fail-closed)", async () => {
     buildTools();
     fetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });

--- a/extensions/scopelybot/src/vendor-config-tools.test.ts
+++ b/extensions/scopelybot/src/vendor-config-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchMock = vi.fn();
 vi.mock("./scopely-api.js", () => ({
@@ -8,6 +8,16 @@ vi.mock("./scopely-api.js", () => ({
     content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
   }),
   buildQuery: () => "",
+}));
+
+// Staging delivers the CONFIRM prompt (with the code) to the channel via
+// sendScopelyText — never through the tool result. Spy on the delivery.
+const sendScopelyTextMock = vi.fn();
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => "MSG-ANCHOR",
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
 }));
 
 import { tryExecuteConfirm } from "./user-maintenance-tools.js";
@@ -33,8 +43,11 @@ function buildTools(): Record<string, ToolDef> {
   return tools;
 }
 const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
-const codeOf = (res: { content: { text: string }[] }) =>
-  parse(res).message.match(/CONFIRM (\d{4})/)?.[1];
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+// codeOf(await stage(...)): the tool result is code-free by design; the code is
+// read from the channel delivery spy (sendScopelyText prompt, arg index 1).
+const codeOf = (_res: { content: { text: string }[] }) =>
+  String(sendScopelyTextMock.mock.calls.at(-1)?.[1] ?? "").match(/CONFIRM (\d{4})/)?.[1];
 
 const WRITE_ARGS: Record<string, Record<string, unknown>> = {
   scopely_create_vendor: { key: "dialpad", display_name: "Dialpad" },
@@ -54,7 +67,14 @@ const WRITE_ARGS: Record<string, Record<string, unknown>> = {
 };
 
 describe("vendor-config-tools", () => {
-  beforeEach(() => fetchMock.mockReset());
+  beforeEach(() => {
+    fetchMock.mockReset();
+    sendScopelyTextMock.mockReset();
+    process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+  });
+  afterEach(() => {
+    delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  });
 
   it("read tools hit the correct BFF paths immediately", async () => {
     const t = buildTools();
@@ -92,7 +112,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls[0];
@@ -114,7 +134,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;
@@ -138,7 +158,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -152,7 +172,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${delCode}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -175,7 +195,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
-      conversationId: "",
+      conversationId: CHANNEL,
       logger: noopLogger as never,
     });
     const [path, opts] = fetchMock.mock.calls.at(-1)!;

--- a/extensions/tesseract/tesseract-auth.ts
+++ b/extensions/tesseract/tesseract-auth.ts
@@ -7,19 +7,33 @@
  * active user session with automatic expiry (default 1 hour).
  */
 
-if (!process.env.TESSERACT_URL) {
-  throw new Error("TESSERACT_URL env var is required. Set it to the internal backend URL (e.g., http://playground-backend:8000).");
-}
-if (!process.env.TESSERACT_EXTERNAL_URL) {
-  throw new Error("TESSERACT_EXTERNAL_URL env var is required. Set it to the browser-accessible backend URL (e.g., http://localhost:8130).");
+// Required env, resolved lazily at call time. A module-level throw here would
+// crash the ENTIRE gateway at plugin load when the var is missing; instead each
+// tool call fails with a clear error (caught by the tools' try/catch) and the
+// rest of the fleet keeps running.
+function tesseractUrl(): string {
+  const url = process.env.TESSERACT_URL;
+  if (!url) {
+    throw new Error(
+      "TESSERACT_URL env var is required. Set it to the internal backend URL (e.g., http://playground-backend:8000).",
+    );
+  }
+  return url;
 }
 
-const TESSERACT_URL = process.env.TESSERACT_URL;
-const TESSERACT_EXTERNAL_URL = process.env.TESSERACT_EXTERNAL_URL;
+function tesseractExternalUrl(): string {
+  const url = process.env.TESSERACT_EXTERNAL_URL;
+  if (!url) {
+    throw new Error(
+      "TESSERACT_EXTERNAL_URL env var is required. Set it to the browser-accessible backend URL (e.g., http://localhost:8130).",
+    );
+  }
+  return url;
+}
 
 /** Rewrite an internal URL to be browser-accessible. */
 export function externalizeUrl(internalUrl: string): string {
-  return internalUrl.replace(TESSERACT_URL, TESSERACT_EXTERNAL_URL);
+  return internalUrl.replace(tesseractUrl(), tesseractExternalUrl());
 }
 
 /** How long a channel session stays active without activity (ms). Default: 24 hours. */
@@ -63,8 +77,8 @@ export function setActiveUser(email: string | null, channel?: string): void {
   if (!channel || INVALID_CHANNEL_KEYS.has(channel)) {
     throw new Error(
       "Channel identifier is required for session management. " +
-      "Cannot store credentials without a specific channel key. " +
-      `Got: ${JSON.stringify(channel)}`
+        "Cannot store credentials without a specific channel key. " +
+        `Got: ${JSON.stringify(channel)}`,
     );
   }
   if (!email) {
@@ -127,7 +141,11 @@ export function getSessionInfo(channel?: string): {
 }
 
 /** List all active (non-expired) sessions. */
-export function listSessions(): Array<{ channel: string; email: string; idleSinceMinutes: number }> {
+export function listSessions(): Array<{
+  channel: string;
+  email: string;
+  idleSinceMinutes: number;
+}> {
   const now = Date.now();
   const active: Array<{ channel: string; email: string; idleSinceMinutes: number }> = [];
   for (const [channel, session] of state.sessions.entries()) {
@@ -156,7 +174,7 @@ export async function tesseractLogin(): Promise<void> {
     throw new Error("TESSERACT_USERNAME and TESSERACT_PASSWORD env vars required");
   }
 
-  const resp = await fetch(`${TESSERACT_URL}/api/auth/login-csrf-free/`, {
+  const resp = await fetch(`${tesseractUrl()}/api/auth/login-csrf-free/`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email, password }),
@@ -182,7 +200,7 @@ export async function tesseractToolCall(
   const asUser = getActiveUser(channel);
 
   const doCall = async (): Promise<Response> =>
-    fetch(`${TESSERACT_URL}/api/chat/tool-proxy/`, {
+    fetch(`${tesseractUrl()}/api/chat/tool-proxy/`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -215,7 +233,7 @@ export async function tesseractToolCall(
 export async function tesseractListTools(): Promise<string[]> {
   if (!state.token) await tesseractLogin();
 
-  const resp = await fetch(`${TESSERACT_URL}/api/chat/tools/`, {
+  const resp = await fetch(`${tesseractUrl()}/api/chat/tools/`, {
     headers: { Authorization: `Bearer ${state.token}` },
   });
 
@@ -234,7 +252,7 @@ export async function tesseractFetch(
   if (!state.token) await tesseractLogin();
 
   const doFetch = async (): Promise<Response> =>
-    fetch(`${TESSERACT_URL}${endpoint}`, {
+    fetch(`${tesseractUrl()}${endpoint}`, {
       ...options,
       headers: {
         "Content-Type": "application/json",
@@ -257,5 +275,5 @@ export async function tesseractFetch(
 }
 
 export function getTesseractUrl(): string {
-  return TESSERACT_URL;
+  return tesseractUrl();
 }


### PR DESCRIPTION
## Summary

Production env contract: every credential/URL fallback that could silently authenticate with a placeholder or silently point at prod is removed — missing config now fails closed, loudly, at the right layer. Plus the EOA confirm-gate (user call: EOA ships, gated first).

- **devtools**: `api-client` reads env at call time with **no baked-in prod URL/token** (an unconfigured deployment previously called `devtools-api.cloudwarriors.ai` with whatever token was lying around); `devtools_db_query` gains the same client-side `assertReadOnlySql` defense-in-depth the bigheadbot/zws copies already have.
- **scopelybot**: `stageWrite` **fails closed** when `SCOPELYBOT_ZOOM_CHANNEL` is unset. The inline (LLM-relayed) CONFIRM-prompt fallback is gone — codes got fabricated/relayed when they traveled through the model (observed live 2026-06-05), and post-#45 channel-bound pendings staged with `channel=""` could never be confirmed from a real channel anyway. 5 per-tool test files converted to the channel-delivery mock pattern.
- **bighead**: `?? "dev-token"` Authorization fallback removed; join tool errors without a real token. (`http://bighead:8000` URL default kept — compose-internal service name, unreachable cross-environment.)
- **tesseract**: module-level `throw` on missing `TESSERACT_URL` **crashed the entire gateway at plugin load**; now lazy accessors → per-tool errors, the rest of the fleet keeps running.
- **external-org-autopilot**: confirm-gate ported from the proven 5-bot implementation. `eoa_run_execute` / `eoa_run_resume` / `eoa_smoke_test` / `eoa_onboard_project` (autonomous runs + repo creation — the prompt-injection-chain risk from ingested issue bodies) now STAGE and fire only on a human `CONFIRM <code>` from the EOA channel, channel-bound, CSPRNG codes, code-free tool results. `EOA_ROOT`/`EOA_STATE_DIR` env-driven (defaults preserve current layout).
- **docker-compose.dev.yml**: stripped `:-dev-token`, `:-devtools-local-key-2026`, `:-tesseract_elastic_dev`, and the **TESSERACT_URL/EXTERNAL_URL prod-host defaults** (dev was silently pointed at the production Tesseract backend — same defect class as devtools); removed the `${CW_CHAT_RESPONDER_TOKEN}` paste artifact glued onto `DEA_ZOOM_CHANNEL`; passes all six `*_ZOOM_CHANNEL` confirm-gate bindings.
- **.env-template**: `DEA_ES_PASSWORD`/`DEVTOOLS_LOCAL_KEY` real values emptied; gateway-token / tesseract / bighead / channel-binding contract documented.

## ⚠️ Deploy-coupling (read before deploying)

Stripping compose defaults changes behavior on hosts whose `.env` is incomplete. Before this lands on a box, its `.env` MUST define: `OPENCLAW_GATEWAY_TOKEN`, `DEVTOOLS_LOCAL_KEY`, `DEA_ES_PASSWORD`, `TESSERACT_URL`, `TESSERACT_EXTERNAL_URL`, and the `*_ZOOM_CHANNEL` JIDs (unset channel = that bot's write staging is disabled, fail-closed — safe but inert). Missing values no longer silently fall back.

## Verification

- `node scripts/run-vitest.mjs extensions/scopelybot extensions/external-org-autopilot extensions/devtools` → **11 files / 72 tests passed** (post-format re-run). Full modified-surface run earlier: 27 files / 180 tests.
- New suites: devtools guards (env fail-closed ×2, SQL guard, non-forwarding of mutating SQL), EOA confirm gate (stage-only, cross-channel refusal, literal argv on confirm, fail-closed wrong code), scopelybot fail-closed staging.
- `tsgo:extensions`: zero new errors in changed files (TS2345 `registerTool` factory pattern is the documented pre-existing fleet baseline; eoa-state-tools template-expression hits are pre-existing per #44).
- Fork CI: same perpetually-red baseline as #42–#45; merge gate = failing-check subset comparison.
