### PR TITLE
fix(scopelybot): derive confirm-prompt env label from SCOPELY_BASE_URL

### DIFF
--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -13,6 +13,17 @@ import { jsonResult } from "./scopely-api.js";
 
 type FetchResult = Promise<{ ok: boolean; status: number; data: unknown }>;
 
+// Label the confirm prompt by the deployment's actual Scopely backend, derived
+// from SCOPELY_BASE_URL (the var that already selects which backend this bot
+// talks to) so the warning names the real environment instead of a baked-in
+// "PROD". Defaults to PROD — the cautious label — for any host that isn't a
+// recognizable non-prod host, so an unknown/misconfigured backend still
+// over-warns rather than under-warns.
+function scopelyEnvLabel(): string {
+  const url = process.env.SCOPELY_BASE_URL ?? process.env.SCOPELY_URL ?? "";
+  return /\/\/(dev|staging|test)[.-]/i.test(url) ? "DEV" : "PROD";
+}
+
 // Stage a gated mutation. Does NOT execute — the real call fires only when a
 // human replies `CONFIRM <code>` (consumed in the before_dispatch hook).
 //
@@ -44,7 +55,7 @@ export async function stageWrite(summary: string, run: () => FetchResult) {
   const code = makeCode();
   putPending({ code, conversationId: channel, summary, run });
   const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `⚠️ Confirm: ${summary} on ${scopelyEnvLabel()}.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
   await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -114,6 +114,29 @@ describe("user-maintenance-tools", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("confirm prompt labels the target from SCOPELY_BASE_URL (defaults to PROD)", async () => {
+    const tools = buildTools();
+    const savedBase = process.env.SCOPELY_BASE_URL;
+    const savedUrl = process.env.SCOPELY_URL;
+    delete process.env.SCOPELY_BASE_URL;
+    delete process.env.SCOPELY_URL;
+    try {
+      // Unknown/unset backend -> cautious PROD label.
+      await tools.scopely_reset_user_password.execute("t", { user_id: 1, email: "a@example.com" });
+      expect(sendScopelyTextMock.mock.calls.at(-1)?.[1]).toMatch(/ on PROD\./);
+
+      // Dev backend -> DEV label so the confirm warning names the real environment.
+      process.env.SCOPELY_BASE_URL = "https://dev.vip.pscx.ai";
+      await tools.scopely_reset_user_password.execute("t", { user_id: 2, email: "b@example.com" });
+      expect(sendScopelyTextMock.mock.calls.at(-1)?.[1]).toMatch(/ on DEV\./);
+    } finally {
+      if (savedBase === undefined) delete process.env.SCOPELY_BASE_URL;
+      else process.env.SCOPELY_BASE_URL = savedBase;
+      if (savedUrl === undefined) delete process.env.SCOPELY_URL;
+      else process.env.SCOPELY_URL = savedUrl;
+    }
+  });
+
   it("scopely_update_user stages only the supplied fields and does NOT execute until confirmed", async () => {
     const tools = buildTools();
 


### PR DESCRIPTION
## Summary

The scopelybot staged-write confirm prompt hardcoded the environment:

```
⚠️ Confirm: <summary> on PROD.
```

So the **dev** deployment warned `on PROD` for dev-backend mutations — misleading. This derives the label from `SCOPELY_BASE_URL` (the env var that already selects which backend the bot talks to), so the confirm warning names the real target:

- `https://dev.vip.pscx.ai` → `on DEV`
- `https://vip.pscx.ai` → `on PROD`
- unknown/unset host → `on PROD` (cautious default — over-warns rather than under-warns)

No new env/config surface (derives from the existing `SCOPELY_BASE_URL`); removes a hardcoded literal in `gated.ts`.

## Behavior

Only the confirm-prompt *label string* changes. Staging, gating, the crypto code, channel delivery, and the no-mutation-until-CONFIRM invariant are all untouched.

## Verification

- Added a behavior test in `user-maintenance-tools.test.ts` asserting the prompt labels `PROD` by default and `DEV` for a `dev.` backend.
- Verified the label logic directly against the real URLs + edge cases (dev/staging/test → DEV; vip.pscx.ai/api.vip.pscx.ai/unset → PROD) — all pass.
- Note: this checkout had no `node_modules` hydrated, so the vitest suite wasn't run locally — CI runs it. No format/lint run locally for the same reason.

## Related (not in this PR)

Paired with a per-box `workspace-scopelybot/IDENTITY.md` env-awareness edit (gitignored runtime config, applied on the dev box separately) so the bot self-reports its environment when asked.