### PR TITLE
fix(confirm-gate): fail closed on unset/empty channel env across all five spoke bots

### DIFF
--- a/.env.prod-template
+++ b/.env.prod-template
@@ -37,9 +37,9 @@ ZOOM_REPORT_USER=
 
 # --- Confirm-gate channel bindings (PROD Zoom channel JIDs) ---
 # Each bot posts its CONFIRM <code> prompt to its channel; only a reply FROM
-# that channel can fire a staged write. Unset = that bot's write staging is
-# disabled (fail-closed, safe but inert). The in-code fallback constants are
-# DEV channels — prod MUST set these.
+# that channel can fire a staged write. Unset or empty = that bot's write
+# staging is disabled (fail-closed, safe but inert). There are NO in-code
+# channel fallbacks — every deployment must set all six.
 SCOPELYBOT_ZOOM_CHANNEL=
 BIGHEADBOT_ZOOM_CHANNEL=
 PULSEBOT_ZOOM_CHANNEL=

--- a/deploy/PROD.md
+++ b/deploy/PROD.md
@@ -29,9 +29,9 @@ the prod compose; dev's `claude-mem-chroma` service is also absent).
    There are no fallbacks: missing secrets fail closed — the gateway boots, but
    that feature errors or stays disabled. Pay attention to:
    - `ZOOM_WEBHOOK_SECRET_TOKEN` — unset means **all** Zoom webhooks are 401'd.
-   - the six `*_ZOOM_CHANNEL` JIDs — must be **prod** channels (the in-code
-     fallback constants are dev channels); unset disables that bot's write
-     staging (fail-closed).
+   - the six `*_ZOOM_CHANNEL` JIDs — must be **prod** channels; unset or empty
+     disables that bot's write staging (fail-closed). There are no in-code
+     channel fallbacks.
    - `OPENCLAW_PUBLIC_DOMAIN` — the Zoom marketplace app's event subscription
      URL must be `https://$OPENCLAW_PUBLIC_DOMAIN/zoom/webhook`.
 2. **Build.** `docker compose -f docker-compose.prod.yml build`

--- a/extensions/bigheadbot/src/bh-tools.test.ts
+++ b/extensions/bigheadbot/src/bh-tools.test.ts
@@ -146,18 +146,23 @@ describe("bigheadbot confirm-gated writes", () => {
     );
   });
 
-  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+  it("unset or compose-injected empty channel env fails closed (no inline prompt, nothing staged)", async () => {
+    const stageWithBrokenEnv = async () => {
+      const tools = buildTools();
+      return parse(await tools.bh_create_ticket.execute("t", { title: "Boom", projectId: "p1" }));
+    };
+    // Compose passes `BIGHEADBOT_ZOOM_CHANNEL=${BIGHEADBOT_ZOOM_CHANNEL}`: an unset host
+    // var arrives as "" in the container. Both "" and unset must refuse to stage.
+    process.env.BIGHEADBOT_ZOOM_CHANNEL = "";
+    const emptyStaged = await stageWithBrokenEnv();
     delete process.env.BIGHEADBOT_ZOOM_CHANNEL;
-    const tools = buildTools();
-    const staged = parse(
-      await tools.bh_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
-    );
-    // The production-safety fix: env unset must NOT degrade to the inline prompt.
-    expect(staged.awaiting_confirmation).toBe(true);
-    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(sendBigheadTextMock).toHaveBeenCalledTimes(1);
-    expect(sendBigheadTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
-    expect(sendBigheadTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    const unsetStaged = await stageWithBrokenEnv();
+    for (const staged of [emptyStaged, unsetStaged]) {
+      expect(staged.ok).toBe(false);
+      expect(String(staged.error)).toContain("BIGHEADBOT_ZOOM_CHANNEL");
+      expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(sendBigheadTextMock).not.toHaveBeenCalled();
   });
 
   it("a wrong/expired code executes nothing (fail-closed)", async () => {

--- a/extensions/bigheadbot/src/gated.ts
+++ b/extensions/bigheadbot/src/gated.ts
@@ -11,7 +11,7 @@
 // docs/reference/hub-and-spoke-implementation-guide.md §7).
 
 import { jsonResult } from "./bh-api.js";
-import { BIGHEADBOT_CHANNEL, getChannelThreadAnchor, sendBigheadText } from "./comfort.js";
+import { getChannelThreadAnchor, sendBigheadText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 
 type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
@@ -27,9 +27,22 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
   // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly. Fall back to the bot's known
-  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
-  const channel = process.env.BIGHEADBOT_ZOOM_CHANNEL ?? BIGHEADBOT_CHANNEL;
+  // — and test stubbing — both resolve correctly. `?? ""` + the falsy check below
+  // also catch the compose-injected empty string (`VAR=${VAR}` with VAR unset).
+  const channel = process.env.BIGHEADBOT_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // on scopelybot) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "BIGHEADBOT_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -38,19 +51,14 @@ export async function stageWrite(summary: string, run: () => RunResult) {
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendBigheadText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendBigheadText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }
 
 // Build a request body from only the fields the caller actually supplied, so we

--- a/extensions/cloudflow-support/src/cf-ops-tools.test.ts
+++ b/extensions/cloudflow-support/src/cf-ops-tools.test.ts
@@ -122,16 +122,25 @@ describe("cloudflow cf_execute_op is confirm-gated", () => {
     expect(reply).toMatch(/✅ Done/);
   });
 
-  it("without the env override, still delivers to the channel constant", async () => {
+  it("unset or compose-injected empty channel env fails closed (no inline prompt, nothing staged)", async () => {
+    const stageWithBrokenEnv = async () => {
+      const tools = buildTools();
+      return parse(
+        await tools.cf_execute_op.execute("t", { operationId: "resetTenant", payload: {} }),
+      );
+    };
+    // Compose passes `CF_ZOOM_CHANNEL=${CF_ZOOM_CHANNEL}`: an unset host
+    // var arrives as "" in the container. Both "" and unset must refuse to stage.
+    process.env.CF_ZOOM_CHANNEL = "";
+    const emptyStaged = await stageWithBrokenEnv();
     delete process.env.CF_ZOOM_CHANNEL;
-    const tools = buildTools();
-    const staged = parse(
-      await tools.cf_execute_op.execute("t", { operationId: "resetTenant", payload: {} }),
-    );
-    expect(staged.awaiting_confirmation).toBe(true);
-    expect(sendCfTextMock).toHaveBeenCalledTimes(1);
-    expect(sendCfTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
-    expect(sendCfTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    const unsetStaged = await stageWithBrokenEnv();
+    for (const staged of [emptyStaged, unsetStaged]) {
+      expect(staged.ok).toBe(false);
+      expect(String(staged.error)).toContain("CF_ZOOM_CHANNEL");
+      expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(sendCfTextMock).not.toHaveBeenCalled();
   });
 
   it("a wrong/expired code executes nothing (fail-closed)", async () => {

--- a/extensions/cloudflow-support/src/gated.ts
+++ b/extensions/cloudflow-support/src/gated.ts
@@ -10,7 +10,7 @@
 // Ported from the proven bigheadbot/scopelybot implementation (see
 // docs/reference/hub-and-spoke-implementation-guide.md §7).
 
-import { CF_CHANNEL, getChannelThreadAnchor, sendCfText } from "./comfort.js";
+import { getChannelThreadAnchor, sendCfText } from "./comfort.js";
 import { jsonResult } from "./helpers.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 
@@ -27,9 +27,22 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
   // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly. Fall back to the bot's known
-  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
-  const channel = process.env.CF_ZOOM_CHANNEL ?? CF_CHANNEL;
+  // — and test stubbing — both resolve correctly. `?? ""` + the falsy check below
+  // also catch the compose-injected empty string (`VAR=${VAR}` with VAR unset).
+  const channel = process.env.CF_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // on scopelybot) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "CF_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -38,17 +51,12 @@ export async function stageWrite(summary: string, run: () => RunResult) {
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendCfText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendCfText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.test.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.test.ts
@@ -144,4 +144,24 @@ describe("eoa-cli-tools confirm gate", () => {
     expect(reply).toMatch(/No pending action/i);
     expect(execFileSyncMock).not.toHaveBeenCalled();
   });
+
+  it("unset or compose-injected empty channel env fails closed (no inline prompt, nothing staged)", async () => {
+    const stageWithBrokenEnv = async () => {
+      const t = buildTools();
+      return parse(await t.eoa_run_execute.execute("x", { issueMirrorId: "mirror-uuid-1" }));
+    };
+    // Compose passes `EOA_ZOOM_CHANNEL=${EOA_ZOOM_CHANNEL}`: an unset host
+    // var arrives as "" in the container. Both "" and unset must refuse to stage.
+    process.env.EOA_ZOOM_CHANNEL = "";
+    const emptyStaged = await stageWithBrokenEnv();
+    delete process.env.EOA_ZOOM_CHANNEL;
+    const unsetStaged = await stageWithBrokenEnv();
+    for (const staged of [emptyStaged, unsetStaged]) {
+      expect(staged.ok).toBe(false);
+      expect(String(staged.error)).toContain("EOA_ZOOM_CHANNEL");
+      expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(sendEoaTextMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/external-org-autopilot/src/eoa-cli-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-cli-tools.ts
@@ -7,8 +7,10 @@ import { stageWrite } from "./gated.js";
 import { jsonResult, errorResult } from "./helpers.js";
 
 // Env-driven so the deploy host can relocate the checkout; the default matches
-// the current production container layout.
-const EOA_ROOT = () => process.env.EOA_ROOT ?? "/root/code/external-org-autopilot";
+// the current production container layout. `||` (not `??`): compose passes
+// `EOA_ROOT=${EOA_ROOT}`, so an unset host var arrives as "" and must still
+// fall through to the default.
+const EOA_ROOT = () => process.env.EOA_ROOT || "/root/code/external-org-autopilot";
 
 // Run the EOA CLI with an explicit argv (NO shell): `npx tsx src/cli.ts <args...>`.
 // Each arg is passed literally, so LLM-controlled paths/ids cannot be interpreted as

--- a/extensions/external-org-autopilot/src/eoa-state-tools.ts
+++ b/extensions/external-org-autopilot/src/eoa-state-tools.ts
@@ -9,9 +9,11 @@ import { jsonResult, errorResult } from "./helpers.js";
 
 // Env-driven so the deploy host can relocate the checkout/state; defaults match
 // the current production container layout (state lives inside the EOA checkout).
+// `||` (not `??`): compose passes `VAR=${VAR}`, so an unset host var arrives as
+// "" and must still fall through to the default.
 const STATE_DIR = () =>
-  process.env.EOA_STATE_DIR ??
-  path.join(process.env.EOA_ROOT ?? "/root/code/external-org-autopilot", ".autopilot-state");
+  process.env.EOA_STATE_DIR ||
+  path.join(process.env.EOA_ROOT || "/root/code/external-org-autopilot", ".autopilot-state");
 
 // GitHub Actions run IDs are numeric. Validate so the value is a sane argv element.
 function assertRunId(value: unknown): string {

--- a/extensions/external-org-autopilot/src/gated.ts
+++ b/extensions/external-org-autopilot/src/gated.ts
@@ -11,7 +11,7 @@
 // Ported from the proven scopelybot/bigheadbot implementation (see
 // docs/reference/hub-and-spoke-implementation-guide.md §7).
 
-import { EOA_CHANNEL, getChannelThreadAnchor, sendEoaText } from "./comfort.js";
+import { getChannelThreadAnchor, sendEoaText } from "./comfort.js";
 import { jsonResult } from "./helpers.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 
@@ -28,9 +28,22 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
   // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly. Fall back to the bot's known
-  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
-  const channel = process.env.EOA_ZOOM_CHANNEL ?? EOA_CHANNEL;
+  // — and test stubbing — both resolve correctly. `?? ""` + the falsy check below
+  // also catch the compose-injected empty string (`VAR=${VAR}` with VAR unset).
+  const channel = process.env.EOA_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // on scopelybot) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "EOA_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -39,17 +52,12 @@ export async function stageWrite(summary: string, run: () => RunResult) {
     `⚠️ Confirm: ${summary}.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendEoaText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendEoaText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }

--- a/extensions/pulsebot/src/gated.ts
+++ b/extensions/pulsebot/src/gated.ts
@@ -10,7 +10,7 @@
 // Ported from the proven bigheadbot/scopelybot implementation (see
 // docs/reference/hub-and-spoke-implementation-guide.md §7).
 
-import { PULSEBOT_CHANNEL, getChannelThreadAnchor, sendPulseText } from "./comfort.js";
+import { getChannelThreadAnchor, sendPulseText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./pp-api.js";
 
@@ -27,9 +27,22 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
   // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly. Fall back to the bot's known
-  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
-  const channel = process.env.PULSEBOT_ZOOM_CHANNEL ?? PULSEBOT_CHANNEL;
+  // — and test stubbing — both resolve correctly. `?? ""` + the falsy check below
+  // also catch the compose-injected empty string (`VAR=${VAR}` with VAR unset).
+  const channel = process.env.PULSEBOT_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // on scopelybot) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "PULSEBOT_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -38,19 +51,14 @@ export async function stageWrite(summary: string, run: () => RunResult) {
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendPulseText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendPulseText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }
 
 // Build a request body from only the fields the caller actually supplied, so we

--- a/extensions/pulsebot/src/pp-tools.test.ts
+++ b/extensions/pulsebot/src/pp-tools.test.ts
@@ -146,18 +146,23 @@ describe("pulsebot confirm-gated writes", () => {
     );
   });
 
-  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+  it("unset or compose-injected empty channel env fails closed (no inline prompt, nothing staged)", async () => {
+    const stageWithBrokenEnv = async () => {
+      const tools = buildTools();
+      return parse(await tools.pp_create_ticket.execute("t", { title: "Boom", projectId: "p1" }));
+    };
+    // Compose passes `PULSEBOT_ZOOM_CHANNEL=${PULSEBOT_ZOOM_CHANNEL}`: an unset host
+    // var arrives as "" in the container. Both "" and unset must refuse to stage.
+    process.env.PULSEBOT_ZOOM_CHANNEL = "";
+    const emptyStaged = await stageWithBrokenEnv();
     delete process.env.PULSEBOT_ZOOM_CHANNEL;
-    const tools = buildTools();
-    const staged = parse(
-      await tools.pp_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
-    );
-    // The production-safety fix: env unset must NOT degrade to the inline prompt.
-    expect(staged.awaiting_confirmation).toBe(true);
-    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(sendPulseTextMock).toHaveBeenCalledTimes(1);
-    expect(sendPulseTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
-    expect(sendPulseTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    const unsetStaged = await stageWithBrokenEnv();
+    for (const staged of [emptyStaged, unsetStaged]) {
+      expect(staged.ok).toBe(false);
+      expect(String(staged.error)).toContain("PULSEBOT_ZOOM_CHANNEL");
+      expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(sendPulseTextMock).not.toHaveBeenCalled();
   });
 
   it("a wrong/expired code executes nothing (fail-closed)", async () => {

--- a/extensions/zoomwarriorssupportbot/src/gated.ts
+++ b/extensions/zoomwarriorssupportbot/src/gated.ts
@@ -10,7 +10,7 @@
 // Ported from the proven bigheadbot/scopelybot implementation (see
 // docs/reference/hub-and-spoke-implementation-guide.md §7).
 
-import { ZWS_CHANNEL, getChannelThreadAnchor, sendZwsText } from "./comfort.js";
+import { getChannelThreadAnchor, sendZwsText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { jsonResult } from "./zws-api.js";
 
@@ -27,9 +27,22 @@ type RunResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 // posted and must stay silent.
 export async function stageWrite(summary: string, run: () => RunResult) {
   // Read the channel at call time (not module load) so env that loads after import
-  // — and test stubbing — both resolve correctly. Fall back to the bot's known
-  // channel constant so production NEVER drops to the inline (LLM-relayed) prompt.
-  const channel = process.env.ZWS_ZOOM_CHANNEL ?? ZWS_CHANNEL;
+  // — and test stubbing — both resolve correctly. `?? ""` + the falsy check below
+  // also catch the compose-injected empty string (`VAR=${VAR}` with VAR unset).
+  const channel = process.env.ZWS_ZOOM_CHANNEL ?? "";
+  if (!channel) {
+    // FAIL CLOSED. Without a channel the CONFIRM prompt would have to travel
+    // inline through the model — codes get fabricated/relayed (observed live
+    // on scopelybot) — and, since pending actions are channel-bound, an inline
+    // staging could never be confirmed anyway. Refuse to stage instead of
+    // silently degrading on a misconfigured deployment.
+    return jsonResult({
+      ok: false,
+      error:
+        "ZWS_ZOOM_CHANNEL is not configured — write staging is disabled (fail-closed). " +
+        "Set the env var to the bot's Zoom channel JID.",
+    });
+  }
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
@@ -38,19 +51,14 @@ export async function stageWrite(summary: string, run: () => RunResult) {
     `⚠️ Confirm: ${summary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
-  if (channel) {
-    await sendZwsText(channel, prompt, getChannelThreadAnchor(channel));
-    return jsonResult({
-      staged: true,
-      awaiting_confirmation: true,
-      message:
-        "Confirm prompt was posted to the channel for the user. " +
-        "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
-    });
-  }
-  // No channel configured (dev/test only): fall back to returning the prompt
-  // inline so the gate still works outside the live deployment.
-  return jsonResult({ staged: true, message: prompt });
+  await sendZwsText(channel, prompt, getChannelThreadAnchor(channel));
+  return jsonResult({
+    staged: true,
+    awaiting_confirmation: true,
+    message:
+      "Confirm prompt was posted to the channel for the user. " +
+      "Reply NO_REPLY — do not repeat, relay, or invent the confirmation code.",
+  });
 }
 
 // Build a request body from only the fields the caller actually supplied, so we

--- a/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
+++ b/extensions/zoomwarriorssupportbot/src/zws-tools.test.ts
@@ -146,18 +146,23 @@ describe("zws confirm-gated writes", () => {
     );
   });
 
-  it("without the env override, still delivers to the channel constant (never an inline LLM prompt)", async () => {
+  it("unset or compose-injected empty channel env fails closed (no inline prompt, nothing staged)", async () => {
+    const stageWithBrokenEnv = async () => {
+      const tools = buildTools();
+      return parse(await tools.zws_create_ticket.execute("t", { title: "Boom", projectId: "p1" }));
+    };
+    // Compose passes `ZWS_ZOOM_CHANNEL=${ZWS_ZOOM_CHANNEL}`: an unset host
+    // var arrives as "" in the container. Both "" and unset must refuse to stage.
+    process.env.ZWS_ZOOM_CHANNEL = "";
+    const emptyStaged = await stageWithBrokenEnv();
     delete process.env.ZWS_ZOOM_CHANNEL;
-    const tools = buildTools();
-    const staged = parse(
-      await tools.zws_create_ticket.execute("t", { title: "Boom", projectId: "p1" }),
-    );
-    // The production-safety fix: env unset must NOT degrade to the inline prompt.
-    expect(staged.awaiting_confirmation).toBe(true);
-    expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
-    expect(sendZwsTextMock).toHaveBeenCalledTimes(1);
-    expect(sendZwsTextMock.mock.calls[0][0]).toBe(FALLBACK_CHANNEL);
-    expect(sendZwsTextMock.mock.calls[0][1]).toMatch(/CONFIRM \d{4}/);
+    const unsetStaged = await stageWithBrokenEnv();
+    for (const staged of [emptyStaged, unsetStaged]) {
+      expect(staged.ok).toBe(false);
+      expect(String(staged.error)).toContain("ZWS_ZOOM_CHANNEL");
+      expect(JSON.stringify(staged)).not.toMatch(/CONFIRM \d{4}/);
+    }
+    expect(sendZwsTextMock).not.toHaveBeenCalled();
   });
 
   it("a wrong/expired code executes nothing (fail-closed)", async () => {


### PR DESCRIPTION
## Summary
- All six confirm-gated bots (scopelybot already had it; now bigheadbot, pulsebot, zws, cloudflow-support, external-org-autopilot) refuse to stage writes when their `*_ZOOM_CHANNEL` env is unset **or empty** — the scopelybot fail-closed shape.
- Why empty matters: compose passes `X_ZOOM_CHANNEL=${X_ZOOM_CHANNEL}`, so an unset host var arrives in the container as `""`. The old `?? DEV_CONSTANT` fallback does not fire on `""`, which dropped `stageWrite` into the inline branch where the CONFIRM code travels **through the LLM** — the exact leak the gates were built to prevent. A forgotten prod var would also have posted prod CONFIRM prompts to dev channels.
- Also fixes a latent ordering bug: `putPending` used to register a channel-bound pending action **before** the channel check, leaving an unconfirmable `""`-bound action behind.
- `EOA_ROOT`/`EOA_STATE_DIR`: `??` → `||` so the compose-injected empty string falls through to the default path.
- `.env.prod-template` + `deploy/PROD.md`: removed now-false 'in-code fallback constants' wording.

## Verification
- `node scripts/run-vitest.mjs` across all five extensions: **18 files, 101 tests, all pass** (includes new/updated unset+empty fail-closed tests per bot).
- `scripts/run-oxlint.mjs` (extensions tsconfig): no findings in changed files (remaining hits are the known pre-existing fleet baseline in untouched files).
- `oxfmt --check` on all 12 changed TS files: clean.