### PR TITLE
chore(slm): pgvector memory cap (256m), slm-scoped

### DIFF
--- a/docker-compose.slm-local.yml
+++ b/docker-compose.slm-local.yml
@@ -1,5 +1,6 @@
 services:
   pgvector:
+    mem_limit: 256m
     image: pgvector/pgvector:pg16
     container_name: ${SLM_PG_CONTAINER_NAME:-moltbot-pgvector}
     environment:


### PR DESCRIPTION
## Summary
Second half of the dev-box working-tree canonicalization, split out of #53 because slm-gates requires slm-touching PRs to touch ONLY slm files (scope guard flagged docker-compose.dev.yml in the bundled version). Value copied verbatim from the noob-root box's live working tree, where pgvector has run under this cap.

## Verification
Compose-only; value matches the running box. slm-gates scope check should pass now that the PR is slm-file-only.