### PR TITLE
ci(fork): skip core matrix on infra-only PRs + disable permanently-red upstream-contract checks

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -19,6 +19,9 @@ permissions: {}
 
 jobs:
   auto-response:
+    # cw-fork (2026-06-10): upstream-maintainer automation; always fails on the
+    # fork (missing upstream context/secrets). Upstream-only.
+    if: github.repository == 'openclaw/openclaw'
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     paths-ignore:
       - "CHANGELOG.md"
+      # cw-fork (2026-06-10): deploy/infra-only PRs cannot affect the core test
+      # matrix — skip the whole workflow for them.
+      - "**/*.md"
+      - "docs/**"
+      - "deploy/**"
+      - "docker-compose*.yml"
+      - ".env-template"
+      - ".env.prod-template"
 
 permissions:
   contents: read
@@ -235,7 +243,8 @@ jobs:
           const checksFastCoreTasks = [];
           if (runNodeFull) {
             checksFastCoreTasks.push(
-              { check_name: "checks-fast-bundled-protocol", runtime: "node", task: "bundled-protocol" },
+              // cw-fork (2026-06-10): checks-fast-bundled-protocol dropped —
+              // permanently red against the upstream bundling contract on this fork.
               { check_name: "checks-fast-bun-launcher", runtime: "bun", task: "bun-launcher" },
             );
           } else {
@@ -262,8 +271,15 @@ jobs:
                 runner: shard.runner,
               }))
             : [];
-          const nodeTestNonDistShards = nodeTestShards.filter((shard) => !shard.requires_dist);
-          const nodeTestDistShards = nodeTestShards.filter((shard) => shard.requires_dist);
+          // cw-fork (2026-06-10): checks-node-core-fast carries the upstream
+          // Dockerfile contract tests; this fork's Dockerfile diverges deliberately
+          // (small-VM/ARM deploys), so the shard can never pass. Drop it.
+          const forkDisabledShards = new Set(["checks-node-core-fast"]);
+          const keptNodeTestShards = nodeTestShards.filter(
+            (shard) => !forkDisabledShards.has(shard.check_name),
+          );
+          const nodeTestNonDistShards = keptNodeTestShards.filter((shard) => !shard.requires_dist);
+          const nodeTestDistShards = keptNodeTestShards.filter((shard) => shard.requires_dist);
 
           const manifest = {
             docs_only: docsOnly,
@@ -273,11 +289,16 @@ jobs:
             run_android: runAndroid,
             run_skills_python: runSkillsPython,
             run_windows: runWindows,
-            run_build_artifacts: runNodeFull,
+            // cw-fork (2026-06-10): the flags forced false below gate jobs that are
+            // permanently red against upstream contracts this fork deliberately
+            // diverged from (build-artifacts/tsdown, channel+plugin contract shards,
+            // check-shard lint/type/dependency lanes, additional-boundary lanes).
+            // Re-enable selectively if the underlying debt is ever paid down.
+            run_build_artifacts: false,
             run_checks_fast_core: checksFastCoreTasks.length > 0,
-            run_checks_fast: runNodeFull,
+            run_checks_fast: false,
             checks_fast_core_matrix: createMatrix(checksFastCoreTasks),
-            run_plugin_contracts_shards: runPluginContractShards,
+            run_plugin_contracts_shards: false,
             plugin_contracts_matrix: createMatrix(
               runPluginContractShards ? createPluginContractTestShards() : [],
             ),
@@ -288,8 +309,8 @@ jobs:
             run_checks_node_core_nondist: nodeTestNonDistShards.length > 0,
             checks_node_core_nondist_matrix: createMatrix(nodeTestNonDistShards),
             run_checks_node_core_dist: nodeTestDistShards.length > 0,
-            run_check: runNodeFull,
-            run_check_additional: runNodeFull,
+            run_check: false, // cw-fork: see note above
+            run_check_additional: false, // cw-fork: see note above
             run_check_docs: docsChanged && eventName !== "push",
             run_control_ui_i18n: runControlUiI18n,
             run_skills_python_job: runSkillsPython,

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,6 +27,9 @@ permissions: {}
 
 jobs:
   label:
+    # cw-fork (2026-06-10): upstream-maintainer automation; always fails on the
+    # fork (missing upstream context/secrets). Upstream-only.
+    if: github.repository == 'openclaw/openclaw'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -15,6 +15,9 @@ permissions: {}
 
 jobs:
   real-behavior-proof:
+    # cw-fork (2026-06-10): contributor proof-block parser; this fork's PRs use
+    # the maintainer verification path instead. Upstream-only.
+    if: github.repository == 'openclaw/openclaw'
     name: Real behavior proof
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Approved by Chad: CI right-sizing options 1+2.
1. **Path filter**: `ci.yml` skips entirely for PRs touching only `**/*.md`, `docs/**`, `deploy/**`, `docker-compose*.yml`, `.env-template`, `.env.prod-template` — one-line infra changes stop paying the 134-check tax.
2. **Permanently-red checks disabled** (all 20 baseline names): manifest flags forced false (`run_build_artifacts`, `run_checks_fast`, `run_plugin_contracts_shards`, `run_check`, `run_check_additional`), preflight matrix drops `checks-fast-bundled-protocol` + `checks-node-core-fast` (upstream Dockerfile contract tests; fork Dockerfile diverges deliberately), and `auto-response`/`label`/`Real behavior proof` are repo-guarded to upstream. Each disable carries a dated `cw-fork` comment for future re-enable.

Green shards (e.g. `checks-fast-bun-launcher`, `checks-node-agentic-*`) keep running.

## Verification
- YAML parse OK on all 4 files; preflight heredoc extracted and `node --check` OK.
- This PR itself is the live test: expected result is the red set collapsing to ~0 failures with green lanes intact.