### PR TITLE
fix(deploy): Traefik service label for the main openclaw router

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -117,6 +117,9 @@ services:
     - traefik.http.routers.openclaw.rule=Host(`${OPENCLAW_PUBLIC_DOMAIN}`)
     - traefik.http.routers.openclaw.entrypoints=websecure
     - traefik.http.routers.openclaw.tls.certresolver=letsencrypt
+    # Required: with two services on one container, Traefik drops any router
+    # that does not name its service ("too many services") — observed live.
+    - traefik.http.routers.openclaw.service=openclaw
     - traefik.http.services.openclaw.loadbalancer.server.port=18789
     - traefik.http.routers.openclaw-zoom.rule=Host(`${OPENCLAW_PUBLIC_DOMAIN}`) &&
       PathPrefix(`/zoom/`)


### PR DESCRIPTION
## Summary
One label: `traefik.http.routers.openclaw.service=openclaw`. The prod container defines two Traefik services (openclaw, openclaw-zoom); Traefik refuses to infer a service for a router when more than one exists on the container (`Could not define the service name for the router: too many services`) and silently drops the router — observed live on the production box: only `openclaw-zoom@docker` registered, root domain 404'd.

## Verification
On the production box with this label applied as a hotfix: both `openclaw@docker` and `openclaw-zoom@docker` report status=enabled in the Traefik API, and an SNI-correct curl to the root domain returns 200 through Traefik → gateway :18789. (/zoom/ 502s by design until Zoom credentials exist — the monitor's startAccount never fires for an unconfigured account.)