### PR TITLE
refactor(fleet): programmatic tool banners, scopelybot confirm.ts extraction, zw2-auth boundary fix

### DIFF
--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -39,9 +39,15 @@ const plugin = {
     // scope them: non-optional plugin tools bypass allowlists and become visible
     // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
     // a tool name, the plugin id ("bigheadbot"), or "group:plugins" see them.
+    // The wrapper also counts registrations so the startup banner can never drift
+    // from the real tool count.
+    let toolCount = 0;
     const optionalApi: OpenClawPluginApi = {
       ...api,
-      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+      registerTool: (tool, opts) => {
+        toolCount += 1;
+        return api.registerTool(tool, { ...opts, optional: true });
+      },
     };
 
     registerBhTools(optionalApi, logger);
@@ -83,7 +89,7 @@ const plugin = {
       return { handled: true, text: result ?? undefined };
     });
 
-    console.log("[bigheadbot] Registered 25 tools (11 BH + 6 GH + 1 correlation + 7 devtools)");
+    console.log(`[bigheadbot] Registered ${toolCount} tools (BH + GH + correlation + devtools)`);
   },
 };
 

--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -37,9 +37,15 @@ const plugin = {
     // scope them: non-optional plugin tools bypass allowlists and become visible
     // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
     // a tool name, the plugin id ("cloudflow-support"), or "group:plugins" see them.
+    // The wrapper also counts registrations so the startup banner can never drift
+    // from the real tool count.
+    let toolCount = 0;
     const optionalApi: OpenClawPluginApi = {
       ...api,
-      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+      registerTool: (tool, opts) => {
+        toolCount += 1;
+        return api.registerTool(tool, { ...opts, optional: true });
+      },
     };
 
     registerCfOpsTools(optionalApi, logger);
@@ -79,7 +85,7 @@ const plugin = {
       return { handled: true, text: result ?? undefined };
     });
 
-    console.log("[cloudflow-support] Registered 15 tools (9 ops + 6 GH)");
+    console.log(`[cloudflow-support] Registered ${toolCount} tools (ops + GH)`);
   },
 };
 

--- a/extensions/pulsebot/index.ts
+++ b/extensions/pulsebot/index.ts
@@ -38,9 +38,15 @@ const plugin = {
     // scope them: non-optional plugin tools bypass allowlists and become visible
     // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
     // a tool name, the plugin id ("pulsebot"), or "group:plugins" see them.
+    // The wrapper also counts registrations so the startup banner can never drift
+    // from the real tool count.
+    let toolCount = 0;
     const optionalApi: OpenClawPluginApi = {
       ...api,
-      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+      registerTool: (tool, opts) => {
+        toolCount += 1;
+        return api.registerTool(tool, { ...opts, optional: true });
+      },
     };
 
     registerPpTools(optionalApi, logger);
@@ -81,7 +87,7 @@ const plugin = {
       return { handled: true, text: result ?? undefined };
     });
 
-    console.log("[pulsebot] Registered 18 tools (11 PP + 6 GH + 1 correlation)");
+    console.log(`[pulsebot] Registered ${toolCount} tools (PP + GH + correlation)`);
   },
 };
 

--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -2,6 +2,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { registerAdminTools } from "./src/admin-tools.js";
 import { createAuditLogger } from "./src/audit.js";
 import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDeploymentConfigTools } from "./src/deployment-config-tools.js";
 import { registerGhTools } from "./src/gh-tools.js";
@@ -12,7 +13,7 @@ import { registerPassthroughTools } from "./src/passthrough-tools.js";
 import { registerPricingTools } from "./src/pricing-tools.js";
 import { registerScopelyTools } from "./src/scopely-tools.js";
 import { registerScopingCardTools } from "./src/scoping-card-tools.js";
-import { registerUserMaintenanceTools, tryExecuteConfirm } from "./src/user-maintenance-tools.js";
+import { registerUserMaintenanceTools } from "./src/user-maintenance-tools.js";
 import { registerVendorConfigTools } from "./src/vendor-config-tools.js";
 
 type PluginConfig = { scopelyRepos?: string[] };

--- a/extensions/scopelybot/src/confirm.ts
+++ b/extensions/scopelybot/src/confirm.ts
@@ -1,0 +1,54 @@
+// Confirm-gate execution for scopelybot. A human `CONFIRM <code>` reply runs the
+// staged action. The LLM is never in the execution path: it cannot fabricate the
+// inbound CONFIRM, and the code never passed through it (delivered deterministically
+// by stageWrite). Wired into the `before_dispatch` hook in index.ts so it can
+// suppress the coordinator. Same module shape as the other gated bots
+// (bigheadbot/pulsebot/zws/cloudflow-support/external-org-autopilot).
+
+import type { AuditLogger } from "./audit.js";
+import { takePending } from "./pending-confirm.js";
+
+// Called from the before_dispatch handler. If the inbound text is `CONFIRM <code>`
+// for a live pending action, execute it and return a human-readable result string.
+// Returns null when the message is not a confirm (so normal handling continues).
+export async function tryExecuteConfirm(params: {
+  text: string;
+  actor: string;
+  conversationId: string;
+  logger: AuditLogger;
+}): Promise<string | null> {
+  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
+  if (!m) return null;
+  // Channel-scoped: only consumes an action staged for THIS conversation.
+  const action = takePending(m[1], params.conversationId);
+  if (!action) {
+    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
+  }
+  const start = Date.now();
+  try {
+    const res = await action.run();
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "scopely_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
+      durationMs: Date.now() - start,
+    });
+    return res.ok
+      ? `✅ Done: ${action.summary}.`
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    params.logger({
+      ts: new Date().toISOString(),
+      tool: "scopely_confirm_execute",
+      actor: params.actor || "unknown",
+      params: { summary: action.summary },
+      resultSummary: "error: exception",
+      error: msg,
+      durationMs: Date.now() - start,
+    });
+    return `❌ Error executing ${action.summary}: ${msg}`;
+  }
+}

--- a/extensions/scopelybot/src/deployment-config-tools.test.ts
+++ b/extensions/scopelybot/src/deployment-config-tools.test.ts
@@ -20,8 +20,8 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
+import { tryExecuteConfirm } from "./confirm.js";
 import { registerDeploymentConfigTools } from "./deployment-config-tools.js";
-import { tryExecuteConfirm } from "./user-maintenance-tools.js";
 
 type ToolDef = {
   name: string;

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -3,7 +3,7 @@
 // THE invariant: a write tool's execute() must only STAGE — it calls stageWrite()
 // (which registers a pending action and delivers the CONFIRM prompt to the channel)
 // and never calls scopelyFetch with a mutating method directly. The real mutation
-// lives in the `run` closure, fired ONLY by tryExecuteConfirm() (user-maintenance-tools.ts)
+// lives in the `run` closure, fired ONLY by tryExecuteConfirm() (confirm.ts)
 // when a human replies `CONFIRM <code>`. The LLM cannot fabricate that inbound message,
 // so the bot cannot self-mutate. Tests assert scopelyFetch is not called during execute().
 

--- a/extensions/scopelybot/src/org-tools.test.ts
+++ b/extensions/scopelybot/src/org-tools.test.ts
@@ -25,8 +25,8 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
+import { tryExecuteConfirm } from "./confirm.js";
 import { registerOrgTools } from "./org-tools.js";
-import { tryExecuteConfirm } from "./user-maintenance-tools.js";
 
 type ToolDef = {
   name: string;

--- a/extensions/scopelybot/src/pricing-tools.test.ts
+++ b/extensions/scopelybot/src/pricing-tools.test.ts
@@ -25,8 +25,8 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
+import { tryExecuteConfirm } from "./confirm.js";
 import { registerPricingTools } from "./pricing-tools.js";
-import { tryExecuteConfirm } from "./user-maintenance-tools.js";
 
 type ToolDef = {
   name: string;

--- a/extensions/scopelybot/src/scoping-card-tools.test.ts
+++ b/extensions/scopelybot/src/scoping-card-tools.test.ts
@@ -20,8 +20,8 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
+import { tryExecuteConfirm } from "./confirm.js";
 import { registerScopingCardTools } from "./scoping-card-tools.js";
-import { tryExecuteConfirm } from "./user-maintenance-tools.js";
 
 type ToolDef = {
   name: string;

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -23,7 +23,8 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
-import { registerUserMaintenanceTools, tryExecuteConfirm } from "./user-maintenance-tools.js";
+import { tryExecuteConfirm } from "./confirm.js";
+import { registerUserMaintenanceTools } from "./user-maintenance-tools.js";
 
 type ToolDef = {
   name: string;

--- a/extensions/scopelybot/src/user-maintenance-tools.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.ts
@@ -3,7 +3,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 import { stageWrite } from "./gated.js";
-import { takePending } from "./pending-confirm.js";
 import { scopelyFetch, jsonResult, errorResult } from "./scopely-api.js";
 
 // Each gated tool resolves a target and stages a pending action via stageWrite(),
@@ -357,49 +356,4 @@ export function registerUserMaintenanceTools(api: OpenClawPluginApi, logger: Aud
       logger,
     ),
   );
-}
-
-// Called from the message_received handler. If the inbound text is `CONFIRM <code>`
-// for a live pending action, execute it and return a human-readable result string.
-// Returns null when the message is not a confirm (so normal handling continues).
-export async function tryExecuteConfirm(params: {
-  text: string;
-  actor: string;
-  conversationId: string;
-  logger: AuditLogger;
-}): Promise<string | null> {
-  const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
-  if (!m) return null;
-  // Channel-scoped: only consumes an action staged for THIS conversation.
-  const action = takePending(m[1], params.conversationId);
-  if (!action) {
-    return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
-  }
-  const start = Date.now();
-  try {
-    const res = await action.run();
-    params.logger({
-      ts: new Date().toISOString(),
-      tool: "scopely_confirm_execute",
-      actor: params.actor || "unknown",
-      params: { summary: action.summary },
-      resultSummary: res.ok ? "ok" : `error: ${res.status}`,
-      durationMs: Date.now() - start,
-    });
-    return res.ok
-      ? `✅ Done: ${action.summary}.`
-      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    params.logger({
-      ts: new Date().toISOString(),
-      tool: "scopely_confirm_execute",
-      actor: params.actor || "unknown",
-      params: { summary: action.summary },
-      resultSummary: "error: exception",
-      error: msg,
-      durationMs: Date.now() - start,
-    });
-    return `❌ Error executing ${action.summary}: ${msg}`;
-  }
 }

--- a/extensions/scopelybot/src/vendor-config-tools.test.ts
+++ b/extensions/scopelybot/src/vendor-config-tools.test.ts
@@ -20,7 +20,7 @@ vi.mock("./comfort.js", () => ({
   sendComfortMessage: () => {},
 }));
 
-import { tryExecuteConfirm } from "./user-maintenance-tools.js";
+import { tryExecuteConfirm } from "./confirm.js";
 import { registerVendorConfigTools } from "./vendor-config-tools.js";
 
 type ToolDef = {

--- a/extensions/test-capture/harness/drive.sh
+++ b/extensions/test-capture/harness/drive.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Resilient routing driver. Reads "expect|prompt" lines on stdin; runs ONE
+# route1.mjs (one harness scenario) per line. A node child crash prints an
+# error line but never kills this loop, because the shell parent is immune to
+# the child's uncaught exceptions. Arg1 = bot/profile name.
+bot="$1"
+cd "$(dirname "$0")" || exit 1
+while IFS='|' read -r exp prompt; do
+  [ -z "$exp" ] && continue
+  # </dev/null so route1.mjs cannot consume the heredoc lines this while-loop
+  # is reading from stdin (classic read-loop stdin-steal bug).
+  res=$(node route1.mjs "$bot" "$prompt" </dev/null 2>/dev/null)
+  echo "$exp :: $res"
+  # Reap lingering detached `dist/entry.js agent` reset boots between prompts.
+  # harness.mjs spawns one per scenario, detached, and they "hang on teardown";
+  # left to pile up they OOM the 4GB cgroup and the kernel kills PID 1 (the
+  # gateway), restarting the container. Reap + settle keeps peak at one boot.
+  pkill -f "dist/entry.js agent" 2>/dev/null
+  sleep 3
+done

--- a/extensions/test-capture/harness/fix-allow.mjs
+++ b/extensions/test-capture/harness/fix-allow.mjs
@@ -1,0 +1,39 @@
+// One-shot, idempotent box-config pairing for S1 (optional-tool scoping).
+// Adds each bot's plugin-id to its agent tools.allow so optional:true tools
+// stay visible to the bot's own agent (isOptionalToolAllowed passes when the
+// allowlist contains the plugin id). Backs up first; only adds if missing.
+import fs from "node:fs";
+
+const CFG = "/root/.openclaw/openclaw.json";
+const BOTS = ["bigheadbot", "pulsebot", "zoomwarriorssupportbot", "cloudflow-support"];
+
+const raw = fs.readFileSync(CFG, "utf8");
+const j = JSON.parse(raw);
+const list = (j.agents && j.agents.list) || [];
+
+const bak = `${CFG}.bak-${Date.now()}`;
+fs.writeFileSync(bak, raw);
+
+const changed = [];
+for (const b of BOTS) {
+  const a = list.find((x) => (x.id || x.agentId) === b);
+  if (!a) {
+    changed.push(`${b}: NO AGENT (skipped)`);
+    continue;
+  }
+  a.tools = a.tools || {};
+  const allow = (a.tools.allow = a.tools.allow || []);
+  if (allow.includes(b)) {
+    changed.push(`${b}: already present`);
+  } else {
+    allow.push(b);
+    changed.push(`${b}: added plugin-id (allow now ${allow.length})`);
+  }
+}
+
+fs.writeFileSync(CFG, `${JSON.stringify(j, null, 2)}\n`);
+// Re-validate the written file parses.
+JSON.parse(fs.readFileSync(CFG, "utf8"));
+console.log(`backup=${bak}`);
+for (const c of changed) console.log(c);
+console.log("OK");

--- a/extensions/test-capture/harness/route1.mjs
+++ b/extensions/test-capture/harness/route1.mjs
@@ -1,0 +1,33 @@
+// Single-prompt routing probe. Runs ONE harness.mjs scenario and prints a
+// compact one-line JSON result. Designed to be driven by a shell loop: each
+// invocation is its own short-lived process, so a crash/throw here cannot kill
+// the loop (unlike a long-lived node batch runner, whose parent dies on any
+// uncaught exception). Usage: node route1.mjs <bot> "<prompt>"
+import { execFileSync } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HARNESS_DIR = dirname(fileURLToPath(import.meta.url));
+const [, , bot, prompt] = process.argv;
+
+try {
+  const out = execFileSync("node", ["harness.mjs", bot, prompt, "--json"], {
+    cwd: HARNESS_DIR,
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 150_000,
+    killSignal: "SIGKILL",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const j = JSON.parse(out.slice(out.indexOf("{")));
+  const u = j.summary || {};
+  console.log(
+    JSON.stringify({
+      tools: u.coordinatorTools || [],
+      mut: u.mutatingToolsCalled || [],
+      out: u.outboundCount || 0,
+    }),
+  );
+} catch (e) {
+  console.log(JSON.stringify({ error: (e.message || String(e)).slice(0, 160) }));
+}

--- a/extensions/zoomwarriors-write/index.ts
+++ b/extensions/zoomwarriors-write/index.ts
@@ -1,10 +1,10 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
-import { DatabaseSync } from "node:sqlite";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
-import { zw2Fetch, getZw2Base } from "../zoomwarriors/zw2-auth.js";
+import { zw2Fetch, getZw2Base } from "./zw2-auth.js";
 
 const ZW2_BASE = getZw2Base();
 
@@ -58,7 +58,9 @@ function jsonResult(data: unknown) {
 
 function errorResult(err: unknown) {
   const message = err instanceof Error ? err.message : String(err);
-  return { content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }] };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
 }
 
 // --- Section submission helper ---
@@ -75,9 +77,10 @@ function registerSectionTool(
     description,
     parameters: Type.Object({
       order_id: Type.Number({ description: "The ZW2 order ID" }),
-      data: method === "POST"
-        ? Type.Optional(Type.String({ description: "JSON string of section fields to submit" }))
-        : Type.Optional(Type.String({ description: "Not used for GET requests" })),
+      data:
+        method === "POST"
+          ? Type.Optional(Type.String({ description: "JSON string of section fields to submit" }))
+          : Type.Optional(Type.String({ description: "Not used for GET requests" })),
     }),
     async execute(_id: string, params: Record<string, unknown>) {
       try {
@@ -131,45 +134,75 @@ const plugin = {
     }));
 
     // Section submission tools
-    registerSectionTool(api, "zw2_submit_customer_info",
+    registerSectionTool(
+      api,
+      "zw2_submit_customer_info",
       "Submit customer info (Section 1) for a ZW2 order: order_name, order_type, company details, decision maker, billing contact.",
-      (id) => `/api/v1/orders/${id}/customer-info/`);
+      (id) => `/api/v1/orders/${id}/customer-info/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zp_license",
+    registerSectionTool(
+      api,
+      "zw2_submit_zp_license",
       "Submit Zoom Phone license counts (Section 2): zoom_phone_licenses, common_area_licenses, power_pack_licenses, additional_dids.",
-      (id) => `/api/v1/orders/${id}/zp-license/`);
+      (id) => `/api/v1/orders/${id}/zp-license/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zp_location",
+    registerSectionTool(
+      api,
+      "zw2_submit_zp_location",
       "Submit Zoom Phone location info (Section 3): sites, e911 zones, foreign ports, international deployment.",
-      (id) => `/api/v1/orders/${id}/zp-location/`);
+      (id) => `/api/v1/orders/${id}/zp-location/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zp_features",
+    registerSectionTool(
+      api,
+      "zw2_submit_zp_features",
       "Submit Zoom Phone features (Section 4): auto receptionists, call queues, ATAs, paging.",
-      (id) => `/api/v1/orders/${id}/zp-features/`);
+      (id) => `/api/v1/orders/${id}/zp-features/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zp_hardware",
+    registerSectionTool(
+      api,
+      "zw2_submit_zp_hardware",
       "Submit Zoom Phone hardware info (Section 5): physical phones, reprovisioning.",
-      (id) => `/api/v1/orders/${id}/zp-hardware/`);
+      (id) => `/api/v1/orders/${id}/zp-hardware/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zp_sbc_pbx",
+    registerSectionTool(
+      api,
+      "zw2_submit_zp_sbc_pbx",
       "Submit Zoom Phone SBC/PBX config (Section 6): BYOC, SBC count/type, PBX count/type.",
-      (id) => `/api/v1/orders/${id}/zp-sbc-pbx/`);
+      (id) => `/api/v1/orders/${id}/zp-sbc-pbx/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_zcc",
+    registerSectionTool(
+      api,
+      "zw2_submit_zcc",
       "Submit Zoom Contact Center config (Section 7): agents, channels (voice/video/sms/webchat/email/social), BYOC.",
-      (id) => `/api/v1/orders/${id}/zcc/`);
+      (id) => `/api/v1/orders/${id}/zcc/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_wfo",
+    registerSectionTool(
+      api,
+      "zw2_submit_wfo",
       "Submit Workplace Optimization (Section 8): workforce management, quality management, AI expert assist, ZVA.",
-      (id) => `/api/v1/orders/${id}/zcc-workplace-optimization/`);
+      (id) => `/api/v1/orders/${id}/zcc-workplace-optimization/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_additions",
+    registerSectionTool(
+      api,
+      "zw2_submit_additions",
       "Submit additions (Section 9): SSO, marketplace apps, CTI integrations.",
-      (id) => `/api/v1/orders/${id}/additions/`);
+      (id) => `/api/v1/orders/${id}/additions/`,
+    );
 
-    registerSectionTool(api, "zw2_submit_wrapup",
+    registerSectionTool(
+      api,
+      "zw2_submit_wrapup",
       "Submit wrapup questions (Section 10): go-live events, training sessions, on-site support.",
-      (id) => `/api/v1/orders/${id}/wrapup-questions/`);
+      (id) => `/api/v1/orders/${id}/wrapup-questions/`,
+    );
 
     // --- Order Modification Tools (Training Data Patterns) ---
 
@@ -195,15 +228,21 @@ const plugin = {
     }));
 
     // SOW generation
-    registerSectionTool(api, "zw2_generate_sow",
+    registerSectionTool(
+      api,
+      "zw2_generate_sow",
       "Generate the Statement of Work document for a completed ZW2 order.",
-      (id) => `/api/v1/orders/${id}/generate-sow/`);
+      (id) => `/api/v1/orders/${id}/generate-sow/`,
+    );
 
     // SOW download (GET)
-    registerSectionTool(api, "zw2_download_sow",
+    registerSectionTool(
+      api,
+      "zw2_download_sow",
       "Download the generated SOW PDF for a ZW2 order. Returns the PDF content or download URL.",
       (id) => `/api/v1/orders/${id}/download-sow-pdf/`,
-      "GET");
+      "GET",
+    );
 
     // --- Extraction tracking tools ---
 
@@ -213,10 +252,14 @@ const plugin = {
         "Save transcript extraction data for a ZW2 order. Call after each bighead_analyze_transcript or bighead_followup to track the latest state. Links conversation_id to order_id.",
       parameters: Type.Object({
         conversation_id: Type.String({ description: "Rebecca conversation ID from bighead" }),
-        order_id: Type.Optional(Type.Number({ description: "ZW2 order ID (set after zw2_create_order)" })),
+        order_id: Type.Optional(
+          Type.Number({ description: "ZW2 order ID (set after zw2_create_order)" }),
+        ),
         extracted_data: Type.String({ description: "Full extracted JSON blob from Rebecca" }),
         customer_name: Type.Optional(Type.String({ description: "Customer/company name" })),
-        order_type: Type.Optional(Type.String({ description: "zoom_phone, zoom_contact_center, or both" })),
+        order_type: Type.Optional(
+          Type.String({ description: "zoom_phone, zoom_contact_center, or both" }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         try {
@@ -227,7 +270,9 @@ const plugin = {
           const notes = JSON.stringify(parsed.confidence_notes ?? []);
           const mfCount = Array.isArray(parsed.missing_fields) ? parsed.missing_fields.length : 0;
 
-          const existing = db.prepare("SELECT id, followup_count FROM extractions WHERE conversation_id = ?").get(convId) as { id: number; followup_count: number } | undefined;
+          const existing = db
+            .prepare("SELECT id, followup_count FROM extractions WHERE conversation_id = ?")
+            .get(convId) as { id: number; followup_count: number } | undefined;
 
           if (existing) {
             db.prepare(`UPDATE extractions SET
@@ -236,19 +281,37 @@ const plugin = {
               customer_name = COALESCE(?, customer_name),
               order_type = COALESCE(?, order_type),
               followup_count = ?
-              WHERE conversation_id = ?`
-            ).run(data, missing, notes,
-              params.order_id ?? null, params.customer_name ?? null, params.order_type ?? null,
-              existing.followup_count + 1, convId);
+              WHERE conversation_id = ?`).run(
+              data,
+              missing,
+              notes,
+              params.order_id ?? null,
+              params.customer_name ?? null,
+              params.order_type ?? null,
+              existing.followup_count + 1,
+              convId,
+            );
           } else {
             db.prepare(`INSERT INTO extractions
               (conversation_id, order_id, customer_name, order_type, extracted_data, missing_fields, confidence_notes, started_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-            ).run(convId, params.order_id ?? null, params.customer_name ?? null,
-              params.order_type ?? null, data, missing, notes, new Date().toISOString());
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(
+              convId,
+              params.order_id ?? null,
+              params.customer_name ?? null,
+              params.order_type ?? null,
+              data,
+              missing,
+              notes,
+              new Date().toISOString(),
+            );
           }
 
-          return jsonResult({ ok: true, conversation_id: convId, missing_fields_count: mfCount, updated: !!existing });
+          return jsonResult({
+            ok: true,
+            conversation_id: convId,
+            missing_fields_count: mfCount,
+            updated: !!existing,
+          });
         } catch (err) {
           return errorResult(err);
         }
@@ -266,16 +329,23 @@ const plugin = {
       async execute(_id: string, params: Record<string, unknown>) {
         try {
           const convId = params.conversation_id as string;
-          const row = db.prepare("SELECT id FROM extractions WHERE conversation_id = ?").get(convId) as { id: number } | undefined;
+          const row = db
+            .prepare("SELECT id FROM extractions WHERE conversation_id = ?")
+            .get(convId) as { id: number } | undefined;
           if (!row) return jsonResult({ ok: false, error: "Session not found" });
 
           db.prepare(`UPDATE extractions SET
             status = 'completed', completed_at = ?,
             order_id = COALESCE(?, order_id)
-            WHERE conversation_id = ?`
-          ).run(new Date().toISOString(), params.order_id ?? null, convId);
+            WHERE conversation_id = ?`).run(
+            new Date().toISOString(),
+            params.order_id ?? null,
+            convId,
+          );
 
-          const session = db.prepare("SELECT * FROM extractions WHERE conversation_id = ?").get(convId) as Record<string, unknown>;
+          const session = db
+            .prepare("SELECT * FROM extractions WHERE conversation_id = ?")
+            .get(convId) as Record<string, unknown>;
           return jsonResult({ ok: true, ...session });
         } catch (err) {
           return errorResult(err);
@@ -295,9 +365,13 @@ const plugin = {
         try {
           let row: Record<string, unknown> | undefined;
           if (params.conversation_id) {
-            row = db.prepare("SELECT * FROM extractions WHERE conversation_id = ?").get(params.conversation_id as string) as Record<string, unknown> | undefined;
+            row = db
+              .prepare("SELECT * FROM extractions WHERE conversation_id = ?")
+              .get(params.conversation_id as string) as Record<string, unknown> | undefined;
           } else if (params.order_id) {
-            row = db.prepare("SELECT * FROM extractions WHERE order_id = ?").get(params.order_id as number) as Record<string, unknown> | undefined;
+            row = db
+              .prepare("SELECT * FROM extractions WHERE order_id = ?")
+              .get(params.order_id as number) as Record<string, unknown> | undefined;
           } else {
             return jsonResult({ ok: false, error: "Provide conversation_id or order_id" });
           }
@@ -306,13 +380,19 @@ const plugin = {
 
           // Parse JSON fields for readability
           if (typeof row.extracted_data === "string") {
-            try { row.extracted_data = JSON.parse(row.extracted_data); } catch {}
+            try {
+              row.extracted_data = JSON.parse(row.extracted_data);
+            } catch {}
           }
           if (typeof row.missing_fields === "string") {
-            try { row.missing_fields = JSON.parse(row.missing_fields); } catch {}
+            try {
+              row.missing_fields = JSON.parse(row.missing_fields);
+            } catch {}
           }
           if (typeof row.confidence_notes === "string") {
-            try { row.confidence_notes = JSON.parse(row.confidence_notes); } catch {}
+            try {
+              row.confidence_notes = JSON.parse(row.confidence_notes);
+            } catch {}
           }
 
           return jsonResult({ ok: true, ...row });
@@ -328,7 +408,9 @@ const plugin = {
         "List recent extraction sessions. Shows conversation_id, order_id, customer, status, and followup count.",
       parameters: Type.Object({
         limit: Type.Optional(Type.Number({ description: "Max rows to return (default 20)" })),
-        status: Type.Optional(Type.String({ description: "Filter by status: in_progress, completed" })),
+        status: Type.Optional(
+          Type.String({ description: "Filter by status: in_progress, completed" }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         try {
@@ -337,13 +419,17 @@ const plugin = {
 
           let rows: unknown[];
           if (status) {
-            rows = db.prepare(
-              "SELECT id, conversation_id, order_id, customer_name, order_type, status, followup_count, started_at, completed_at FROM extractions WHERE status = ? ORDER BY id DESC LIMIT ?"
-            ).all(status, limit) as unknown[];
+            rows = db
+              .prepare(
+                "SELECT id, conversation_id, order_id, customer_name, order_type, status, followup_count, started_at, completed_at FROM extractions WHERE status = ? ORDER BY id DESC LIMIT ?",
+              )
+              .all(status, limit) as unknown[];
           } else {
-            rows = db.prepare(
-              "SELECT id, conversation_id, order_id, customer_name, order_type, status, followup_count, started_at, completed_at FROM extractions ORDER BY id DESC LIMIT ?"
-            ).all(limit) as unknown[];
+            rows = db
+              .prepare(
+                "SELECT id, conversation_id, order_id, customer_name, order_type, status, followup_count, started_at, completed_at FROM extractions ORDER BY id DESC LIMIT ?",
+              )
+              .all(limit) as unknown[];
           }
 
           return jsonResult({ ok: true, count: rows.length, sessions: rows });

--- a/extensions/zoomwarriors-write/zw2-auth.ts
+++ b/extensions/zoomwarriors-write/zw2-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * ZW2 authentication for zoomwarriors-write.
+ *
+ * Deliberate per-package copy of extensions/zoomwarriors/zw2-auth.ts: extension
+ * packages must not deep-import another extension's files (boundary rule in
+ * extensions/AGENTS.md), and this fork keeps bot code per-package by policy.
+ * Both copies share ONE token state via the `__zw2_auth_state__` globalThis key,
+ * so read and write plugins still reuse the same access/refresh tokens.
+ */
+
+const ZW2_BASE = process.env.ZW2_URL ?? "http://zoomwarriors2-backend:8000";
+
+interface Zw2AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+}
+
+// Global singleton — survives across plugin boundaries. MUST match the key used
+// by extensions/zoomwarriors/zw2-auth.ts.
+const GLOBAL_KEY = "__zw2_auth_state__";
+const g = globalThis as Record<string, unknown>;
+if (!g[GLOBAL_KEY]) {
+  g[GLOBAL_KEY] = { accessToken: null, refreshToken: null };
+}
+const state = g[GLOBAL_KEY] as Zw2AuthState;
+
+async function zw2Login(): Promise<void> {
+  const username = process.env.ZW2_USERNAME;
+  const password = process.env.ZW2_PASSWORD;
+  if (!username || !password) throw new Error("ZW2_USERNAME and ZW2_PASSWORD env vars required");
+
+  const resp = await fetch(`${ZW2_BASE}/api/v1/auth/login/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password, terms_accepted: true }),
+  });
+
+  if (!resp.ok) throw new Error(`ZW2 login failed: ${resp.status}`);
+  const data = (await resp.json()) as Record<string, unknown>;
+  state.accessToken = data.access_token as string;
+  state.refreshToken = data.refresh_token as string;
+}
+
+async function zw2RefreshToken(): Promise<void> {
+  if (!state.refreshToken) return zw2Login();
+
+  const resp = await fetch(`${ZW2_BASE}/api/v1/auth/token/refresh/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refresh_token: state.refreshToken }),
+  });
+
+  if (!resp.ok) return zw2Login();
+  const data = (await resp.json()) as Record<string, unknown>;
+  state.accessToken = data.access_token as string;
+  state.refreshToken = data.refresh_token as string;
+}
+
+export async function zw2Fetch(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  if (!state.accessToken) await zw2Login();
+
+  const doFetch = async (): Promise<Response> =>
+    fetch(`${ZW2_BASE}${endpoint}`, {
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        Authorization: `Bearer ${state.accessToken}`,
+      },
+    });
+
+  let resp = await doFetch();
+  if (resp.status === 401) {
+    await zw2RefreshToken();
+    resp = await doFetch();
+  }
+
+  const data = resp.headers.get("content-type")?.includes("application/json")
+    ? await resp.json()
+    : await resp.text();
+
+  return { ok: resp.ok, status: resp.status, data };
+}
+
+export function getZw2Base(): string {
+  return ZW2_BASE;
+}

--- a/extensions/zoomwarriorssupportbot/index.ts
+++ b/extensions/zoomwarriorssupportbot/index.ts
@@ -39,9 +39,15 @@ const plugin = {
     // scope them: non-optional plugin tools bypass allowlists and become visible
     // to EVERY agent. With this wrapper, only agents whose `tools.allow` includes
     // a tool name, the plugin id ("zoomwarriorssupportbot"), or "group:plugins" see them.
+    // The wrapper also counts registrations so the startup banner can never drift
+    // from the real tool count.
+    let toolCount = 0;
     const optionalApi: OpenClawPluginApi = {
       ...api,
-      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+      registerTool: (tool, opts) => {
+        toolCount += 1;
+        return api.registerTool(tool, { ...opts, optional: true });
+      },
     };
 
     registerZwsTools(optionalApi, logger);
@@ -84,7 +90,7 @@ const plugin = {
     });
 
     console.log(
-      "[zoomwarriorssupportbot] Registered 25 tools (11 ZWS + 6 GH + 1 correlation + 7 devtools)",
+      `[zoomwarriorssupportbot] Registered ${toolCount} tools (ZWS + GH + correlation + devtools)`,
     );
   },
 };


### PR DESCRIPTION
## Summary

Fleet cleanliness follow-ups from the production-readiness review (no behavior changes to gated writes):

- **Programmatic tool-count banners** (bigheadbot / zoomwarriorssupportbot / pulsebot / cloudflow-support): the `optionalApi` wrapper now counts registrations and the startup banner reports `${toolCount}` — bigheadbot/zws claimed "25 tools" while actually registering 26. The drift class is dead, not just the instance.
- **scopelybot `confirm.ts` extraction**: `tryExecuteConfirm` moves out of `user-maintenance-tools.ts` into `src/confirm.ts`, matching the module shape of every other gated bot (bigheadbot/pulsebot/zws/cloudflow/EOA). All 8 import sites updated; no re-export shim.
- **zoomwarriors-write boundary fix**: the `../zoomwarriors/zw2-auth.js` deep import (cross-extension boundary violation per `extensions/AGENTS.md`) is replaced with a deliberate per-package copy. Both copies share one token state via the `__zw2_auth_state__` globalThis key — read+write plugins still reuse the same access/refresh tokens (same pattern the original module was built around).
- **Harness tooling**: commit `route1.mjs` (single-prompt routing probe), `drive.sh` (resilient shell batch driver), `fix-allow.mjs` (idempotent, backup-first agent-allowlist pairing — needed again when the PROD box gets paired); delete deprecated `cases-bots-reads.mjs` (dies on parent-process exceptions). These live under `extensions/test-capture/` which is fully inert unless `OPENCLAW_TEST_CAPTURE=1`; keep the harness out of the prod image regardless.

## Verification

- `node scripts/run-vitest.mjs extensions/{scopelybot,bigheadbot,zoomwarriorssupportbot,pulsebot,cloudflow-support}` → **24 files / 142 tests passed** (post-extraction; scopelybot 53/53 includes all confirm-flow tests now importing from `confirm.js`).
- Stacked on #47 (merged); diff is this branch's commit only.
- Fork CI: same perpetually-red baseline; merge gate = failing-check subset comparison vs #46/#47.
