### PR TITLE
fix(deploy): compose v2.21 compat + PROD.md fix-allow note

### DIFF
--- a/deploy/PROD.md
+++ b/deploy/PROD.md
@@ -39,10 +39,13 @@ the prod compose; dev's `claude-mem-chroma` service is also absent).
    bindings). Then run BOTH config scripts (idempotent, backup-first):
    - `node deploy/prod-plugin-policy.mjs ./.data/openclaw/openclaw.json`
      (prod deny list)
-   - `node extensions/test-capture/harness/fix-allow.mjs` against the same file
-     (adds each bot's plugin id to its agent `tools.allow` — REQUIRED before
-     boot: bot tools are registered `optional:true` and an agent without its
-     plugin id in the allowlist loses its own tools).
+   - fix-allow (adds each bot's plugin id to its agent `tools.allow` — REQUIRED
+     before boot: bot tools are registered `optional:true` and an agent without
+     its plugin id in the allowlist loses its own tools). The script hardcodes
+     the in-container path, so either run it via
+     `docker exec openclaw node /app/extensions/test-capture/harness/fix-allow.mjs`
+     after first start, or skip it when provisioning by copying a dev
+     `openclaw.json` whose allowlists already carry the pairings.
 4. **Up.** `docker compose -f docker-compose.prod.yml up -d`
    No host ports are published — Traefik (on the external `proxy` network)
    terminates TLS and routes `/` → 18789 and `/zoom/` → 4000.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -104,7 +104,8 @@ services:
     - --allow-unconfigured
     mem_limit: 4g
     memswap_limit: 4g
-    cpus: '4.0'
+    # Unquoted float: docker compose v2.21 (prod box) rejects the string form.
+    cpus: 4.0
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## Summary
- `cpus: '4.0'` → `cpus: 4.0`: docker compose v2.21.0 (production box) fails `config` with *cpus expected type float32, got string*; newer compose coerces, old does not. Found during prod bring-up.
- PROD.md: fix-allow.mjs hardcodes the in-container config path — documented the `docker exec` invocation and the copy-a-paired-dev-config alternative.

## Verification
- `docker compose -f docker-compose.prod.yml config -q` on the production box (v2.21.0) with the real .env: valid after the fix (was failing before).
- Same file already applied as a working-tree hotfix on the prod box; this lands it canonically.