### PR TITLE
feat(praxis-write): hardened, default-disabled Praxis operator write plugin

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+import { mintConfirmToken } from "./policy.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const ISSUE = { id: 5, state: "blocked", state_reason: "no_response", version: 12 };
+
+function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    headers: {
+      get: (h: string) => (h.toLowerCase() === "content-type" ? "application/json" : null),
+    },
+    json: async () => opts.body,
+    text: async () => JSON.stringify(opts.body),
+  } as unknown as Response;
+}
+
+const DEFAULT_CTX = {
+  requesterSenderId: "alice",
+  deliveryContext: { channel: "dev_praxis", threadId: 1 },
+  sessionId: "s1",
+};
+
+function buildTools(opts?: { pluginConfig?: unknown; toolContext?: unknown }): {
+  tools: Record<string, ToolDef>;
+  registerOpts: Record<string, unknown>[];
+} {
+  const tools: Record<string, ToolDef> = {};
+  const registerOpts: Record<string, unknown>[] = [];
+  const toolContext = opts?.toolContext ?? DEFAULT_CTX;
+  const api = {
+    pluginConfig: opts?.pluginConfig,
+    registerTool: (factory: unknown, opt?: unknown) => {
+      const t = typeof factory === "function" ? factory(toolContext) : factory;
+      tools[(t as ToolDef).name] = t as ToolDef;
+      registerOpts.push((opt ?? {}) as Record<string, unknown>);
+    },
+  } as never;
+  plugin.register(api);
+  return { tools, registerOpts };
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+const ALLOW_ALICE = { allowedUsers: ["alice"], allowedChannels: ["dev_praxis"] };
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.stubEnv("PRAXIS_API_TOKEN", "test-token");
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("praxis-write registration", () => {
+  it("registers exactly the two write tools, both optional", () => {
+    const { tools, registerOpts } = buildTools();
+    expect(Object.keys(tools).toSorted()).toEqual(["praxis_cancel", "praxis_unblock"]);
+    expect(registerOpts).toHaveLength(2);
+    expect(registerOpts.every((o) => o.optional === true)).toBe(true);
+  });
+});
+
+describe("policy gate (no mutation reaches Praxis)", () => {
+  it("fails closed when the allowlist is unconfigured", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(await tools.praxis_unblock.execute("c1", { issue_id: 5, reason: "go" }));
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("denies a requester not on the allowlist", async () => {
+    const { tools } = buildTools({ pluginConfig: { allowedUsers: ["bob"] } });
+    const out = parse(await tools.praxis_unblock.execute("c1", { issue_id: 5, reason: "go" }));
+    expect(out).toEqual({ ok: false, denied: "requester_not_allowlisted" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("denies when the runtime gives no requester identity (cannot be spoofed via args)", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(
+      await tools.praxis_unblock.execute("c1", {
+        issue_id: 5,
+        reason: "go",
+        requested_by: "alice", // model-supplied arg is ignored; identity is trusted-context only
+      }),
+    );
+    expect(out).toEqual({ ok: false, denied: "no_requester_identity" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a reason before any fetch", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_unblock.execute("c1", { issue_id: 5, reason: "   " }));
+    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("two-step dry-run / confirm", () => {
+  it("first call previews and mutates nothing", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: ISSUE }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_unblock.execute("c1", { issue_id: 5, reason: "reporter idle" }),
+    );
+
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("unblock");
+    expect(out.issue).toEqual(ISSUE);
+    expect(typeof out.confirm_token).toBe("string");
+    // Exactly one call (the GET) — no POST mutation.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.method).toBeUndefined();
+  });
+
+  it("a fabricated/wrong confirm token re-previews instead of executing", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: ISSUE }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_unblock.execute("c1", {
+        issue_id: 5,
+        reason: "reporter idle",
+        confirm: "deadbeefdeadbeef",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // GET only, still no POST
+  });
+
+  it("executes on a valid confirm token, sending the trusted actor context", async () => {
+    // The flow does GET (fetch issue) then POST (submit) — mock them in that order.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { error: "", applied: true, state: "needs_info" },
+        }),
+      );
+    const token = mintConfirmToken({ secret: "test-token", kind: "unblock", issue: ISSUE });
+
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_unblock.execute("c9", {
+        issue_id: 5,
+        reason: "reporter idle",
+        confirm: token,
+      }),
+    );
+
+    expect(out).toEqual({ ok: true, status: 200, error: "", applied: true, state: "needs_info" });
+    const post = fetchMock.mock.calls.find((c) => c[1]?.method === "POST");
+    expect(post?.[0]).toBe("http://praxis:8000/api/v1/issues/5/events");
+    const body = JSON.parse(post?.[1].body as string);
+    expect(body).toEqual({
+      kind: "unblock",
+      reason: "reporter idle",
+      requested_by: "alice",
+      channel: "dev_praxis",
+      message_id: "1",
+      idempotency_key: "unblock:5:12",
+    });
+  });
+});
+
+describe("praxis_cancel", () => {
+  it("rejects an unsupported kind before any fetch", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_cancel.execute("c1", {
+        issue_id: 5,
+        kind: "manual_override",
+        reason: "x",
+      }),
+    );
+    expect(out.error).toBe("unsupported_kind");
+    expect(out.allowed).toContain("cancelled");
+    expect(out.allowed).not.toContain("manual_override");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("previews a valid cancel kind", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: ISSUE }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_cancel.execute("c1", {
+        issue_id: 5,
+        kind: "duplicate",
+        reason: "dupe of #4",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("duplicate");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -1,0 +1,228 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { buildPluginConfigSchema } from "openclaw/plugin-sdk/core";
+import { mapPluginConfigIssues } from "openclaw/plugin-sdk/extension-shared";
+import { z } from "zod";
+import {
+  type ActorContext,
+  checkPolicy,
+  confirmTokenMatches,
+  deriveActorContext,
+  idempotencyKey,
+  mintConfirmToken,
+  resolveWritePolicyConfig,
+  type WritePolicyConfig,
+} from "./policy.js";
+import {
+  getApiToken,
+  getIssue,
+  type PraxisIssueState,
+  submitCommand,
+} from "./praxis-write-client.js";
+
+// The cancel-family kinds Praxis accepts off-band. `manual_override` is deliberately
+// NOT here: it is too broad / terminal-state risky for a chat surface (spar MED) and is
+// rejected server-side too. `unblock` is its own tool.
+const CANCEL_KINDS = ["cancelled", "duplicate", "superseded", "source_closed"] as const;
+
+const PraxisWriteConfigSchema = z.strictObject({
+  allowedUsers: z.array(z.string()).optional(),
+  allowedChannels: z.array(z.string()).optional(),
+});
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+function errorResult(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
+  };
+}
+
+/** Shared path for both write tools: policy gate -> reason check -> fetch issue ->
+ * dry-run/confirm -> submit. Identity comes from `actor` (trusted runtime context),
+ * never from model args. */
+async function runWriteCommand(params: {
+  kind: string;
+  reason: unknown;
+  confirm: unknown;
+  issueId: unknown;
+  actor: ActorContext;
+  config: WritePolicyConfig;
+}) {
+  const decision = checkPolicy(params.actor, params.config);
+  if (!decision.allowed) {
+    return jsonResult({ ok: false, denied: decision.reason });
+  }
+  const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+  if (!reason) {
+    return jsonResult({ ok: false, error: "reason_required" });
+  }
+  const issueId = Number(params.issueId);
+  if (!Number.isInteger(issueId) || issueId <= 0) {
+    return jsonResult({ ok: false, error: "invalid_issue_id" });
+  }
+
+  let token: string;
+  try {
+    token = getApiToken();
+  } catch (err) {
+    return errorResult(err);
+  }
+
+  let issue: PraxisIssueState;
+  try {
+    issue = await getIssue(issueId);
+  } catch (err) {
+    return errorResult(err);
+  }
+
+  const expected = mintConfirmToken({ secret: token, kind: params.kind, issue });
+  const confirm = typeof params.confirm === "string" ? params.confirm : "";
+  if (!confirm || !confirmTokenMatches(confirm, expected)) {
+    return jsonResult({
+      ok: true,
+      preview: true,
+      action: params.kind,
+      issue: {
+        id: issue.id,
+        state: issue.state,
+        state_reason: issue.state_reason,
+        version: issue.version,
+      },
+      requested_by: params.actor.requestedBy,
+      confirm_token: expected,
+      message:
+        `Dry run only — nothing changed. Re-call this tool with confirm="${expected}" to execute ` +
+        `${params.kind} on issue ${issue.id}. The token is bound to the issue's current state and ` +
+        `is rejected if the issue changes before you confirm.`,
+    });
+  }
+
+  let res: Awaited<ReturnType<typeof submitCommand>>;
+  try {
+    res = await submitCommand(issueId, {
+      kind: params.kind,
+      reason,
+      requested_by: params.actor.requestedBy,
+      channel: params.actor.channel,
+      message_id: params.actor.messageId,
+      idempotency_key: idempotencyKey(params.kind, issue),
+    });
+  } catch (err) {
+    return errorResult(err);
+  }
+  return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+}
+
+const plugin = {
+  id: "praxis-write",
+  name: "Praxis Write",
+  description:
+    "Praxis operator write tools (hardened): unblock or cancel a stuck issue. Default-disabled, " +
+    "allowlist-gated, two-step dry-run/confirm.",
+  configSchema: buildPluginConfigSchema(PraxisWriteConfigSchema, {
+    safeParse(value) {
+      if (value === undefined) {
+        return { success: true, data: undefined };
+      }
+      const parsed = PraxisWriteConfigSchema.safeParse(value);
+      if (parsed.success) {
+        return { success: true, data: parsed.data };
+      }
+      return { success: false, error: { issues: mapPluginConfigIssues(parsed.error.issues) } };
+    },
+  }),
+
+  register(api: OpenClawPluginApi) {
+    const config = resolveWritePolicyConfig(api.pluginConfig);
+
+    // Register every tool as `optional: true` so per-agent allowlists scope them — an operator
+    // must name the tool / plugin id / "group:plugins" in an agent's `tools.allow`. Combined with
+    // the plugin being disabled by default (no `enabledByDefault` in the manifest), the write
+    // surface is dormant until explicitly enabled, allowlisted, AND configured.
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => api.registerTool(tool, { ...opts, optional: true }),
+    };
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_unblock",
+      description:
+        "Operator action: unblock a Praxis issue (resume it from `blocked`). The unblock target is " +
+        "derived server-side from the issue's block reason — you do not pick it. Two steps: call " +
+        "first with just issue_id + reason to get a dry-run preview and a confirm_token, then call " +
+        "again passing that token in `confirm` to execute. Allowlist-gated; the human you are acting " +
+        "for is recorded for audit. If denied, surface the reason to the human; do not retry.",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+        reason: Type.String({
+          description: "Operator justification for the unblock (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+        return runWriteCommand({
+          kind: "unblock",
+          reason: params.reason,
+          confirm: params.confirm,
+          issueId: params.issue_id,
+          actor,
+          config,
+        });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_cancel",
+      description:
+        "Operator action: cancel a Praxis issue, collapsing it to `cancelled` with a tag. `kind` is " +
+        "one of: cancelled | duplicate | superseded | source_closed. Two steps: call first with " +
+        "issue_id + kind + reason to get a dry-run preview and a confirm_token, then call again " +
+        "passing that token in `confirm` to execute. Allowlist-gated; the human you are acting for " +
+        "is recorded for audit. `manual_override` is intentionally not available here.",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+        kind: Type.String({
+          description: "Cancel reason tag: cancelled | duplicate | superseded | source_closed",
+        }),
+        reason: Type.String({
+          description: "Operator justification for the cancel (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const kind = typeof params.kind === "string" ? params.kind : "";
+        if (!(CANCEL_KINDS as readonly string[]).includes(kind)) {
+          return jsonResult({ ok: false, error: "unsupported_kind", allowed: CANCEL_KINDS });
+        }
+        const actor = deriveActorContext(toolContext, toolCallId);
+        return runWriteCommand({
+          kind,
+          reason: params.reason,
+          confirm: params.confirm,
+          issueId: params.issue_id,
+          actor,
+          config,
+        });
+      },
+    }));
+  },
+};
+
+export default plugin;

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "praxis-write",
+  "name": "Praxis Write",
+  "description": "Praxis operator write tools (hardened): unblock or cancel a stuck issue. Default-disabled; each call is allowlist-gated, requires a reason, and runs a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "allowedUsers": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Chat sender ids permitted to issue write commands. Each configured dimension (users/channels) must match; an empty allowlist authorizes nobody (fail closed)."
+      },
+      "allowedChannels": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Channel ids in which write commands are permitted. Each configured dimension (users/channels) must match; an empty allowlist authorizes nobody (fail closed)."
+      }
+    }
+  },
+  "contracts": {
+    "tools": [
+      "praxis_cancel",
+      "praxis_unblock"
+    ]
+  }
+}

--- a/extensions/praxis-write/package.json
+++ b/extensions/praxis-write/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/praxis-write",
+  "version": "0.1.0",
+  "description": "Praxis operator write tools (hardened, default-disabled): unblock / cancel a stuck issue",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/praxis-write/policy.test.ts
+++ b/extensions/praxis-write/policy.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ActorContext,
+  checkPolicy,
+  confirmTokenMatches,
+  deriveActorContext,
+  idempotencyKey,
+  mintConfirmToken,
+  resolveWritePolicyConfig,
+} from "./policy.js";
+import type { PraxisIssueState } from "./praxis-write-client.js";
+
+const issue: PraxisIssueState = {
+  id: 5,
+  state: "blocked",
+  state_reason: "no_response",
+  version: 12,
+};
+
+function actor(overrides: Partial<ActorContext> = {}): ActorContext {
+  return {
+    requestedBy: "alice",
+    channel: "dev_praxis",
+    messageId: "m-1",
+    toolCallId: "call-1",
+    ...overrides,
+  };
+}
+
+describe("resolveWritePolicyConfig", () => {
+  it("defaults to empty allowlists when unset or malformed", () => {
+    expect(resolveWritePolicyConfig(undefined)).toEqual({ allowedUsers: [], allowedChannels: [] });
+    expect(resolveWritePolicyConfig({ allowedUsers: "nope" })).toEqual({
+      allowedUsers: [],
+      allowedChannels: [],
+    });
+  });
+
+  it("keeps only non-empty string entries", () => {
+    expect(
+      resolveWritePolicyConfig({ allowedUsers: ["alice", "", 7, "bob"], allowedChannels: ["c1"] }),
+    ).toEqual({ allowedUsers: ["alice", "bob"], allowedChannels: ["c1"] });
+  });
+});
+
+describe("checkPolicy", () => {
+  it("denies when there is no requester identity", () => {
+    const decision = checkPolicy(actor({ requestedBy: "" }), {
+      allowedUsers: ["alice"],
+      allowedChannels: [],
+    });
+    expect(decision).toEqual({ allowed: false, reason: "no_requester_identity" });
+  });
+
+  it("fails closed when neither allowlist is configured", () => {
+    expect(checkPolicy(actor(), { allowedUsers: [], allowedChannels: [] })).toEqual({
+      allowed: false,
+      reason: "write_policy_unconfigured",
+    });
+  });
+
+  it("denies a requester not in a configured user allowlist", () => {
+    expect(
+      checkPolicy(actor({ requestedBy: "mallory" }), {
+        allowedUsers: ["alice"],
+        allowedChannels: [],
+      }),
+    ).toEqual({ allowed: false, reason: "requester_not_allowlisted" });
+  });
+
+  it("denies a channel not in a configured channel allowlist", () => {
+    expect(
+      checkPolicy(actor({ channel: "random" }), {
+        allowedUsers: ["alice"],
+        allowedChannels: ["dev_praxis"],
+      }),
+    ).toEqual({ allowed: false, reason: "channel_not_allowlisted" });
+  });
+
+  it("allows when every configured dimension matches", () => {
+    expect(
+      checkPolicy(actor(), { allowedUsers: ["alice"], allowedChannels: ["dev_praxis"] }),
+    ).toEqual({ allowed: true });
+  });
+
+  it("treats a channel-only allowlist as 'anyone in this channel'", () => {
+    expect(
+      checkPolicy(actor({ requestedBy: "anyone" }), {
+        allowedUsers: [],
+        allowedChannels: ["dev_praxis"],
+      }),
+    ).toEqual({ allowed: true });
+  });
+});
+
+describe("deriveActorContext", () => {
+  it("reads identity from the trusted runtime context, not tool args", () => {
+    const ctx = {
+      requesterSenderId: "alice",
+      deliveryContext: { channel: "dev_praxis", threadId: 99 },
+      sessionId: "sess-1",
+    };
+    expect(deriveActorContext(ctx, "call-7")).toEqual({
+      requestedBy: "alice",
+      channel: "dev_praxis",
+      messageId: "99",
+      toolCallId: "call-7",
+    });
+  });
+
+  it("falls back to messageChannel and sessionId, empty requester when absent", () => {
+    expect(deriveActorContext({ messageChannel: "zoom", sessionId: "sess-2" }, "call-8")).toEqual({
+      requestedBy: "",
+      channel: "zoom",
+      messageId: "sess-2",
+      toolCallId: "call-8",
+    });
+  });
+});
+
+describe("confirm token", () => {
+  const secret = "server-only-secret";
+
+  it("a token minted for an issue verifies against the same state", () => {
+    const token = mintConfirmToken({ secret, kind: "unblock", issue });
+    expect(confirmTokenMatches(token, mintConfirmToken({ secret, kind: "unblock", issue }))).toBe(
+      true,
+    );
+  });
+
+  it("rejects a stale token after the issue version changes", () => {
+    const stale = mintConfirmToken({ secret, kind: "unblock", issue });
+    const fresh = mintConfirmToken({
+      secret,
+      kind: "unblock",
+      issue: { ...issue, version: 13 },
+    });
+    expect(confirmTokenMatches(stale, fresh)).toBe(false);
+  });
+
+  it("is bound to the command kind", () => {
+    const unblock = mintConfirmToken({ secret, kind: "unblock", issue });
+    const cancel = mintConfirmToken({ secret, kind: "cancelled", issue });
+    expect(unblock).not.toBe(cancel);
+  });
+
+  it("changes with the secret, so it cannot be forged without the token", () => {
+    const a = mintConfirmToken({ secret, kind: "unblock", issue });
+    const b = mintConfirmToken({ secret: "other", kind: "unblock", issue });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("idempotencyKey", () => {
+  it("is one logical command per issue version", () => {
+    expect(idempotencyKey("unblock", issue)).toBe("unblock:5:12");
+    expect(idempotencyKey("cancelled", { ...issue, version: 13 })).toBe("cancelled:5:13");
+  });
+});

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -1,0 +1,120 @@
+/**
+ * Code-enforced write policy for the Praxis operator tools.
+ *
+ * The SKILL/prompt is NOT the gate (spar CRITICAL: prompt-injection on a
+ * chat-reachable, side-effecting surface). The gate is here, in code:
+ *   1. Identity comes from the trusted runtime context (requesterSenderId,
+ *      delivery channel) — never from model-supplied tool args, so a prompt
+ *      cannot spoof who is asking.
+ *   2. An explicit user/channel allowlist (plugin config). Empty = fail closed.
+ *   3. A two-step dry-run/confirm: the confirm token is an HMAC bound to the
+ *      issue's current state, so a confirm the model fabricates (skipping the
+ *      preview) or that races a state change is rejected.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { PraxisIssueState } from "./praxis-write-client.js";
+
+/** Trusted, runtime-supplied request context. Mirrors the OpenClaw tool context
+ * fields we read; declared structurally so this module stays pure + unit-testable. */
+export interface ToolRequestContext {
+  requesterSenderId?: string;
+  messageChannel?: string;
+  deliveryContext?: { channel?: string; threadId?: string | number };
+  sessionId?: string;
+}
+
+export interface ActorContext {
+  requestedBy: string;
+  channel: string;
+  messageId: string;
+  toolCallId: string;
+}
+
+export interface WritePolicyConfig {
+  allowedUsers: string[];
+  allowedChannels: string[];
+}
+
+export type PolicyDecision = { allowed: true } | { allowed: false; reason: string };
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+/** Coerce the raw plugin config into the policy allowlists, defaulting to empty
+ * (fail closed) when unset or malformed. */
+export function resolveWritePolicyConfig(raw: unknown): WritePolicyConfig {
+  const obj = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  return {
+    allowedUsers: toStringArray(obj.allowedUsers),
+    allowedChannels: toStringArray(obj.allowedChannels),
+  };
+}
+
+/** Build the actor context from the TRUSTED runtime context, not tool args. The
+ * model can pick the issue + reason, but never who/where the request came from. */
+export function deriveActorContext(ctx: ToolRequestContext, toolCallId: string): ActorContext {
+  const channel = ctx.deliveryContext?.channel ?? ctx.messageChannel ?? "";
+  const threadId = ctx.deliveryContext?.threadId;
+  const messageId =
+    threadId !== undefined && threadId !== null ? String(threadId) : (ctx.sessionId ?? "");
+  return {
+    requestedBy: ctx.requesterSenderId ?? "",
+    channel,
+    messageId,
+    toolCallId,
+  };
+}
+
+/** Each configured dimension must match; an empty allowlist authorizes nobody.
+ * A missing requester identity always denies (cannot attribute the action). */
+export function checkPolicy(actor: ActorContext, config: WritePolicyConfig): PolicyDecision {
+  if (!actor.requestedBy) {
+    return { allowed: false, reason: "no_requester_identity" };
+  }
+  const { allowedUsers, allowedChannels } = config;
+  if (allowedUsers.length === 0 && allowedChannels.length === 0) {
+    return { allowed: false, reason: "write_policy_unconfigured" };
+  }
+  if (allowedUsers.length > 0 && !allowedUsers.includes(actor.requestedBy)) {
+    return { allowed: false, reason: "requester_not_allowlisted" };
+  }
+  if (allowedChannels.length > 0 && !allowedChannels.includes(actor.channel)) {
+    return { allowed: false, reason: "channel_not_allowlisted" };
+  }
+  return { allowed: true };
+}
+
+/** HMAC over (kind + the issue's identity and current state), keyed by the API
+ * token (never exposed to the model). Knowing the token is impossible for the
+ * model, so it cannot forge a token without first calling the dry-run; binding
+ * to state/version makes a stale confirm fail closed. */
+export function mintConfirmToken(params: {
+  secret: string;
+  kind: string;
+  issue: PraxisIssueState;
+}): string {
+  const { secret, kind, issue } = params;
+  const msg = `${kind}:${issue.id}:${issue.state}:${issue.state_reason}:${issue.version}`;
+  return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
+}
+
+/** Constant-time compare of a presented confirm token against the expected one. */
+export function confirmTokenMatches(presented: string, expected: string): boolean {
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return false;
+  }
+  return timingSafeEqual(a, b);
+}
+
+/** Idempotency key for a confirmed command: one logical "do <kind> to issue N at
+ * version V", so a double-fire of the same command dedupes server-side. */
+export function idempotencyKey(kind: string, issue: PraxisIssueState): string {
+  return `${kind}:${issue.id}:${issue.version}`;
+}

--- a/extensions/praxis-write/praxis-write-client.test.ts
+++ b/extensions/praxis-write/praxis-write-client.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getApiToken, getIssue, praxisFetch, submitCommand } from "./praxis-write-client.js";
+
+const BASE = "http://praxis:8000";
+
+function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Response {
+  return {
+    ok: opts.ok,
+    status: opts.status,
+    headers: {
+      get: (h: string) => (h.toLowerCase() === "content-type" ? "application/json" : null),
+    },
+    json: async () => opts.body,
+    text: async () => JSON.stringify(opts.body),
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.stubEnv("PRAXIS_API_TOKEN", "test-token");
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("getApiToken", () => {
+  it("returns the env token", () => {
+    expect(getApiToken()).toBe("test-token");
+  });
+
+  it("throws when unset", () => {
+    vi.stubEnv("PRAXIS_API_TOKEN", "");
+    expect(() => getApiToken()).toThrow("PRAXIS_API_TOKEN env var required");
+  });
+});
+
+describe("praxisFetch", () => {
+  it("attaches the bearer and does not throw on non-2xx", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 409, body: { error: "x" } }));
+    const res = await praxisFetch("/api/v1/issues/5/events", { method: "POST", body: "{}" });
+    expect(res).toEqual({ ok: false, status: 409, data: { error: "x" } });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues/5/events`);
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer test-token");
+  });
+});
+
+describe("getIssue", () => {
+  it("returns the issue state body", async () => {
+    const body = { id: 5, state: "blocked", state_reason: "no_response", version: 12 };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body }));
+    expect(await getIssue(5)).toEqual(body);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/v1/issues/5`);
+  });
+
+  it("throws on a 404 without echoing the token", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: false, status: 404, body: { detail: "x" } }));
+    await expect(getIssue(999)).rejects.toThrow(/Praxis API 404 on \/api\/v1\/issues\/999/);
+    await expect(getIssue(999)).rejects.not.toThrow(/test-token/);
+  });
+});
+
+describe("submitCommand", () => {
+  it("POSTs the command + audit context and returns the raw structured result", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { error: "", applied: true, state: "needs_info" },
+      }),
+    );
+    const res = await submitCommand(5, {
+      kind: "unblock",
+      reason: "reporter idle",
+      requested_by: "alice",
+      channel: "dev_praxis",
+      message_id: "m-1",
+      idempotency_key: "unblock:5:12",
+    });
+    expect(res).toEqual({
+      ok: true,
+      status: 200,
+      data: { error: "", applied: true, state: "needs_info" },
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues/5/events`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({
+      kind: "unblock",
+      reason: "reporter idle",
+      requested_by: "alice",
+      channel: "dev_praxis",
+      message_id: "m-1",
+      idempotency_key: "unblock:5:12",
+    });
+    // No client-supplied payload or actor_id: the server derives + binds those.
+    expect(sent.payload).toBeUndefined();
+    expect(sent.actor_id).toBeUndefined();
+  });
+});

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -1,0 +1,99 @@
+/**
+ * Praxis REST client (write surface).
+ *
+ * A deliberate copy of the read plugin's client rather than a shared import:
+ * extension packages are isolated (see extensions/CLAUDE.md — prod code may not
+ * reach into a sibling extension), so the write plugin owns its own thin client.
+ *
+ * Praxis authorizes the REST surface with a single static org bearer token (the
+ * `rest_api_token` credential), read from env. The surface is pinned to the
+ * versioned contract (`/api/v1`). Authorization for a command binds server-side
+ * to the configured operator; this client only carries the command + the audit
+ * context (requested_by / channel / message_id) the server records.
+ */
+
+const PRAXIS_BASE = (process.env.PRAXIS_API_URL ?? "http://praxis:8000").replace(/\/+$/, "");
+
+/** The bearer token, read lazily per call so a missing token fails the call, not module load. */
+export function getApiToken(): string {
+  const token = process.env.PRAXIS_API_TOKEN;
+  if (!token) {
+    throw new Error("PRAXIS_API_TOKEN env var required");
+  }
+  return token;
+}
+
+export interface PraxisResponse<T> {
+  ok: boolean;
+  status: number;
+  data: T;
+}
+
+/** The fields of an issue the write flow needs: the confirm token binds to these
+ * so a confirm that races a state change fails closed. */
+export interface PraxisIssueState {
+  id: number;
+  state: string;
+  state_reason: string;
+  version: number;
+}
+
+/** The audit context recorded on the event row. Authorization is NOT here — it
+ * binds to the server's configured operator. These describe the real requester. */
+export interface CommandAuditContext {
+  requested_by: string;
+  channel: string;
+  message_id: string;
+  idempotency_key: string;
+}
+
+export function getPraxisBase(): string {
+  return PRAXIS_BASE;
+}
+
+/** Raw fetch with the bearer attached. Does not throw on HTTP error — returns the
+ * parsed body and status so callers map the structured command result themselves. */
+export async function praxisFetch<T = unknown>(
+  endpoint: string,
+  options?: RequestInit,
+): Promise<PraxisResponse<T>> {
+  const resp = await fetch(`${PRAXIS_BASE}${endpoint}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${getApiToken()}`,
+    },
+  });
+  const contentType = resp.headers.get("content-type") ?? "";
+  const data = contentType.includes("json") ? await resp.json() : await resp.text();
+  return { ok: resp.ok, status: resp.status, data: data as T };
+}
+
+/** GET that throws a normalized error on non-2xx. The token is never echoed. */
+export async function praxisGet<T = unknown>(endpoint: string): Promise<T> {
+  const result = await praxisFetch<T>(endpoint);
+  if (!result.ok) {
+    const body = typeof result.data === "string" ? result.data : JSON.stringify(result.data);
+    throw new Error(`Praxis API ${result.status} on ${endpoint}: ${body}`);
+  }
+  return result.data;
+}
+
+/** Fetch the current issue state used to build + bind the confirm token. */
+export async function getIssue(issueId: number): Promise<PraxisIssueState> {
+  return praxisGet<PraxisIssueState>(`/api/v1/issues/${issueId}`);
+}
+
+/** Submit an operator command. Returns the raw structured result + HTTP status so
+ * the tool surfaces Praxis's own error/applied/rejected/idempotent outcome verbatim.
+ * The server derives any payload and binds authorization to its operator; we send
+ * only the command kind + reason + audit context. */
+export async function submitCommand(
+  issueId: number,
+  command: { kind: string; reason: string } & CommandAuditContext,
+): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>(`/api/v1/issues/${issueId}/events`, {
+    method: "POST",
+    body: JSON.stringify(command),
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1364,6 +1364,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/praxis-write:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/pulsebot:
     devDependencies:
       openclaw:


### PR DESCRIPTION
## Summary

Phase-2 Slice 3 of the Praxis support agent: the **hardened write surface** in moltbot. Adds `extensions/praxis-write` with two operator tools — `praxis_unblock` and `praxis_cancel` — gated in **code**, not in the skill/prompt (the risk-first plan's central correction: a chat-reachable side-effecting surface must not rely on the model as its guardrail).

Pairs with the already-merged read plugin (`extensions/praxis`, #60) and the Praxis-side hardened command contract (praxis PR #31). The plugin is **dormant by default** — it does nothing until it is enabled, allowlisted in an agent's `tools.allow`, AND configured with an allowlist.

## What it does

- **Default-disabled.** No `enabledByDefault` in the manifest; both tools registered `optional: true` so per-agent allowlists must name them.
- **Code-enforced policy** (`policy.ts`): chat user/channel allowlist from plugin config; **fail-closed** when unconfigured or when the runtime supplies no requester identity.
- **Identity is trusted, not model-supplied.** `requested_by`/`channel` come from the OpenClaw tool context (`requesterSenderId`, delivery channel), never from tool args — a prompt cannot spoof who is asking (test covers this).
- **Two-step dry-run / confirm.** First call returns a preview + an HMAC confirm token keyed by the API token and bound to the issue's current `state`/`state_reason`/`version`. The model must preview to learn the token; a fabricated or stale (raced) confirm fails closed.
- **Actor-context propagation.** `requested_by`/`channel`/`message_id` flow into the `POST /api/v1/issues/<id>/events` body Praxis records as audit context; `idempotency_key` dedupes a double-fire.
- **Narrow + server-mirrored.** Sends only `kind` + `reason` + audit context (no client payload or `actor_id`); the server derives the unblock payload and binds authorization to its configured operator. `manual_override` is not reachable here (rejected client- and server-side).
- **Own thin REST client** (`praxis-write-client.ts`) — extensions are package-isolated, so the write plugin does not import the sibling read plugin.

## Enabling it (later, gated — not in this PR)

Live use on noob-root requires, all explicit: enable `plugins.entries.praxis-write.enabled`, add the two tools to the praxisbot agent's `tools.allow`, set `plugins.entries.praxis-write.config.allowedUsers`/`allowedChannels`, and bind `PRAXIS_REST_OPERATOR_ID` + an `ActorRole` on the Praxis side. This PR only lands the dormant capability.

## Verification

- `pnpm test extensions/praxis-write` — **31 passed** (policy gate, confirm token, client, plugin registration, dry-run/confirm flow, deny paths).
- `node scripts/run-oxlint.mjs extensions/praxis-write` — clean.
- `pnpm format:check extensions/praxis-write` — clean.

**Known gap (pre-existing, out of scope):** `pnpm tsgo:extensions` is red repo-wide on `development` — ~50 extension files (including the merged sibling `extensions/praxis/index.ts` and `zoomwarriors-write`, untouched here) fail with the same `AnyAgentTool` "label missing" pattern. The runtime `AgentTool` type requires `label` while every hand-rolled `registerTool(() => ({...}))` plugin omits it (`label` is optional in `src/agents/tools/common.ts:69`). This plugin matches the established sibling pattern exactly; it introduces no new failure class. The lane needs a separate repo-wide fix.
