### PR TITLE
feat(praxis): read-only Praxis support tools + skill

### DIFF
--- a/extensions/praxis/index.test.ts
+++ b/extensions/praxis/index.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    headers: {
+      get: (h: string) => (h.toLowerCase() === "content-type" ? "application/json" : null),
+    },
+    json: async () => opts.body,
+    text: async () => JSON.stringify(opts.body),
+  } as unknown as Response;
+}
+
+function buildTools(): { tools: Record<string, ToolDef>; opts: Record<string, unknown>[] } {
+  const tools: Record<string, ToolDef> = {};
+  const opts: Record<string, unknown>[] = [];
+  const api = {
+    registerTool: (factory: () => ToolDef, opt?: unknown) => {
+      const t = factory();
+      tools[t.name] = t;
+      opts.push((opt ?? {}) as Record<string, unknown>);
+    },
+  } as never;
+  plugin.register(api);
+  return { tools, opts };
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.stubEnv("PRAXIS_API_TOKEN", "test-token");
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("praxis plugin registration", () => {
+  it("registers all five read tools", () => {
+    const { tools } = buildTools();
+    expect(Object.keys(tools).toSorted()).toEqual([
+      "praxis_diagnose_issue",
+      "praxis_get_issue",
+      "praxis_health",
+      "praxis_list_events",
+      "praxis_list_issues",
+    ]);
+  });
+
+  it("registers every tool as optional so per-agent allowlists scope them", () => {
+    const { opts } = buildTools();
+    expect(opts).toHaveLength(5);
+    expect(opts.every((o) => o.optional === true)).toBe(true);
+  });
+});
+
+describe("praxis tool handlers", () => {
+  it("praxis_diagnose_issue returns the redacted diagnosis body", async () => {
+    const diagnosis = { id: 5, state: "blocked", fuses: { resolver: { at_cap: true } } };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: diagnosis }));
+
+    const { tools } = buildTools();
+    const out = parse(await tools.praxis_diagnose_issue.execute("call-1", { issue_id: 5 }));
+
+    expect(out).toEqual(diagnosis);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://praxis:8000/api/v1/issues/5/diagnose");
+  });
+
+  it("praxis_list_issues forwards repo + state filters into the query", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: { issues: [] } }));
+
+    const { tools } = buildTools();
+    await tools.praxis_list_issues.execute("call-2", {
+      repo: "cloudwarriors-ai/scopely",
+      state: "blocked",
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://praxis:8000/api/v1/issues?repo=cloudwarriors-ai%2Fscopely&state=blocked",
+    );
+  });
+
+  it("returns a normalized error result on a non-2xx response (no throw)", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 404, body: { detail: "x" } }));
+
+    const { tools } = buildTools();
+    const out = parse(await tools.praxis_get_issue.execute("call-3", { issue_id: 999 }));
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/Praxis API 404/);
+  });
+});

--- a/extensions/praxis/index.ts
+++ b/extensions/praxis/index.ts
@@ -1,0 +1,136 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { listIssuesPath, praxisGet, praxisHealth } from "./praxis-client.js";
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+function errorResult(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
+}
+
+const plugin = {
+  id: "praxis",
+  name: "Praxis",
+  description:
+    "Praxis issue-orchestrator support tools - diagnose stuck issues, list/inspect issues and their event trace (read-only)",
+  configSchema: emptyPluginConfigSchema(),
+
+  register(api: OpenClawPluginApi) {
+    // Register every tool as `optional: true` so per-agent allowlists scope them:
+    // a non-optional plugin tool bypasses allowlists and becomes visible to EVERY
+    // agent. With this, only agents whose `tools.allow` names a tool, the plugin id
+    // ("praxis"), or "group:plugins" see the Praxis tools. (Mirrors zoomwarriorssupportbot.)
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    // Connectivity + contract check: confirms Praxis is reachable and still speaks
+    // the API version this client targets (catches cross-repo contract drift).
+    optionalApi.registerTool(() => ({
+      name: "praxis_health",
+      description:
+        "Check Praxis connectivity and API-version compatibility. Run this first if other " +
+        "praxis_* tools are failing, to tell a config/auth problem apart from a real issue state.",
+      parameters: Type.Object({}),
+      async execute() {
+        try {
+          return jsonResult(await praxisHealth());
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    }));
+
+    // List issues, optionally filtered by repo and/or lifecycle state.
+    optionalApi.registerTool(() => ({
+      name: "praxis_list_issues",
+      description:
+        "List issues Praxis is tracking, newest first. Optionally filter by repo full name " +
+        "(e.g. 'cloudwarriors-ai/scopely') and/or lifecycle state (e.g. 'blocked', 'needs_info', " +
+        "'dispatch_requested'). Use this to find stuck issues.",
+      parameters: Type.Object({
+        repo: Type.Optional(Type.String({ description: "Filter by repo full name" })),
+        state: Type.Optional(Type.String({ description: "Filter by lifecycle state" })),
+      }),
+      async execute(_id: string, params: Record<string, unknown>) {
+        try {
+          const path = listIssuesPath({
+            repo: params.repo as string | undefined,
+            state: params.state as string | undefined,
+          });
+          return jsonResult(await praxisGet(path));
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    }));
+
+    // Single issue: state, fuses, risk score, recent events.
+    optionalApi.registerTool(() => ({
+      name: "praxis_get_issue",
+      description:
+        "Get one Praxis issue by its Praxis id: current state, fuse counters, risk score, and its " +
+        "most recent events.",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+      }),
+      async execute(_id: string, params: Record<string, unknown>) {
+        try {
+          return jsonResult(await praxisGet(`/api/v1/issues/${params.issue_id as number}`));
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    }));
+
+    // Full append-only event trace for an issue (the audit trail).
+    optionalApi.registerTool(() => ({
+      name: "praxis_list_events",
+      description:
+        "Get the full event trace (append-only audit trail) for a Praxis issue: every state " +
+        "transition with actor, from/to state, and reason. Use this to reconstruct how an issue " +
+        "reached its current state.",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id" }),
+      }),
+      async execute(_id: string, params: Record<string, unknown>) {
+        try {
+          return jsonResult(await praxisGet(`/api/v1/issues/${params.issue_id as number}/events`));
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    }));
+
+    // Support-triage aggregation: WHY an issue is where it is (redacted server-side).
+    optionalApi.registerTool(() => ({
+      name: "praxis_diagnose_issue",
+      description:
+        "Diagnose WHY a Praxis issue is stuck: fuse counters vs their caps (at_cap = tripped to " +
+        "blocked), open questions awaiting a human reply, the live resolver attempt, and any " +
+        "unsettled outbox effects. This is the primary triage tool. The response is redacted by " +
+        "Praxis (no raw error text or tokens).",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id" }),
+      }),
+      async execute(_id: string, params: Record<string, unknown>) {
+        try {
+          return jsonResult(
+            await praxisGet(`/api/v1/issues/${params.issue_id as number}/diagnose`),
+          );
+        } catch (err) {
+          return errorResult(err);
+        }
+      },
+    }));
+  },
+};
+
+export default plugin;

--- a/extensions/praxis/openclaw.plugin.json
+++ b/extensions/praxis/openclaw.plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "praxis",
+  "name": "Praxis",
+  "description": "Praxis issue-orchestrator support tools - diagnose stuck issues, list/inspect issues and their event trace (read-only)",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "contracts": {
+    "tools": [
+      "praxis_diagnose_issue",
+      "praxis_get_issue",
+      "praxis_health",
+      "praxis_list_events",
+      "praxis_list_issues"
+    ]
+  }
+}

--- a/extensions/praxis/package.json
+++ b/extensions/praxis/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/praxis",
+  "version": "0.1.0",
+  "description": "Praxis issue-orchestrator support tools (read-only diagnostics)",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/praxis/praxis-client.test.ts
+++ b/extensions/praxis/praxis-client.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPraxisBase,
+  listIssuesPath,
+  praxisFetch,
+  praxisGet,
+  praxisHealth,
+} from "./praxis-client.js";
+
+// The client reads PRAXIS_API_URL at module load (defaults to http://praxis:8000) and
+// PRAXIS_API_TOKEN lazily per call, so we leave the base at its default and only stub the token.
+const BASE = "http://praxis:8000";
+
+function mockResponse(opts: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+  json?: boolean;
+}): Response {
+  const json = opts.json ?? true;
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    headers: {
+      get: (h: string) =>
+        h.toLowerCase() === "content-type" ? (json ? "application/json" : "text/plain") : null,
+    },
+    json: async () => opts.body,
+    text: async () => (typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body)),
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.stubEnv("PRAXIS_API_TOKEN", "test-token");
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("praxisFetch", () => {
+  it("attaches the bearer token and parses a JSON body", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: { issues: [] } }));
+    const res = await praxisFetch("/api/v1/issues");
+
+    expect(res).toEqual({ ok: true, status: 200, data: { issues: [] } });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues`);
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer test-token");
+  });
+
+  it("throws a clear error when PRAXIS_API_TOKEN is unset", async () => {
+    vi.stubEnv("PRAXIS_API_TOKEN", "");
+    await expect(praxisFetch("/api/v1/issues")).rejects.toThrow(
+      "PRAXIS_API_TOKEN env var required",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("praxisGet", () => {
+  it("returns the body on success", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { state: "blocked" } }),
+    );
+    expect(await praxisGet("/api/v1/issues/5")).toEqual({ state: "blocked" });
+  });
+
+  it("throws on non-2xx with status + body, never the token", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 404, body: { detail: "Not found." } }),
+    );
+    await expect(praxisGet("/api/v1/issues/999")).rejects.toThrow(
+      /Praxis API 404 on \/api\/v1\/issues\/999/,
+    );
+    await expect(praxisGet("/api/v1/issues/999")).rejects.not.toThrow(/test-token/);
+  });
+});
+
+describe("listIssuesPath", () => {
+  it("returns the bare path with no filters", () => {
+    expect(listIssuesPath({})).toBe("/api/v1/issues");
+  });
+
+  it("encodes repo and state filters", () => {
+    expect(listIssuesPath({ repo: "cloudwarriors-ai/scopely", state: "blocked" })).toBe(
+      "/api/v1/issues?repo=cloudwarriors-ai%2Fscopely&state=blocked",
+    );
+  });
+});
+
+describe("praxisHealth", () => {
+  it("reports ok when the server API version matches", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { info: { version: "v1" } } }),
+    );
+    expect(await praxisHealth()).toEqual({ ok: true, version: "v1" });
+  });
+
+  it("reports a version mismatch as not ok", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { info: { version: "v2" } } }),
+    );
+    const health = await praxisHealth();
+    expect(health.ok).toBe(false);
+    expect(health.version).toBe("v2");
+    expect(health.error).toMatch(/version mismatch/);
+  });
+
+  it("reports a non-ok schema fetch as not ok without throwing", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 502, body: "bad gateway" }));
+    const health = await praxisHealth();
+    expect(health.ok).toBe(false);
+    expect(health.error).toMatch(/HTTP 502/);
+  });
+});
+
+describe("getPraxisBase", () => {
+  it("exposes the configured base with no trailing slash", () => {
+    expect(getPraxisBase()).toBe(BASE);
+  });
+});

--- a/extensions/praxis/praxis-client.ts
+++ b/extensions/praxis/praxis-client.ts
@@ -1,0 +1,104 @@
+/**
+ * Praxis REST client (read-only).
+ *
+ * Praxis authorizes the REST surface with a single static org bearer token
+ * (the `rest_api_token` credential), so this is much simpler than the ZW2
+ * login flow: read base URL + token from env, attach the bearer, normalize
+ * errors. Connection config is env-based to match the sibling integration
+ * extensions (ZW2_*, ZWS_*); nothing here is persisted.
+ *
+ * The surface is pinned to Praxis's versioned contract (`/api/v1`, the
+ * committed OpenAPI schema). `praxisHealth()` validates connectivity AND that
+ * the server still speaks the version this client was built against, so a
+ * cross-repo contract drift surfaces as a clear health failure instead of
+ * mysterious 404s.
+ */
+
+const EXPECTED_API_VERSION = "v1";
+
+const PRAXIS_BASE = (process.env.PRAXIS_API_URL ?? "http://praxis:8000").replace(/\/+$/, "");
+
+function bearerToken(): string {
+  const token = process.env.PRAXIS_API_TOKEN;
+  if (!token) {
+    throw new Error("PRAXIS_API_TOKEN env var required");
+  }
+  return token;
+}
+
+export interface PraxisResponse<T> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+export function getPraxisBase(): string {
+  return PRAXIS_BASE;
+}
+
+/** Raw fetch against the Praxis API with the bearer attached. Does not throw on
+ * HTTP error — returns the parsed body and status so callers can decide. */
+export async function praxisFetch<T = unknown>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<PraxisResponse<T>> {
+  // Every call goes through here with a fixed header set; callers never override headers, so we
+  // build them explicitly rather than spreading options.headers (which may be an array form).
+  const resp = await fetch(`${PRAXIS_BASE}${endpoint}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${bearerToken()}`,
+    },
+  });
+
+  const contentType = resp.headers.get("content-type") ?? "";
+  const data = contentType.includes("json") ? await resp.json() : await resp.text();
+  return { ok: resp.ok, status: resp.status, data: data as T };
+}
+
+/** GET that throws a normalized error on non-2xx. The token is never echoed in
+ * the message; the body is included so a 400/404 reason is visible. */
+export async function praxisGet<T = unknown>(endpoint: string): Promise<T> {
+  const result = await praxisFetch<T>(endpoint);
+  if (!result.ok) {
+    const body = typeof result.data === "string" ? result.data : JSON.stringify(result.data);
+    throw new Error(`Praxis API ${result.status} on ${endpoint}: ${body}`);
+  }
+  return result.data;
+}
+
+/** Build `/api/v1/issues` with optional repo/state filters. */
+export function listIssuesPath(filters: { repo?: string; state?: string }): string {
+  const params = new URLSearchParams();
+  if (filters.repo) {
+    params.set("repo", filters.repo);
+  }
+  if (filters.state) {
+    params.set("state", filters.state);
+  }
+  const qs = params.toString();
+  return qs ? `/api/v1/issues?${qs}` : "/api/v1/issues";
+}
+
+/** Connectivity + contract check: fetch the OpenAPI schema and confirm the
+ * server's version matches the version this client targets. */
+export async function praxisHealth(): Promise<{ ok: boolean; version?: string; error?: string }> {
+  try {
+    const result = await praxisFetch<{ info?: { version?: string } }>("/api/v1/schema?format=json");
+    if (!result.ok) {
+      return { ok: false, error: `schema fetch failed: HTTP ${result.status}` };
+    }
+    const version = result.data?.info?.version;
+    if (version !== EXPECTED_API_VERSION) {
+      return {
+        ok: false,
+        version,
+        error: `Praxis API version mismatch: client targets ${EXPECTED_API_VERSION}, server reports ${version ?? "unknown"}`,
+      };
+    }
+    return { ok: true, version };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1358,6 +1358,12 @@ importers:
         specifier: 2026.5.28
         version: 2026.5.28
 
+  extensions/praxis:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/pulsebot:
     devDependencies:
       openclaw:

--- a/skills/praxis/SKILL.md
+++ b/skills/praxis/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: praxis
+description: >
+  Support and triage for Praxis, the GitHub-issue resolution orchestrator. Diagnose stuck or
+  blocked issues, explain why an issue is where it is, and read its event trace — then escalate any
+  fix to a human (this skill is read-only). Use the praxis_* tools.
+  Triggers: "why is issue X stuck", "diagnose praxis issue", "what's blocking", "praxis status",
+  "is praxis stuck", "check praxis", "list blocked issues", "praxis issue [id]".
+metadata:
+  openclaw:
+    emoji: "🩺"
+---
+
+# Praxis support
+
+Praxis is a deterministic state machine that drives a GitHub issue from intake to done, wrapping the
+org autopilot/Sentinel engine as a swappable resolver. Your job here is **triage**: figure out _why_
+an issue is where it is, explain it plainly, and hand any required action to a human. **This skill is
+read-only** — see "Boundary" below.
+
+## Tools
+
+- `praxis_health` — connectivity + API-version check. Run this first if other tools error, to tell a
+  config/auth problem apart from a real issue state.
+- `praxis_list_issues` — list tracked issues, optionally filtered by `repo` and/or `state`. Use
+  `state="blocked"` to find stuck issues.
+- `praxis_get_issue` — one issue: state, fuses, risk score, recent events. Takes the **Praxis issue
+  id**, not the GitHub number.
+- `praxis_list_events` — the full append-only event trace (audit trail) for an issue.
+- `praxis_diagnose_issue` — the primary triage tool. Aggregates fuses-vs-caps, open questions, the
+  live resolver attempt, and unsettled outbox effects. Server-side redacted (no raw errors/tokens).
+
+## Lifecycle
+
+`intake → needs_info ⇄ ready → dispatch_requested → in_progress → deployed_dev → dev_uat →
+user_uat → done`. Side states: `blocked` (with a reason), `cancelled`.
+
+- **needs_info** — the issue is missing a required field; Praxis asked the reporter and is waiting.
+- **ready** — sufficiency floor passed; awaiting dispatch to the resolver.
+- **dispatch_requested** — handed to the engine; waiting for it to accept (the `claude-working` label).
+- **in_progress** — engine accepted and is working.
+- **deployed_dev → dev_uat → user_uat** — deployed; awaiting maintainer then reporter UAT verdicts.
+- **blocked** — a fuse tripped or a precondition failed. The `state_reason` says which.
+
+## Fuses (why things block)
+
+Three retry fuses, each capped at **3**. At the cap the issue routes to `blocked`:
+
+- `resolver` — resolver/dispatch attempts. At cap → `blocked(resolver)`.
+- `uat_loop` — failed UAT rounds. At cap → `blocked(uat_loop)`.
+- `nudge` — unanswered nudges to a human. At cap → `blocked(no_response)`.
+
+In a diagnosis, each fuse shows `{count, cap, at_cap}`. **`at_cap: true` is the smoking gun** — that
+fuse is why the issue is blocked.
+
+## Playbook: diagnose → explain → escalate
+
+1. **Diagnose.** Resolve the issue to its Praxis id (`praxis_list_issues` by repo/state if you only
+   have a GitHub number or a description), then `praxis_diagnose_issue`. Pull the event trace with
+   `praxis_list_events` if you need the full history.
+2. **Explain.** Translate the diagnosis into plain language for the human:
+   - Blocked? Name the `state_reason` and the `at_cap` fuse. (`resolver` = the engine kept failing
+     to pick it up; `uat_loop` = UAT kept failing; `no_response` = a human never answered.)
+   - `needs_info` with an open question? Say which `field` is missing and that the reporter must
+     answer (open questions show `field`, `purpose`, `age_seconds`).
+   - An unsettled `pending_effect` with `had_error: true` and rising `attempts`? A side-effect
+     (dispatch/comms) is failing to send — flag it as an infra/engine problem, not issue content.
+3. **Escalate.** The fix for a stuck issue is almost always a privileged action (`unblock`,
+   `cancel`, `manual_override`) or a human reply (answering `needs_info`, giving a UAT verdict).
+   **None of those are available in this skill.** Tell the human exactly what action is needed and
+   who must take it; do not attempt it yourself.
+
+## Boundary (read-only)
+
+This skill and its tools only **read** Praxis. There are no unblock/cancel/override/reply tools here
+by design. If your diagnosis concludes a mutation is needed, surface the recommendation and escalate
+to a human operator — never imply you performed it. (Hardened, opt-in write tools are a separate
+future phase, gated behind explicit policy.)


### PR DESCRIPTION
## Summary

New bundled extension `extensions/praxis` (plugin id `praxis`) + `skills/praxis` that give an agent **read-only support access to Praxis**, the GitHub-issue resolution orchestrator. This is Phase 1 (read-only) of the Praxis support agent; hardened opt-in write tools and async ops are deliberately later phases.

Mirrors the existing `zoomwarriors` / `zoomwarriorssupportbot` extension pattern (sibling package, env-based connection config, `optional: true` tool registration).

### Tools (all `optional: true` so per-agent `tools.allow` scopes them)
- `praxis_health` — connectivity + API-version check (catches cross-repo contract drift)
- `praxis_list_issues` — list/filter tracked issues (by `repo`, `state`)
- `praxis_get_issue` — one issue: state, fuses, risk, recent events
- `praxis_list_events` — full append-only event trace
- `praxis_diagnose_issue` — the triage tool: fuses-vs-caps, open questions, live attempt, unsettled effects (Praxis redacts it server-side)

### Client
`praxis-client.ts` — static-bearer REST client. Base URL + token via env (`PRAXIS_API_URL`, `PRAXIS_API_TOKEN`), matching the `ZW2_*`/`ZWS_*` sibling convention. Pinned to Praxis's versioned `/api/v1` contract; `praxisHealth()` validates the server's API version against the version this client targets.

### Skill
`skills/praxis/SKILL.md` — lifecycle / fuse / blocked-reason semantics + a **diagnose → explain → escalate** playbook. Read-only by design: any mutation (unblock/cancel/override, needs_info/UAT replies) is escalated to a human, never performed.

## Verification
- `pnpm test extensions/praxis` → **15 passed** (client URL/auth/error/health + tool handlers + optional-registration).
- `pnpm exec oxfmt --check extensions/praxis` → clean.
- `node scripts/run-oxlint.mjs extensions/praxis` → clean.
- `pnpm install` reconciles `pnpm-lock.yaml` with the new workspace package (only change: the `extensions/praxis` `workspace:*` link).

## Known pre-existing (not introduced by this PR)
- `tsgo:extensions` is red **repo-wide** on `development` — every CW extension (`zoomwarriors`, `zoomwarriorssupportbot`, `scopelybot`, `tesseract`, `zoom`, …) has the same `OpenClawPluginToolFactory` "missing `label`" TS2345 on each `registerTool`. praxis matches the `zoomwarriors` pattern exactly (5 errors, one per tool); fixing only praxis would break style consistency with every sibling.
- `plugins:sync:check` and `plugins:inventory:check` are already red on `development` (the whole CW-bot cohort is at `0.1.0`/`workspace:*` and the inventory doc was 21 plugins stale). praxis follows the `zoomwarriorssupportbot` precedent (`0.1.0`, no committed reference doc); the global `plugins:sync` / inventory regen would touch ~13–22 unrelated plugins, so they're left for a separate bulk refresh.

## Config to run against a live Praxis (deploy step, separate)
Set `PRAXIS_API_URL` (e.g. the noob-root Praxis dev URL) and `PRAXIS_API_TOKEN`, then enable the plugin (`plugins.entries.praxis.enabled`) and allow the tools for the support agent.