### PR TITLE
feat(deploy): production compose profile, env contract, plugin deny policy

### DIFF
--- a/.env.prod-template
+++ b/.env.prod-template
@@ -1,0 +1,97 @@
+# Production .env contract for docker-compose.prod.yml.
+# Copy to .env on the PROD host and fill every value. There are NO baked-in
+# fallbacks: a missing credential/URL fails closed in code (loud error or the
+# feature stays disabled) — it never silently authenticates or points at the
+# wrong environment.
+
+# --- Public ingress (Traefik) ---
+# The prod equivalent of molty-dev.cloudwarriors.ai. The Zoom marketplace app's
+# webhook URL must be https://$OPENCLAW_PUBLIC_DOMAIN/zoom/webhook
+OPENCLAW_PUBLIC_DOMAIN=
+# Image tag the box runs (built from this checkout: docker compose -f docker-compose.prod.yml build)
+OPENCLAW_IMAGE=openclaw:prod
+
+# --- Model providers ---
+ANTHROPIC_API_KEY=
+OPENROUTER_API_KEY=
+OPENAI_API_KEY=
+ZOOM_PREFILTER_MODEL=anthropic/claude-haiku-4.5
+ZOOM_PREFILTER_ENABLED=
+
+# --- Gateway auth (REQUIRED — no dev-token default exists anymore) ---
+OPENCLAW_GATEWAY_TOKEN=
+
+# --- Zoom S2S OAuth (Team Chat App — use the PROD marketplace app) ---
+ZOOM_CLIENT_ID=
+ZOOM_CLIENT_SECRET=
+ZOOM_ACCOUNT_ID=
+ZOOM_BOT_JID=
+# REQUIRED: with this unset, ALL inbound Zoom webhooks are rejected 401 (fail-closed).
+ZOOM_WEBHOOK_SECRET_TOKEN=
+
+# --- Zoom S2S OAuth (Admin Reports — chat history ingest) ---
+ZOOM_REPORT_ACCOUNT_ID=${ZOOM_ACCOUNT_ID}
+ZOOM_REPORT_CLIENT_ID=
+ZOOM_REPORT_CLIENT_SECRET=
+ZOOM_REPORT_USER=
+
+# --- Confirm-gate channel bindings (PROD Zoom channel JIDs) ---
+# Each bot posts its CONFIRM <code> prompt to its channel; only a reply FROM
+# that channel can fire a staged write. Unset = that bot's write staging is
+# disabled (fail-closed, safe but inert). The in-code fallback constants are
+# DEV channels — prod MUST set these.
+SCOPELYBOT_ZOOM_CHANNEL=
+BIGHEADBOT_ZOOM_CHANNEL=
+PULSEBOT_ZOOM_CHANNEL=
+ZWS_ZOOM_CHANNEL=
+CF_ZOOM_CHANNEL=
+EOA_ZOOM_CHANNEL=
+
+# --- Per-product backends ---
+PROJECT_PULSE_URL=https://projectpulse.pscx.ai
+PROJECT_PULSE_EMAIL=
+PROJECT_PULSE_PASSWORD=
+
+ZW2_URL=
+ZW2_USERNAME=
+ZW2_PASSWORD=
+
+SCOPELY_BASE_URL=https://vip.pscx.ai
+SCOPELY_EMAIL=
+SCOPELY_PASSWORD=
+SCOPELY_CONTAINER=
+SCOPELY_DEVTOOLS_API_URL=
+SCOPELY_DEV_TOOLS_API=
+
+# Tesseract ETL backend. Unset = tesseract tools error per-call (gateway stays up).
+TESSERACT_URL=
+TESSERACT_EXTERNAL_URL=
+TESSERACT_USERNAME=
+TESSERACT_PASSWORD=
+
+# Bighead avatar API. URL defaults to the compose-internal http://bighead:8000;
+# the token has NO default — the join tool fails closed without it.
+BIGHEAD_GATEWAY_TOKEN=
+
+# External Org Autopilot checkout + state inside the container.
+# Defaults (unset) = /root/code/external-org-autopilot and <root>/.autopilot-state
+EOA_ROOT=
+EOA_STATE_DIR=
+
+# --- Sidecars / infra on this box ---
+# devtools-api sidecar bearer key (REQUIRED for devtools tools; no default).
+DEVTOOLS_LOCAL_KEY=
+GITHUB_READ_ACCESS=
+CW_CHAT_RESPONDER_URL=
+CW_CHAT_RESPONDER_TOKEN=
+# Elasticsearch for the dev-events agent (DEA). Host-specific URL, no default.
+DEA_ES_URL=
+DEA_ES_USER=elastic
+DEA_ES_PASSWORD=
+DEA_ES_INDEX=logs-noobbox.docker-events-default
+DEA_ZOOM_CHANNEL=
+PEA_ZOOM_CHANNEL=
+PEA_RELAY_TOKEN=
+PEA_RELAY_URL=
+
+ADMIN_DOMAIN=cloudwarriors.ai

--- a/deploy/PROD.md
+++ b/deploy/PROD.md
@@ -1,0 +1,75 @@
+# Production deployment — cw-openclaw
+
+The flip-switch model: **dev and prod run the same SHA**; only three things
+differ per box — `.env`, the compose profile, and the box's `openclaw.json`
+runtime config. No prod-only branches, no image surgery.
+
+| Surface       | Dev box (noob-root)         | Prod box (Linode)                                  |
+| ------------- | --------------------------- | -------------------------------------------------- |
+| Compose       | `docker-compose.dev.yml`    | `docker-compose.prod.yml`                          |
+| Env           | `.env` from `.env-template` | `.env` from `.env.prod-template`                   |
+| Plugin policy | all bundled extensions      | `plugins.deny` via `deploy/prod-plugin-policy.mjs` |
+| Domain        | molty-dev.cloudwarriors.ai  | `$OPENCLAW_PUBLIC_DOMAIN`                          |
+
+## What prod excludes (and how)
+
+`claude-mem`, `slm-pipeline`, `slm-supervisor`, `2fa-github`, `test-capture`
+are excluded at the **loader level**: `plugins.deny` in the box's
+`openclaw.json` removes them from the effective-enabled set
+(`src/plugins/effective-plugin-ids.ts`) and `enable.ts` refuses to re-enable a
+denied id. Defense in depth for the test harness: `OPENCLAW_TEST_CAPTURE` is
+absent from the prod compose, which keeps `test-capture` fully inert even if
+the deny were removed. The slm-dashboard app is never started (no service in
+the prod compose; dev's `claude-mem-chroma` service is also absent).
+
+## First-time bring-up (ordered)
+
+1. **Checkout + env.** Clone/fetch the repo on the box, check out `development`
+   (or the release SHA), `cp .env.prod-template .env`, fill EVERY value.
+   There are no fallbacks: missing secrets fail closed — the gateway boots, but
+   that feature errors or stays disabled. Pay attention to:
+   - `ZOOM_WEBHOOK_SECRET_TOKEN` — unset means **all** Zoom webhooks are 401'd.
+   - the six `*_ZOOM_CHANNEL` JIDs — must be **prod** channels (the in-code
+     fallback constants are dev channels); unset disables that bot's write
+     staging (fail-closed).
+   - `OPENCLAW_PUBLIC_DOMAIN` — the Zoom marketplace app's event subscription
+     URL must be `https://$OPENCLAW_PUBLIC_DOMAIN/zoom/webhook`.
+2. **Build.** `docker compose -f docker-compose.prod.yml build`
+3. **Runtime config.** Provision `.data/openclaw/openclaw.json` (agents list,
+   bindings). Then run BOTH config scripts (idempotent, backup-first):
+   - `node deploy/prod-plugin-policy.mjs ./.data/openclaw/openclaw.json`
+     (prod deny list)
+   - `node extensions/test-capture/harness/fix-allow.mjs` against the same file
+     (adds each bot's plugin id to its agent `tools.allow` — REQUIRED before
+     boot: bot tools are registered `optional:true` and an agent without its
+     plugin id in the allowlist loses its own tools).
+4. **Up.** `docker compose -f docker-compose.prod.yml up -d`
+   No host ports are published — Traefik (on the external `proxy` network)
+   terminates TLS and routes `/` → 18789 and `/zoom/` → 4000.
+5. **Zoom URL validation.** In the Zoom marketplace app, point the event
+   subscription at the prod webhook URL and run validation (the fail-closed
+   handler answers the challenge only when the secret is configured).
+
+## Smoke checklist (after every deploy)
+
+- `docker logs openclaw | grep -E "Registered .* tools"` — each bot banner
+  appears on first dispatch with the counted total; no module-load crashes.
+- Denied plugins absent: `docker logs openclaw | grep -Ei "claude-mem|slm-|2fa|test-capture"`
+  shows no activation.
+- Webhook fail-closed: `curl -s -o /dev/null -w "%{http_code}" -X POST
+https://$OPENCLAW_PUBLIC_DOMAIN/zoom/webhook -H 'content-type: application/json' -d '{}'`
+  → **401** (unsigned must be rejected).
+- One read-tool round trip per bot from its prod channel; one staged write →
+  threaded `CONFIRM <code>` prompt → `CONFIRM 0000` from the wrong code is
+  refused ("No pending action").
+
+## Routine deploy (the switch)
+
+```sh
+git fetch && git checkout <sha-or-development>
+docker compose -f docker-compose.prod.yml build   # only when Dockerfile/dist changed
+docker restart openclaw                            # extensions are mounted source
+```
+
+Rollback = `git checkout <previous sha>` + restart. `.env` and
+`openclaw.json` are not tracked by git and survive checkouts.

--- a/deploy/prod-plugin-policy.mjs
+++ b/deploy/prod-plugin-policy.mjs
@@ -1,0 +1,44 @@
+// One-shot, idempotent PROD plugin policy for the box's openclaw.json.
+// Merges the production deny list into plugins.deny so the loader never
+// activates extensions excluded from prod (resolveEffectivePluginIds drops
+// denied ids; enable.ts refuses to re-enable them). Backs up first; only adds
+// missing ids; never removes operator-added entries.
+//
+// Run ON the box (config lives in runtime state, not the repo):
+//   node deploy/prod-plugin-policy.mjs [/path/to/openclaw.json]
+import fs from "node:fs";
+
+const CFG = process.argv[2] ?? "/root/.openclaw/openclaw.json";
+
+// Excluded from prod (decision 2026-06-09): claude-mem (bun fork + chroma dep),
+// slm-pipeline/slm-supervisor (HTTP routes, dev-only), 2fa-github (dead-code
+// enforcement gap, not shipped until fixed), test-capture (test harness;
+// also inert without OPENCLAW_TEST_CAPTURE=1 which prod compose never sets).
+const PROD_DENY = ["claude-mem", "slm-pipeline", "slm-supervisor", "2fa-github", "test-capture"];
+
+const raw = fs.readFileSync(CFG, "utf8");
+const j = JSON.parse(raw);
+
+const bak = `${CFG}.bak-${Date.now()}`;
+fs.writeFileSync(bak, raw);
+
+j.plugins = j.plugins || {};
+const deny = (j.plugins.deny = j.plugins.deny || []);
+
+const report = [];
+for (const id of PROD_DENY) {
+  if (deny.includes(id)) {
+    report.push(`${id}: already denied`);
+  } else {
+    deny.push(id);
+    report.push(`${id}: added to plugins.deny`);
+  }
+}
+
+fs.writeFileSync(CFG, `${JSON.stringify(j, null, 2)}\n`);
+// Re-validate the written file parses.
+JSON.parse(fs.readFileSync(CFG, "utf8"));
+console.log(`backup=${bak}`);
+for (const line of report) console.log(line);
+console.log(`plugins.deny now: ${JSON.stringify(deny)}`);
+console.log("OK");

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,130 @@
+# Production compose profile. Same image + same mounted-extensions deploy model
+# as docker-compose.dev.yml so dev and prod "flip a switch": identical SHA, only
+# .env and this profile differ. Deliberate deltas from the dev profile:
+#   - NO published ports: Traefik reaches the container over the shared `proxy`
+#     network; publishing 18789/4000 on a public host would expose the gateway
+#     directly.
+#   - NO claude-mem-chroma service, NO OPENCLAW_TEST_CAPTURE, NO ngrok/2FA env:
+#     claude-mem, slm-*, 2fa-github, and test-capture are excluded from prod
+#     (loader-level plugins.deny — see deploy/prod-plugin-policy.mjs).
+#   - NO baked-in channel JIDs or box IPs: everything host-specific comes from
+#     .env (see .env.prod-template). Missing values fail closed in code.
+#   - NO ./src or ./scripts/tests mounts: the runtime executes the image's dist;
+#     only extensions load as mounted source.
+services:
+  openclaw:
+    build:
+      context: .
+    image: ${OPENCLAW_IMAGE:-openclaw:prod}
+    container_name: openclaw
+    user: root
+    environment:
+    - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+    - ZOOM_PREFILTER_MODEL=${ZOOM_PREFILTER_MODEL}
+    - ZOOM_PREFILTER_ENABLED=${ZOOM_PREFILTER_ENABLED}
+    - PROJECT_PULSE_URL=${PROJECT_PULSE_URL}
+    - PROJECT_PULSE_EMAIL=${PROJECT_PULSE_EMAIL}
+    - PROJECT_PULSE_PASSWORD=${PROJECT_PULSE_PASSWORD}
+    # No baked-in credential defaults anywhere below: a missing var must fail
+    # closed in the consuming code, never silently authenticate.
+    - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+    - CLAWDBOT_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
+    - BIGHEAD_API_URL=${BIGHEAD_API_URL:-http://bighead:8000}
+    - BIGHEAD_GATEWAY_TOKEN=${BIGHEAD_GATEWAY_TOKEN}
+    - ZW2_USERNAME=${ZW2_USERNAME}
+    - ZW2_PASSWORD=${ZW2_PASSWORD}
+    - ZW2_URL=${ZW2_URL}
+    - ZOOM_CLIENT_ID=${ZOOM_CLIENT_ID}
+    - ZOOM_CLIENT_SECRET=${ZOOM_CLIENT_SECRET}
+    - ZOOM_ACCOUNT_ID=${ZOOM_ACCOUNT_ID}
+    - ZOOM_BOT_JID=${ZOOM_BOT_JID}
+    - ZOOM_WEBHOOK_SECRET_TOKEN=${ZOOM_WEBHOOK_SECRET_TOKEN}
+    - ZOOM_REPORT_ACCOUNT_ID=${ZOOM_REPORT_ACCOUNT_ID}
+    - ZOOM_REPORT_CLIENT_ID=${ZOOM_REPORT_CLIENT_ID}
+    - ZOOM_REPORT_CLIENT_SECRET=${ZOOM_REPORT_CLIENT_SECRET}
+    - ZOOM_REPORT_USER=${ZOOM_REPORT_USER}
+    - TESSERACT_URL=${TESSERACT_URL}
+    - TESSERACT_EXTERNAL_URL=${TESSERACT_EXTERNAL_URL}
+    - TESSERACT_USERNAME=${TESSERACT_USERNAME}
+    - TESSERACT_PASSWORD=${TESSERACT_PASSWORD}
+    - ADMIN_DOMAIN=${ADMIN_DOMAIN:-cloudwarriors.ai}
+    - GH_TOKEN=${GITHUB_READ_ACCESS}
+    - DEVTOOLS_API_URL=http://devtools-api:9100
+    - DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
+    - CCMCP_DEVTOOLS_API_URL=http://devtools-api:9100
+    - CCMCP_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
+    - NODE_OPTIONS=--max-old-space-size=3072
+    - CW_CHAT_RESPONDER_URL=${CW_CHAT_RESPONDER_URL}
+    - CW_CHAT_RESPONDER_TOKEN=${CW_CHAT_RESPONDER_TOKEN}
+    - DEA_ES_URL=${DEA_ES_URL}
+    - DEA_ES_USER=${DEA_ES_USER:-elastic}
+    - DEA_ES_PASSWORD=${DEA_ES_PASSWORD}
+    - DEA_ES_INDEX=${DEA_ES_INDEX:-logs-noobbox.docker-events-default}
+    - DEA_ZOOM_CHANNEL=${DEA_ZOOM_CHANNEL}
+    - PEA_ZOOM_CHANNEL=${PEA_ZOOM_CHANNEL}
+    - PEA_RELAY_TOKEN=${PEA_RELAY_TOKEN}
+    - PEA_RELAY_URL=${PEA_RELAY_URL}
+    - ZKE_DEVTOOLS_API_URL=http://devtools-api:9100
+    - ZKE_DEV_TOOLS_API=${DEVTOOLS_LOCAL_KEY}
+    - SCOPELY_BASE_URL=${SCOPELY_BASE_URL}
+    - SCOPELY_URL=${SCOPELY_URL:-${SCOPELY_BASE_URL}}
+    - SCOPELY_EMAIL=${SCOPELY_EMAIL}
+    - SCOPELY_PASSWORD=${SCOPELY_PASSWORD}
+    - SCOPELY_CONTAINER=${SCOPELY_CONTAINER}
+    - SCOPELY_DEVTOOLS_API_URL=${SCOPELY_DEVTOOLS_API_URL}
+    - SCOPELY_DEV_TOOLS_API=${SCOPELY_DEV_TOOLS_API}
+    - SCOPELY_REPO_PATH=${SCOPELY_REPO_PATH:-/app/code/scopely}
+    # Confirm-gate channel bindings: each bot's staged writes post their CONFIRM
+    # prompt here and only a reply FROM this channel can fire them. Unset =
+    # write staging is disabled (fail-closed) for that bot.
+    - SCOPELYBOT_ZOOM_CHANNEL=${SCOPELYBOT_ZOOM_CHANNEL}
+    - BIGHEADBOT_ZOOM_CHANNEL=${BIGHEADBOT_ZOOM_CHANNEL}
+    - PULSEBOT_ZOOM_CHANNEL=${PULSEBOT_ZOOM_CHANNEL}
+    - ZWS_ZOOM_CHANNEL=${ZWS_ZOOM_CHANNEL}
+    - CF_ZOOM_CHANNEL=${CF_ZOOM_CHANNEL}
+    - EOA_ZOOM_CHANNEL=${EOA_ZOOM_CHANNEL}
+    - EOA_ROOT=${EOA_ROOT}
+    - EOA_STATE_DIR=${EOA_STATE_DIR}
+    - OPENCLAW_BUNDLED_PLUGINS_DIR=/app/extensions
+    volumes:
+    - ./extensions:/app/extensions
+    - ./.data/openclaw:/root/.openclaw
+    - ./code:/app/code
+    command:
+    - node
+    - --max-old-space-size=3072
+    - dist/entry.js
+    - gateway
+    - --bind
+    - lan
+    - --port
+    - '18789'
+    - --allow-unconfigured
+    mem_limit: 4g
+    memswap_limit: 4g
+    cpus: '4.0'
+    logging:
+      driver: json-file
+      options:
+        max-size: 25m
+        max-file: '3'
+    restart: unless-stopped
+    labels:
+    - traefik.enable=true
+    - traefik.http.routers.openclaw.rule=Host(`${OPENCLAW_PUBLIC_DOMAIN}`)
+    - traefik.http.routers.openclaw.entrypoints=websecure
+    - traefik.http.routers.openclaw.tls.certresolver=letsencrypt
+    - traefik.http.services.openclaw.loadbalancer.server.port=18789
+    - traefik.http.routers.openclaw-zoom.rule=Host(`${OPENCLAW_PUBLIC_DOMAIN}`) &&
+      PathPrefix(`/zoom/`)
+    - traefik.http.routers.openclaw-zoom.priority=100
+    - traefik.http.routers.openclaw-zoom.entrypoints=websecure
+    - traefik.http.routers.openclaw-zoom.tls.certresolver=letsencrypt
+    - traefik.http.routers.openclaw-zoom.service=openclaw-zoom
+    - traefik.http.services.openclaw-zoom.loadbalancer.server.port=4000
+networks:
+  default:
+    name: proxy
+    external: true

--- a/docs/reference/agent-test-harness-design.md
+++ b/docs/reference/agent-test-harness-design.md
@@ -20,13 +20,13 @@ spoke execution → outbound reply — and:
 2. **Observe the internal hub-and-spoke behavior** — which spoke the coordinator routed to, which
    tools each agent called — so routing/delegation correctness is assertable, not just final text.
 3. Be **modular / agent-agnostic**: testing pulsebot vs scopelybot vs bigheadbot is a different
-   *profile*, not different code. Test-only; inert in production.
+   _profile_, not different code. Test-only; inert in production.
 
 ## Why the obvious seams don't work (the finding that shapes this)
 
 Every bot ships the **same duplicated raw-POST pattern**: `extensions/<bot>/src/comfort.ts` and
 `zoom-dm.ts` call `fetch("https://api.zoom.us/v2/...messages")` **directly, bypassing core
-outbound**. The coordinator's *final reply* goes through core (and fires the `message_sending`
+outbound**. The coordinator's _final reply_ goes through core (and fires the `message_sending`
 hook), but the comfort message and the confirm prompt — the two messages a confirm-gate test most
 needs — do not.
 
@@ -47,7 +47,8 @@ Likewise, the channel output alone can't prove hub-and-spoke routing — that re
   overkill for the need. Revisit only if multi-channel simulation is later required.
 
 ### Reuse-first record
-- `src/proxy-capture/` — MITM capture **proxy**; it *forwards* traffic, so it can't satisfy "don't
+
+- `src/proxy-capture/` — MITM capture **proxy**; it _forwards_ traffic, so it can't satisfy "don't
   write to channel". **Reuse its SQLite store/schema** (`CaptureDirection: "outbound"`) as the
   record sink. **[chosen]**
 - `message_sending` hook — core-only, misses raw POSTs. Rejected as the egress seam.
@@ -88,17 +89,20 @@ Likewise, the channel output alone can't prove hub-and-spoke routing — that re
 ```
 
 ### 1. Intake injector (external CLI)
+
 Posts a signed `team_chat.channel_message_posted` to `:4000/zoom/webhook`. Signature =
 `v0=HMAC_SHA256(ZOOM_WEBHOOK_SECRET_TOKEN, "v0:<ts>:<rawBody>")`, headers `x-zm-signature` +
 `x-zm-request-timestamp`. Parameterized by `channelJid` (routes to whichever bot is bound),
 message text, operator. One injector → any bot.
 
 ### 2. Egress interceptor (the one in-process, test-only piece)
+
 Env-gated (`OPENCLAW_ZOOM_CAPTURE_CHANNELS=<jid,jid>`). Installed at gateway bootstrap; **wraps**
 the existing `undici-runtime` global dispatcher. For requests to `api.zoom.us` message endpoints
 (`/v2/im/chat/messages`, `/v2/chat/users/*/messages`):
+
 - `to_jid` (or DM target) ∈ capture-set → **record outbound + return synthetic `200
-  {status:"ok", message_id:"<fake>"}`**; no real send.
+{status:"ok", message_id:"<fake>"}`**; no real send.
 - otherwise → **forward to the real dispatcher** (production bots in other channels keep working).
 - all non-Zoom traffic (openrouter model calls, Scopely BFF reads, Zoom token/history) →
   untouched passthrough.
@@ -107,6 +111,7 @@ Catches core sends **and** every bot's raw POSTs in one place, scoped so only th
 test go silent.
 
 ### 3. Tool-trace hook (the hub-and-spoke observability piece)
+
 A `before_tool_call` hook (same test env gate) records each call: `{runId, toolName, params,
 toolCallId, agentAttribution}`. Because it fires for `sessions_spawn` too, the trace shows exactly
 which spoke the coordinator chose (`sessions_spawn` `params.agentId`) and which domain tools each
@@ -117,27 +122,31 @@ spoke then called. Records go to the same capture store, correlated by `runId`.
 > tool-policy boundary. **Open question** — confirm the cleanest attribution source.
 
 ### 4. Session reset (external step)
+
 Before each run, `/reset` the target agent's channel session (parameterized by `sessionKey`) so
 prior-turn contamination cannot poison results. (This is the documented non-channel lever; it also
 prevented the 2026-06-05 "fixated on resetting Matt Keuning" failure mode from recurring.)
 
 ### 5. Assertion runner (external)
+
 Reads outbound + tool-trace records for the run from the capture store and asserts. All assertions
 are payload/trace-level — no screenshots needed.
 
 ## What this lets you assert
 
 **Output fidelity (per-bot, e.g. scopelybot confirm-gate):**
+
 - Confirm prompt was posted to the channel and **contains a real `CONFIRM <code>`**.
 - Coordinator's reply is **code-free** (regex: no `CONFIRM \d{4}`).
 - Result is **in-thread** (`reply_to`/`reply_main_message_id` set to the originating message).
 - Wrong-code CONFIRM is a no-op (fail-closed).
 
 **Hub-and-spoke routing (any bot):**
+
 - **Routing discrimination** — request X spawned spoke Y (assert the `sessions_spawn`
   `params.agentId`); a different-domain request spawns a different spoke.
 - **Router-only coordinator** — the coordinator's tool calls ⊆ `{sessions_spawn, subagents,
-  liveness reads}`; it never calls a domain tool directly.
+liveness reads}`; it never calls a domain tool directly.
 - **Per-spoke tool use** — spoke Y called the expected tools (e.g. `scopely_list_users`), and only
   from its own allowlist.
 - **No cross-spoke reach** — a single in-domain task completed without the spoke needing a tool
@@ -146,12 +155,14 @@ are payload/trace-level — no screenshots needed.
   2026-06-05 "list users → staged password reset" contamination directly).
 
 ## Modularity model
+
 An **agent profile** = `{ agentId, channelJid, sessionKey }`. The harness takes a profile + a test
 message + expected assertions. The capture-set is the profile's `channelJid`, so only that bot's
 channel is silenced. Testing another bot = another profile, zero code change. Profiles can live in
 a small test fixture (one entry per bot) or be passed inline.
 
 ## Test flow (one run)
+
 1. Ensure the gateway is running with the interceptor armed (`OPENCLAW_ZOOM_CAPTURE_CHANNELS`
    includes the profile's `channelJid`).
 2. `/reset` the profile's `sessionKey`.
@@ -162,14 +173,17 @@ a small test fixture (one entry per bot) or be passed inline.
 6. Nothing reached the real channel.
 
 ## Where the in-process pieces live
+
 A small **bundled test-capture extension** (`extensions/test-capture/`, or a test-helper module)
 that on `gateway:startup`, **only when the env flag is set**:
+
 - installs the egress interceptor by composing with `undici-runtime`, and
 - registers the `before_tool_call` trace hook.
-Inert when the flag is unset → safe to ship disabled. This keeps the harness in the
-`extensions/`/test boundary and touches no bot code.
+  Inert when the flag is unset → safe to ship disabled. This keeps the harness in the
+  `extensions/`/test boundary and touches no bot code.
 
 ## Open questions to resolve before building
+
 1. **undici composition point** — confirm `src/infra/net/undici-runtime.ts` exposes a clean way to
    wrap the existing dispatcher (capture-or-forward) without clobbering its custom Agent
    (timeouts/proxy).
@@ -184,11 +198,13 @@ Inert when the flag is unset → safe to ship disabled. This keeps the harness i
    `runId`, or an `agent_end` hook) instead of a fixed sleep.
 
 ## Estimated scope
+
 ~300–400 LOC, almost entirely **test infrastructure**: the test-capture extension (interceptor +
 trace hook + store writer), the injector CLI, and the assertion runner. Net **production-runtime**
 change ≈ the env-gated interceptor/hook install only (off by default).
 
 ## Worthwhile follow-on (not required by this design)
+
 The duplicated `comfort.ts`/`zoom-dm.ts` raw POSTs across 7 bots are the reason a clean hook-level
 egress seam doesn't already exist — they violate the repo's "channels are transport-only; product
 code shouldn't raw-send" guidance. Routing them through core outbound (or a shared SDK send helper)

--- a/docs/reference/hub-and-spoke-implementation-guide.md
+++ b/docs/reference/hub-and-spoke-implementation-guide.md
@@ -6,7 +6,7 @@ status: reference
 
 # Hub-and-Spoke for Support Bots — Comprehensive Implementation Guide
 
-> **Scope.** A reusable, copy-this guide for applying the hub-and-spoke pattern to *any* OpenClaw
+> **Scope.** A reusable, copy-this guide for applying the hub-and-spoke pattern to _any_ OpenClaw
 > support bot (scopelybot, pulsebot, bigheadbot, zoomwarriorssupportbot, …). First proven on
 > `scopelybot` (86 tools → router + 8 spokes, live-validated). This is the single canonical
 > reference; it supersedes `hub-spoke-pattern-playbook.md` and absorbs the lessons from
@@ -17,7 +17,7 @@ status: reference
 
 ## 1. What it is
 
-One user-facing **coordinator** agent (bound to the channel) that owns *no domain tools* — it
+One user-facing **coordinator** agent (bound to the channel) that owns _no domain tools_ — it
 classifies each request into one domain and delegates to a single-domain **specialist spoke** via
 `sessions_spawn(runtime=subagent)`. Each spoke sees only its own small toolset; the coordinator
 composes/relays the reply.
@@ -42,19 +42,20 @@ Hub-and-spoke is **not free**: every delegated call costs a full subagent spawn 
 (latency + 2–3× model tokens), it needs a capable-enough coordinator model, and it adds deploy and
 session-management complexity. Apply it only when the payoff is real.
 
-**The trigger is confusable-tool density and *measured* misrouting — NOT raw tool count.**
-A model selects reliably among 40–50 *distinct, well-known* tools (`read`, `exec`, `gh_create_issue`,
-`zoom_send`, …). It fails among dozens of *near-synonym domain* tools in one menu (scopelybot's
+**The trigger is confusable-tool density and _measured_ misrouting — NOT raw tool count.**
+A model selects reliably among 40–50 _distinct, well-known_ tools (`read`, `exec`, `gh_create_issue`,
+`zoom_send`, …). It fails among dozens of _near-synonym domain_ tools in one menu (scopelybot's
 `list_users` vs `active_users` vs `list_invites`; CRUD across orgs/pricing/vendors/deploy). Count the
 **confusable domain surface**, not the menu size.
 
 Decision checklist for a candidate bot:
+
 1. **Measure first.** Use the test-capture harness (§8) to inject representative domain requests and
    inspect tool selection / routing. Only act on demonstrated misrouting.
 2. **Is the confusable domain surface large (≈30+ same-domain tools with overlapping names)?** If no,
    prefer cheaper fixes: sharpen tool descriptions, consolidate thin CRUD wrappers, or split the
-   *menu* with a shared tool bundle (§10) — not a full coordinator/spoke split.
-3. **Is the bot unscoped (no `tools.allow`)?** Then its real problem is *missing scoping*, not
+   _menu_ with a shared tool bundle (§10) — not a full coordinator/spoke split.
+3. **Is the bot unscoped (no `tools.allow`)?** Then its real problem is _missing scoping_, not
    confusability — give it an allowlist first (an unscoped agent sees every non-optional plugin tool
    across all bots; see §3). That alone may resolve it.
 4. **Is the per-call spawn cost acceptable?** Hub-and-spoke doubles model turns per request. Fine for
@@ -90,7 +91,7 @@ registerXxxTools(optionalApi, logger); // ...register all the bot's tools throug
 ```
 
 > **Verify after wiring:** the tool-policy log line `tool policy removed N tool(s) via
-> agents.<id>.tools.allow: …` shows the allowlist filtering. Model self-reports about "which tools do
+agents.<id>.tools.allow: …` shows the allowlist filtering. Model self-reports about "which tools do
 > you have" are unreliable — trust the gateway log / the harness trace, not the agent.
 
 ---
@@ -99,6 +100,7 @@ registerXxxTools(optionalApi, logger); // ...register all the bot's tools throug
 
 For a Zoom bot these already exist (landed during the scopelybot build) and a new hub-and-spoke bot
 inherits them for free:
+
 1. **Subagent spawn unblock** — `sessions_spawn` ignores acp-only `streamTo` for `runtime=subagent`.
 2. **Inbound threading** — `channels.zoom.threading.inheritParent: true` routes threaded replies to
    the channel-bound agent with parent context.
@@ -113,42 +115,70 @@ feishu ship one; others may need it).
 ## 5. Per-bot implementation recipe
 
 ### 5a. Define the spokes (one unbound agent per domain)
+
 Each spoke is an entry in `agents.list[]` in `~/.openclaw/openclaw.json`
 (`.data/openclaw/openclaw.json` in the dev container):
 
 ```jsonc
 {
   "id": "scopely-users",
-  "model": { "primary": "openrouter/openai/gpt-5.4-mini",
-             "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"] },
-  "tools": { "allow": [            // EXCLUSIVE allowlist = exactly this domain's tools
-    "scopely_list_users", "scopely_get_user", "scopely_reset_user_password",
-    "scopely_set_user_active", "scopely_update_user", "scopely_create_invite",
-    "scopely_list_invites", "scopely_list_access_requests",
-    "scopely_approve_access_request", "scopely_reject_access_request"
-  ] }
+  "model": {
+    "primary": "openrouter/openai/gpt-5.4-mini",
+    "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"],
+  },
+  "tools": {
+    "allow": [
+      // EXCLUSIVE allowlist = exactly this domain's tools
+      "scopely_list_users",
+      "scopely_get_user",
+      "scopely_reset_user_password",
+      "scopely_set_user_active",
+      "scopely_update_user",
+      "scopely_create_invite",
+      "scopely_list_invites",
+      "scopely_list_access_requests",
+      "scopely_approve_access_request",
+      "scopely_reject_access_request",
+    ],
+  },
 }
 ```
+
 Each spoke gets a `workspace-<spoke>/IDENTITY.md` worker prompt (template in §11). Same model as the
 coordinator is fine. Spokes are **unbound** (no `bindings` entry) — only the coordinator is bound.
 
 ### 5b. Make the coordinator router-only
-Shrink the coordinator's `tools.allow` to *just* routing + at most 1–2 trivial liveness reads, and
+
+Shrink the coordinator's `tools.allow` to _just_ routing + at most 1–2 trivial liveness reads, and
 set `subagents.allowAgents` to the spoke ids:
 
 ```jsonc
 {
   "id": "scopelybot",
-  "model": { "primary": "openrouter/openai/gpt-5.4-mini",
-             "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"] },
-  "tools": { "allow": ["sessions_spawn", "subagents",
-                       "scopely_health_check", "scopely_auth_status"] },
-  "subagents": { "allowAgents": ["scopely-observe","scopely-admin","scopely-users","scopely-orgs",
-                                 "scopely-pricing","scopely-vendors","scopely-deploy","scopely-github"] }
+  "model": {
+    "primary": "openrouter/openai/gpt-5.4-mini",
+    "fallbacks": ["openrouter/anthropic/claude-haiku-4.5"],
+  },
+  "tools": {
+    "allow": ["sessions_spawn", "subagents", "scopely_health_check", "scopely_auth_status"],
+  },
+  "subagents": {
+    "allowAgents": [
+      "scopely-observe",
+      "scopely-admin",
+      "scopely-users",
+      "scopely-orgs",
+      "scopely-pricing",
+      "scopely-vendors",
+      "scopely-deploy",
+      "scopely-github",
+    ],
+  },
 }
 ```
 
 > ### THE critical lesson (cost 4 failed live tests on scopelybot)
+>
 > The coordinator must have **NO general tools** — no `read`, `memory_search`, `memory_get`,
 > `web_*`, `exec`. If it can read anything, a weak model uses that to answer domain questions from
 > its own memory/history instead of delegating, and tends to ask permission instead of acting.
@@ -156,14 +186,17 @@ set `subagents.allowAgents` to the spoke ids:
 > remove the tools.**
 
 ### 5c. Enable the bot in discovery
+
 An extension only loads if its id is in `plugins.entries` in `openclaw.json` — having the dir +
 manifest + `OPENCLAW_BUNDLED_PLUGINS_DIR` is **not** enough, and discovery skips unlisted plugins
-*silently* (no log, no error):
+_silently_ (no log, no error):
+
 ```jsonc
 "plugins": { "entries": { "<bot>": { "enabled": true }, /* … */ } }
 ```
 
 ### 5d. Bind the coordinator to the channel
+
 ```jsonc
 "bindings": [ { "agentId": "<bot>",
   "match": { "channel": "zoom", "peer": { "kind": "channel", "id": "<channelJid>" } } } ]
@@ -178,14 +211,14 @@ tools by **action-class** (list / summary / CRUD / telemetry) instead of by the 
 coordinator routes on**. Get this right:
 
 - **Routing axis == partitioning axis.** A request classified to a domain noun ("users", "pricing")
-  must land on a spoke holding the *full* surface to answer it — reads **and** writes **and** the
+  must land on a spoke holding the _full_ surface to answer it — reads **and** writes **and** the
   lookups those depend on. The coordinator must never need to know which sibling holds a dependency.
 - **Each spoke owns its full CRUD.** Don't split "read pricing" and "edit pricing" across spokes.
 - **No cross-domain dependency reaches.** If a write needs an id from a lookup, that lookup lives in
-  the *same* spoke (scopelybot bug: scoping cards needed `list_project_types`, which lived in a
+  the _same_ spoke (scopelybot bug: scoping cards needed `list_project_types`, which lived in a
   different spoke → the deploy spoke brute-forced ids 0–10 and gave up).
 - **Cross-cutting reads** (telemetry, dashboards, audit) get a dedicated `observe`/`admin` spoke —
-  but keep their charter crisp, or you reintroduce routing ambiguity ("active users" → users *or*
+  but keep their charter crisp, or you reintroduce routing ambiguity ("active users" → users _or_
   observe?).
 - **Keep each spoke ≲ 30 tools.** Merge thin wrappers / sharpen descriptions first if a single domain
   is still too big.
@@ -211,7 +244,7 @@ codes; observed live). The proven pattern (scopelybot `gated.ts` + `index.ts`):
 2. **Execution in `before_dispatch`, not an observe hook.** A `before_dispatch` hook matches
    `^CONFIRM\s+\d{4}` and runs the staged action, returning `{handled: true, text: <result>}`.
    `handled:true` **suppresses the coordinator** (so the CONFIRM can't re-stage) and the result is
-   delivered threaded by core. (`message_received` is fire-and-forget and runs *before*
+   delivered threaded by core. (`message_received` is fire-and-forget and runs _before_
    `before_dispatch` — do **not** execute there, or it consumes the pending first.)
 3. **Persona guard (defense-in-depth).** Coordinator `IDENTITY.md`: "never emit/relay/invent a
    `CONFIRM <code>`; on `awaiting_confirmation` reply `NO_REPLY`; if a message is `CONFIRM <code>`,
@@ -239,12 +272,13 @@ recording the routing/tool trace. To onboard a new bot:
    `docker exec openclaw sh -lc 'cd /app && node extensions/test-capture/harness/cases.mjs'`
 
 Assertions the harness makes possible (all payload/trace-level, no screenshots):
+
 - **Routing discrimination** — request X spawned spoke Y (`sessions_spawn` `params.agentId`).
 - **Router-only coordinator** — coordinator's tool calls ⊆ `{sessions_spawn, subagents, liveness}`.
 - **Per-spoke tool use / no cross-spoke reach** — spoke Y answered with only its own tools.
-- **Confirm-gate fidelity** — confirm prompt posted *with* a code; coordinator reply code-free;
+- **Confirm-gate fidelity** — confirm prompt posted _with_ a code; coordinator reply code-free;
   in-thread; wrong code = no-op (fail-closed).
-- **Safety guard** — a *read* request triggered *no* write/staging tool (catches the contamination
+- **Safety guard** — a _read_ request triggered _no_ write/staging tool (catches the contamination
   class directly).
 
 Validation gates to run in order: spawn round-trip → routing discrimination → in-thread delivery →
@@ -255,9 +289,9 @@ confirm-gate. The harness covers all four.
 ## 9. Deploy model + gotchas
 
 - **Extensions are jiti-live** from the `./extensions` bind-mount: edit `extensions/<bot>/**`, then
-  restart the container. **Core `src/**` changes need a `docker build`** (the container runs baked
-  `dist/`). A full `pnpm build` can OOM the box — avoid unless necessary.
-- **NEVER `rm -rf /tmp/jiti/*`** — it forces a cold re-transpile of *every* extension on the next
+  restart the container. **Core `src/**`changes need a`docker build`** (the container runs baked
+`dist/`). A full `pnpm build` can OOM the box — avoid unless necessary.
+- **NEVER `rm -rf /tmp/jiti/*`** — it forces a cold re-transpile of _every_ extension on the next
   message (~70s + a memory spike to critical). jiti re-transpiles only changed files by mtime; just
   restart. (Wiping the whole cache caused a self-inflicted "bot hung" stall.)
 - **First message after a restart is slow** (~70s cold load of all extensions); subsequent messages
@@ -275,17 +309,17 @@ Support bots heavily duplicate shared capabilities — `gh-tools.ts` is copy-pas
 extensions (already drifting: 401 vs 223 lines), `comfort.ts` ×6, `zoom-dm.ts` ×5, `correlation` ×4,
 `devtools` ×3. Two different reuse units solve two different problems — don't conflate them:
 
-| | **Shared bundle** (shared *code*) | **Shared spoke** (shared *agent*) |
-|---|---|---|
-| What | one `registerGithubTools(api,{prefix})` imported by all bots | a `github` agent the coordinator spawns |
-| Per-call cost | zero (in-process, direct) | a full spawn round-trip (latency + tokens) |
-| Reduces coordinator menu | no | yes |
-| Best for | **frequent, distinct** shared tools (GH, devtools) | **infrequent, large/confusable** shared clusters |
+|                          | **Shared bundle** (shared _code_)                            | **Shared spoke** (shared _agent_)                |
+| ------------------------ | ------------------------------------------------------------ | ------------------------------------------------ |
+| What                     | one `registerGithubTools(api,{prefix})` imported by all bots | a `github` agent the coordinator spawns          |
+| Per-call cost            | zero (in-process, direct)                                    | a full spawn round-trip (latency + tokens)       |
+| Reduces coordinator menu | no                                                           | yes                                              |
+| Best for                 | **frequent, distinct** shared tools (GH, devtools)           | **infrequent, large/confusable** shared clusters |
 
 - Fix duplication with a **shared bundle** (prefix-parameterized so `bh_gh_*` / `gh_*` /
-  `scopely_gh_*` still work). This is the plug-and-play win at the *code* layer; no spawn cost.
-- Promote a shared capability to a **shared spoke** only when a bot is *both* demonstrably overloaded
-  *and* uses that capability infrequently enough to absorb the spawn. The bundle is the prerequisite
+  `scopely_gh_*` still work). This is the plug-and-play win at the _code_ layer; no spawn cost.
+- Promote a shared capability to a **shared spoke** only when a bot is _both_ demonstrably overloaded
+  _and_ uses that capability infrequently enough to absorb the spawn. The bundle is the prerequisite
   either way (a shared spoke also needs one implementation).
 - Deciding factor per capability: **frequency × confusability.** Frequent+distinct → bundle.
   Infrequent+large/confusable → spoke.
@@ -295,18 +329,22 @@ extensions (already drifting: 401 vs 223 lines), `comfort.ts` ×6, `zoom-dm.ts` 
 ## 11. Templates
 
 ### Coordinator `IDENTITY.md` (router)
+
 ```markdown
 # IDENTITY.md — <Bot> Coordinator
+
 - Role: router for <product> administration in this channel. You are a ROUTER, not a doer.
 - You own NO domain tools (only liveness checks). For every real request, classify into ONE
   domain and delegate to that domain's spoke.
 
 ## Never answer from memory — always route, never ask
+
 History/notes/memory may be stale. Never answer a domain question from recall/`read`/`memory_*`/
 assumption. For ANY domain question, immediately spawn the relevant spoke and relay its fresh result.
 Do not ask permission ("would you like me to…"); just spawn and answer.
 
 ## How to delegate
+
 1. Pick the single best spoke from the routing table.
 2. sessions_spawn(runtime="subagent", agentId="<spoke>", task="<full restatement incl. every
    id/name/value the spoke needs — it cannot see the channel or history>").
@@ -315,11 +353,13 @@ Do not ask permission ("would you like me to…"); just spawn and answer.
 5. On the result turn, relay the spoke's fresh result clearly.
 
 ## Routing table
-| Spoke | Use when the request is about… |
-|---|---|
-| <spoke-a> | … |
+
+| Spoke     | Use when the request is about… |
+| --------- | ------------------------------ |
+| <spoke-a> | …                              |
 
 ## Confirm-gate (writes)
+
 Writes are confirm-gated; the code is handled entirely by the system. A staging spoke returns
 `awaiting_confirmation` and NO code (the system posts the `CONFIRM <code>` prompt directly). On that
 turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a message is just
@@ -327,8 +367,10 @@ turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a me
 ```
 
 ### Spoke `IDENTITY.md` (worker)
+
 ```markdown
 # IDENTITY.md — <Bot> <Domain> Specialist
+
 - You run only your domain's tools and return the result to your coordinator.
 - You NEVER address the channel directly; the coordinator owns all user-facing replies.
 - Writes are confirm-gated: stage via the write tool (which posts the CONFIRM prompt) and return its
@@ -339,6 +381,7 @@ turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a me
 ---
 
 ## 12. Quick-start checklist
+
 1. **Measure** the candidate bot with the harness; confirm real confusable-domain misrouting (§2).
 2. Make the bot's tools `optional: true` (§3).
 3. Partition tools into domain spokes by the **routing noun**, full CRUD per spoke (§6).
@@ -354,6 +397,7 @@ turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a me
 ---
 
 ## 13. Failure modes we actually hit (and the fix)
+
 - **Coordinator answers from memory instead of routing** → it still had general tools. Remove them (§5b).
 - **Weak coordinator fabricates/relays confirm codes** → deterministic confirm delivery; code never
   through the LLM (§7).
@@ -363,7 +407,7 @@ turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a me
   destructive tools out.
 - **Bot "hung" / no model request after tool-policy** → bloated coordinator session (context-build
   stalls). Reset the session: `docker exec openclaw node dist/entry.js agent --session-key
-  '<key>' --message '/reset'` (CLI times out on teardown but the reset completes server-side).
+'<key>' --message '/reset'` (CLI times out on teardown but the reset completes server-side).
 - **Extension silently not loaded** → missing from `plugins.entries` (§5c).
 - **Self-inflicted ~70s stall + memory spike** → someone wiped `/tmp/jiti/*`. Don't (§9).
 - **Spoke can't answer an in-domain question** → a needed lookup/read tool lives in another spoke;
@@ -372,6 +416,7 @@ turn reply `NO_REPLY`. Never write/invent/relay a `CONFIRM <code>` line. If a me
 ---
 
 ## 14. References
+
 - As-built record: `scopelybot-hub-spoke-recommendation.md`
 - Confirm-gate detail: `scopelybot-confirm-gate-fidelity.md`
 - Partitioning problem: `scopelybot-spoke-partitioning-problem.md`

--- a/docs/reference/scopelybot-confirm-gate-fidelity.md
+++ b/docs/reference/scopelybot-confirm-gate-fidelity.md
@@ -48,28 +48,31 @@ REAL stagings (spoke putPending)     RELAYED to channel (coordinator reply)
 ```
 
 ### D1 — Coordinator fabricates confirm codes (highest severity)
+
 At 19:04:00 the coordinator relayed `CONFIRM 7951`, a code that was **never staged** (the real
 code `5799` did not exist until 19:04:02). `gpt-5.4-mini` invented a plausible 4-digit code, in
-direct violation of its own persona (`IDENTITY.md`: *"Relay the CONFIRM code exactly,
-character-for-character… never invent a code"*). It also **re-relayed a stale code** (`9042` at
+direct violation of its own persona (`IDENTITY.md`: _"Relay the CONFIRM code exactly,
+character-for-character… never invent a code"_). It also **re-relayed a stale code** (`9042` at
 18:39 with no staging behind it).
 
 - **Why it matters:** the user cannot tell the real code from the invented one. A fabricated code
-  *fails closed* (it matches no pending action, so nothing executes) — so this is not a
+  _fails closed_ (it matches no pending action, so nothing executes) — so this is not a
   security hole — but it is a **trust and usability hole**: it directly caused the operator to type
   wrong codes (`1001`, `9042`-expired) and conclude the gate was broken.
 - **Root cause:** the exact code passes **through the LLM** on its way to the channel. Any model —
   especially a small one — can mangle, re-emit, or invent it.
 
 ### D2 — Duplicate confirm prompt
+
 The same real code is relayed twice for one staging (`9042` at 18:29:48 & :52; `5799`-class double
 relays observed). This is the coordinator double-delivering a reply — the same intermittent
 double-reply pattern that the `NO_REPLY`-on-spawn persona rule reduced for normal answers but does
 not fully eliminate under `gpt-5.4-mini`.
 
 ### D3 — `CONFIRM` message re-triggers the coordinator → spurious re-stage
+
 The `message_received` confirm hook is **observe-only**: it executes the confirm but does **not**
-suppress the message from reaching the coordinator. So `CONFIRM <code>` is *also* dispatched to the
+suppress the message from reaching the coordinator. So `CONFIRM <code>` is _also_ dispatched to the
 coordinator, which sometimes interprets it as a new request and **re-stages**:
 
 ```
@@ -84,6 +87,7 @@ coordinator, which sometimes interprets it as a new request and **re-stages**:
   it depends on whether the mini model decides to act on the `CONFIRM` text.
 
 ### D4 — Confirm result delivered out-of-thread
+
 The confirm execution result (and the `No pending action…` errors) are sent via `sendScopelyText`
 (`src/comfort.ts:84`), which POSTs to the channel JID with **no `reply_to`** — unlike
 `sendComfortMessage`, which supports threading. So results land at **channel root**, detached from
@@ -123,8 +127,8 @@ observe hook with a non-threaded sender.
   suppresses the coordinator (fixes D3); `text` is delivered via the core's threaded
   `sendFinalPayload` (fixes D4). Remove `tryExecuteConfirm` from `message_received` to avoid
   double-consuming the single-use code.
-- **Defense-in-depth:** persona line — *"never emit a `CONFIRM <code>` line yourself; if a message
-  is `CONFIRM <code>`, reply `NO_REPLY`."* Covers any path the deterministic delivery misses.
+- **Defense-in-depth:** persona line — _"never emit a `CONFIRM <code>` line yourself; if a message
+  is `CONFIRM <code>`, reply `NO_REPLY`."_ Covers any path the deterministic delivery misses.
 
 ## Open questions / to verify before building
 

--- a/docs/reference/scopelybot-hub-spoke-recommendation.md
+++ b/docs/reference/scopelybot-hub-spoke-recommendation.md
@@ -209,7 +209,7 @@ and silently undoes all scoping work for threaded conversations. Note the audit 
 
 ## Appendix — As-deployed configuration snapshot (2026-06-08)
 
-> **Why this is here.** The hub-and-spoke *wiring* (agent definitions, allowlists, router/worker
+> **Why this is here.** The hub-and-spoke _wiring_ (agent definitions, allowlists, router/worker
 > personas, plugin enablement) lives in **gitignored runtime state** — `~/.openclaw/openclaw.json`
 > (`agents.list[]`, `plugins.entries`, `bindings`) and `~/.openclaw/workspace-*/IDENTITY.md` — so it
 > is **not otherwise reviewable from this branch**. This appendix snapshots the live config verbatim
@@ -245,16 +245,20 @@ scopely-deploy   (14) create/update/delete {deployment_type, deployment_type_tem
 scopely-github   (6)  gh_add_comment, gh_close_issue, gh_create_issue, gh_get_issue,
                       gh_list_issues, gh_search_issues
 ```
+
 (All tool names carry the `scopely_` prefix. Spokes are **unbound**; only the coordinator is bound.)
 
 ### Plugin enablement + binding
+
 ```
 plugins.entries.scopelybot = { "enabled": true, "config": { "scopelyRepos": ["cloudwarriors-ai/scopely"] } }
 binding: scopelybot <- zoom channel 575b23671d6b4b7f8c22b1924b6177fa@conference.xmpp.zoom.us
 ```
 
 ### Coordinator persona (`workspace-scopelybot/IDENTITY.md`) — router prompt
+
 Key clauses (full text in runtime state):
+
 - "You are a **router**, not a doer ... only liveness checks (`scopely_health_check`,
   `scopely_auth_status`). Classify into **one** domain and delegate to that domain's spoke."
 - "**NEVER answer domain questions from memory** ... immediately spawn the relevant spoke and relay
@@ -267,6 +271,7 @@ Key clauses (full text in runtime state):
   `CONFIRM <code>` line yourself."
 
 ### Spoke persona (`workspace-scopely-users/IDENTITY.md`) — worker prompt (representative)
+
 - "You are a **worker subagent** ... do exactly that task using only your tools, then return the
   result. You do **not** talk to the channel."
 - "If you lack an id/value ... look it up with your read tools first; ... rather than guessing."

--- a/docs/reference/scopelybot-spoke-partitioning-problem.md
+++ b/docs/reference/scopelybot-spoke-partitioning-problem.md
@@ -33,7 +33,7 @@ scopely-github    GitHub issues        (6)
 
 **Tools were grouped by action-class (listing, summaries, CRUD, telemetry) instead of by the
 domain noun the coordinator actually routes on.** The coordinator routes on the noun in the request
-("users", "vendors", "scoping cards"). When a *read* or *dependency-resolution* tool for that noun
+("users", "vendors", "scoping cards"). When a _read_ or _dependency-resolution_ tool for that noun
 lives in a different spoke, the spoke that receives the question cannot answer it.
 
 This is not a one-off; it is a **structural mismatch** between the routing axis (domain noun) and
@@ -58,11 +58,12 @@ that are each individually "just add a tool" but collectively signal the split i
 3. **Cross-cutting overlap (open).** `scopely-admin` ("summaries") and `scopely-observe`
    ("telemetry") cut **across every domain**: `scopely_session_pricing` and `scopely_vendor_config`
    live in `admin`; `scopely_active_users`/`scopely_user_activity` live in `observe`. So
-   "vendor config" could plausibly route to `vendors` *or* `admin`; "active users" to `users` *or*
+   "vendor config" could plausibly route to `vendors` _or_ `admin`; "active users" to `users` _or_
    `observe`. This is **routing ambiguity by construction** — the coordinator has to guess which
    spoke owns a tool, and a weak model guesses wrong.
 
 ### Symptoms this produces
+
 - Spokes that **cannot answer in-domain questions** because a needed read/lookup tool is elsewhere.
 - Spokes **brute-forcing or approximating** (guessing ids, deriving counts from proxy data) instead
   of calling the right tool — which then looks like a model failure but is a missing-tool failure.
@@ -94,7 +95,7 @@ has." Nothing prevents the table and the allowlists from disagreeing.
 
 ## What a good split must achieve (success criteria, not a design)
 
-Any future rework should be judged against these — the *how* is out of scope for this doc:
+Any future rework should be judged against these — the _how_ is out of scope for this doc:
 
 1. **Routing axis == partitioning axis.** A request classified to a domain noun must land on a
    spoke that holds the full surface needed to answer it (read + write + the lookups those depend


### PR DESCRIPTION
## Summary

Production deploy profile — the "flip a switch" staging model. Dev and prod run the **same SHA**; only `.env`, the compose profile, and the box `openclaw.json` differ.

- **docker-compose.prod.yml** — dev-profile mirror minus dev-only surface: **no published host ports** (Traefik routes over the `proxy` network; dev publishes 18789/4000 which on a public Linode would expose the gateway directly), no `claude-mem-chroma` service, no `OPENCLAW_TEST_CAPTURE`/ngrok/2FA env, no `./src`/test mounts, no baked-in channel JIDs or box IPs. Public domain via `OPENCLAW_PUBLIC_DOMAIN`.
- **.env.prod-template** — the complete required-vars contract; every var documents its fail-closed behavior when unset (webhook secret → all Zoom traffic 401'd; `*_ZOOM_CHANNEL` → that bot's write staging disabled; gateway/devtools/ES tokens → feature errors loudly).
- **deploy/prod-plugin-policy.mjs** — idempotent, backup-first merge of the prod deny list (`claude-mem`, `slm-pipeline`, `slm-supervisor`, `2fa-github`, `test-capture`) into `plugins.deny`. Exclusion is **loader-level**, core-supported: `resolveEffectivePluginIds` drops denied ids (`src/plugins/effective-plugin-ids.ts:115`), `enable.ts:25` refuses re-enable. Harness double-covered: prod compose never sets `OPENCLAW_TEST_CAPTURE`.
- **deploy/PROD.md** — ordered bring-up (env → build → policy + `fix-allow.mjs` allowlist pairing → up → Zoom URL validation), smoke checklist, routine deploy/rollback.

## Verification

- `docker compose -f docker-compose.prod.yml config --no-interpolate -q` → valid.
- `node --check deploy/prod-plugin-policy.mjs` → parses.
- Deny mechanism verified against core source (not assumed): `effective-plugin-ids.ts` deny pruning + `enable.ts` denylist block + `installed-plugin-index-policy.ts` hashing deny into activation state.
- Config/docs-only change: no runtime code touched; extension tests unaffected (269/269 green on the development base).
