### PR TITLE
Sync main to development (slm-gates fix parity)

### DIFF
--- a/docker-compose.slm-local.yml
+++ b/docker-compose.slm-local.yml
@@ -1,6 +1,9 @@
 services:
   pgvector:
-    mem_limit: 256m
+    # Host-tunable: noob-root sets SLM_PG_MEM_LIMIT=256m in .env (memory-pressured
+    # box). The 1g default keeps the slm-gates CI smoke green — a hard 256m cap
+    # crashed it (node abort, runs 2026-06-10).
+    mem_limit: ${SLM_PG_MEM_LIMIT:-1g}
     image: pgvector/pgvector:pg16
     container_name: ${SLM_PG_CONTAINER_NAME:-moltbot-pgvector}
     environment:

--- a/vitest.slm.config.ts
+++ b/vitest.slm.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 import baseConfig from "./vitest.config.ts";
 
-const baseTest = (
+const baseTestWithProjects = (
   baseConfig as {
     test?: {
       testTimeout?: number;
@@ -10,9 +10,14 @@ const baseTest = (
       maxWorkers?: number;
       setupFiles?: string[];
       exclude?: string[];
+      projects?: unknown[];
     };
   }
 ).test ?? { testTimeout: 120_000, hookTimeout: 120_000, pool: "forks", maxWorkers: 4 };
+// Drop the root `projects` matrix (test/vitest/vitest.config.ts) — inheriting it
+// makes vitest ignore `include` below and run the ENTIRE repo suite, which OOMs
+// the slm-gates runner heap. Same drop precedent: test/vitest/vitest.e2e.config.ts.
+const { projects: _projects, ...baseTest } = baseTestWithProjects;
 const isBunRuntime = typeof Bun !== "undefined";
 const include = [
   "extensions/slm-pipeline/**/*.test.ts",

--- a/vitest.slm.e2e.config.ts
+++ b/vitest.slm.e2e.config.ts
@@ -1,16 +1,22 @@
 import { defineConfig } from "vitest/config";
-import baseConfig from "./vitest.e2e.config.ts";
+// Root vitest.e2e.config.ts was deleted when upstream moved configs under
+// test/vitest/ (2ccb5cff22); import the moved file directly.
+import baseConfig from "./test/vitest/vitest.e2e.config.ts";
 
-const baseTest = (
-  baseConfig as {
-    test?: {
-      pool?: "forks" | "threads";
-      maxWorkers?: number;
-      setupFiles?: string[];
-      exclude?: string[];
-    };
-  }
-).test ?? {};
+const baseTestWithProjects =
+  (
+    baseConfig as {
+      test?: {
+        pool?: "forks" | "threads";
+        maxWorkers?: number;
+        setupFiles?: string[];
+        exclude?: string[];
+        projects?: unknown[];
+      };
+    }
+  ).test ?? {};
+// Drop any inherited `projects` matrix so `include` below stays authoritative.
+const { projects: _projects, ...baseTest } = baseTestWithProjects;
 
 export default defineConfig({
   ...baseConfig,


### PR DESCRIPTION
## Summary
Parity merge: brings PR #57 (slm-gates unbreak: pgvector cap host-overridable + slm vitest lanes no longer inherit the full repo projects matrix + fixed deleted-config import) into main. Keeps main == development for the flip-switch deploy model.

## Verification
PR #57 merged fully green — including slm-gates at 2m14s (previously 32min + heap OOM) and the entire core matrix.