### PR TITLE
fix(slm): pgvector mem_limit host-overridable (unbreaks slm-gates)

### DIFF
--- a/docker-compose.slm-local.yml
+++ b/docker-compose.slm-local.yml
@@ -1,6 +1,9 @@
 services:
   pgvector:
-    mem_limit: 256m
+    # Host-tunable: noob-root sets SLM_PG_MEM_LIMIT=256m in .env (memory-pressured
+    # box). The 1g default keeps the slm-gates CI smoke green — a hard 256m cap
+    # crashed it (node abort, runs 2026-06-10).
+    mem_limit: ${SLM_PG_MEM_LIMIT:-1g}
     image: pgvector/pgvector:pg16
     container_name: ${SLM_PG_CONTAINER_NAME:-moltbot-pgvector}
     environment:

--- a/vitest.slm.config.ts
+++ b/vitest.slm.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 import baseConfig from "./vitest.config.ts";
 
-const baseTest = (
+const baseTestWithProjects = (
   baseConfig as {
     test?: {
       testTimeout?: number;
@@ -10,9 +10,14 @@ const baseTest = (
       maxWorkers?: number;
       setupFiles?: string[];
       exclude?: string[];
+      projects?: unknown[];
     };
   }
 ).test ?? { testTimeout: 120_000, hookTimeout: 120_000, pool: "forks", maxWorkers: 4 };
+// Drop the root `projects` matrix (test/vitest/vitest.config.ts) — inheriting it
+// makes vitest ignore `include` below and run the ENTIRE repo suite, which OOMs
+// the slm-gates runner heap. Same drop precedent: test/vitest/vitest.e2e.config.ts.
+const { projects: _projects, ...baseTest } = baseTestWithProjects;
 const isBunRuntime = typeof Bun !== "undefined";
 const include = [
   "extensions/slm-pipeline/**/*.test.ts",

--- a/vitest.slm.e2e.config.ts
+++ b/vitest.slm.e2e.config.ts
@@ -1,16 +1,22 @@
 import { defineConfig } from "vitest/config";
-import baseConfig from "./vitest.e2e.config.ts";
+// Root vitest.e2e.config.ts was deleted when upstream moved configs under
+// test/vitest/ (2ccb5cff22); import the moved file directly.
+import baseConfig from "./test/vitest/vitest.e2e.config.ts";
 
-const baseTest = (
-  baseConfig as {
-    test?: {
-      pool?: "forks" | "threads";
-      maxWorkers?: number;
-      setupFiles?: string[];
-      exclude?: string[];
-    };
-  }
-).test ?? {};
+const baseTestWithProjects =
+  (
+    baseConfig as {
+      test?: {
+        pool?: "forks" | "threads";
+        maxWorkers?: number;
+        setupFiles?: string[];
+        exclude?: string[];
+        projects?: unknown[];
+      };
+    }
+  ).test ?? {};
+// Drop any inherited `projects` matrix so `include` below stays authoritative.
+const { projects: _projects, ...baseTest } = baseTestWithProjects;
 
 export default defineConfig({
   ...baseConfig,


### PR DESCRIPTION
## Summary
Unbreaks the slm-gates lane (red since PR #54 merged; root causes predate it):

1. **`docker-compose.slm-local.yml`**: pgvector `mem_limit` becomes host-tunable `${SLM_PG_MEM_LIMIT:-1g}`. noob-root opts into its 256m cap via `.env`; CI keeps the 1g default.
2. **`vitest.slm.config.ts`**: stop inheriting the root `projects` matrix. Upstream sync `2ccb5cff22` made the base vitest config project-driven; the spread carried `projects` into the slm config, so vitest ignored the slm `include` and ran the ENTIRE repo suite — 32-minute "SLM integration" steps that OOM the runner heap (exit 134, `FATAL ERROR: Ineffective mark-compacts near heap limit`). Drop precedent: `test/vitest/vitest.e2e.config.ts`.
3. **`vitest.slm.e2e.config.ts`**: repoint the base import at `test/vitest/vitest.e2e.config.ts` — the root `vitest.e2e.config.ts` was deleted by the same sync (broken import; the e2e step couldn't load its config at all).

## Verification
- `vitest list --config vitest.slm.config.ts` → 104 tests, all under slm-owned paths (zero non-slm collections).
- `vitest run --config vitest.slm.config.ts` → **104/104 passed in 720ms** (was 32min + OOM in CI).
- `vitest list --config vitest.slm.e2e.config.ts` → import resolves, collects only `test/slm/**` e2e tests.
- slm-gates on this PR is the end-to-end proof (runs the real lane including the pgvector smoke at the restored 1g default).