### PR TITLE
feat(praxis-write): on-behalf-of UAT verdict + GitHub link tools

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -11,6 +11,8 @@ type ToolDef = {
 };
 
 const ISSUE = { id: 5, state: "blocked", state_reason: "no_response", version: 12 };
+const ISSUE_DEV_UAT = { id: 7, state: "dev_uat", state_reason: "", version: 3 };
+const ISSUE_USER_UAT = { id: 8, state: "user_uat", state_reason: "", version: 5 };
 
 function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Response {
   return {
@@ -70,10 +72,15 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the two write tools, both optional", () => {
+  it("registers exactly the four write tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
-    expect(Object.keys(tools).toSorted()).toEqual(["praxis_cancel", "praxis_unblock"]);
-    expect(registerOpts).toHaveLength(2);
+    expect(Object.keys(tools).toSorted()).toEqual([
+      "praxis_cancel",
+      "praxis_link_github",
+      "praxis_submit_verdict",
+      "praxis_unblock",
+    ]);
+    expect(registerOpts).toHaveLength(4);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -214,5 +221,251 @@ describe("praxis_cancel", () => {
     expect(out.preview).toBe(true);
     expect(out.action).toBe("duplicate");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("praxis_submit_verdict", () => {
+  it("fails policy gate when unconfigured", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c1", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "looks good",
+      }),
+    );
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported verdict value before any fetch", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c1", {
+        issue_id: 7,
+        verdict: "maybe",
+        reason: "not sure",
+      }),
+    );
+    expect(out.error).toBe("unsupported_verdict");
+    expect(out.allowed).toContain("pass");
+    expect(out.allowed).toContain("fail");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing reason before any fetch", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c1", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "  ",
+      }),
+    );
+    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns issue_not_awaiting_verdict when the issue state is not dev_uat or user_uat", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: ISSUE }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c1", {
+        issue_id: 5,
+        verdict: "pass",
+        reason: "looks good",
+      }),
+    );
+    expect(out.error).toBe("issue_not_awaiting_verdict");
+    expect(out.state).toBe("blocked");
+    expect(fetchMock).toHaveBeenCalledTimes(1); // only the GET
+    // No POST was sent
+    expect(
+      fetchMock.mock.calls.every(
+        (c: unknown[]) => (c[1] as RequestInit | undefined)?.method !== "POST",
+      ),
+    ).toBe(true);
+  });
+
+  it("submits uat1_pass for a dev_uat issue with verified Zoom identity", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_DEV_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "done" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c2", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "UAT complete, feature verified",
+      }),
+    );
+    expect(out).toEqual({ ok: true, status: 200, applied: true, state: "done" });
+
+    const post = fetchMock.mock.calls.find(
+      (c: unknown[]) => (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    if (!post) {
+      throw new Error("expected a POST call");
+    }
+    expect(post[0]).toBe("http://praxis:8000/api/v1/issues/7/events");
+    const body = JSON.parse((post[1] as RequestInit).body as string);
+    expect(body).toEqual({
+      kind: "uat1_pass",
+      reason: "UAT complete, feature verified",
+      requested_by: "alice",
+      channel: "zoom",
+      channel_user_id: "alice",
+    });
+  });
+
+  it("submits uat2_fail for a user_uat issue", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "in_progress" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c3", {
+        issue_id: 8,
+        verdict: "fail",
+        reason: "button still broken",
+      }),
+    );
+    expect(out.ok).toBe(true);
+
+    const post = fetchMock.mock.calls.find(
+      (c: unknown[]) => (c[1] as RequestInit | undefined)?.method === "POST",
+    );
+    if (!post) {
+      throw new Error("expected a POST call");
+    }
+    const body = JSON.parse((post[1] as RequestInit).body as string);
+    expect(body.kind).toBe("uat2_fail");
+    expect(body.channel).toBe("zoom");
+    expect(body.channel_user_id).toBe("alice");
+  });
+
+  it("surfaces identity_not_linked with a link instruction", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_DEV_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 403,
+          body: { error: "identity_not_linked" },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c4", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "looks good",
+      }),
+    );
+    expect(out.error).toBe("identity_not_linked");
+    expect(out.message).toMatch(/praxis_link_github/);
+  });
+
+  it("surfaces 403 unauthorized with a clear message", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_DEV_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 403,
+          body: { reason: "unauthorized" },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c5", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "looks good",
+      }),
+    );
+    expect(out.error).toBe("unauthorized");
+    expect(out.message).toMatch(/reporter or owner/);
+  });
+
+  it("denies when no requester identity in runtime context", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("c6", {
+        issue_id: 7,
+        verdict: "pass",
+        reason: "ok",
+        channel_user_id: "injected-by-model", // should be ignored
+      }),
+    );
+    expect(out.denied).toBe("no_requester_identity");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("praxis_link_github", () => {
+  it("fails policy gate when unconfigured", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(await tools.praxis_link_github.execute("c1", {}));
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("denies when no requester identity in runtime context", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(await tools.praxis_link_github.execute("c2", {}));
+    expect(out.denied).toBe("no_requester_identity");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts channel=zoom and channel_user_id from trusted context, returns the url", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { url: "https://github.com/login/oauth/authorize?state=xyz" },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_link_github.execute("c3", {}));
+    expect(out.ok).toBe(true);
+    expect(out.url).toBe("https://github.com/login/oauth/authorize?state=xyz");
+    expect(out.message).toContain("https://github.com/login/oauth/authorize?state=xyz");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://praxis:8000/api/v1/identity/link");
+    expect((init as RequestInit).method).toBe("POST");
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent).toEqual({ channel: "zoom", channel_user_id: "alice" });
+  });
+
+  it("surfaces linking_not_configured with a clear message", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 400, body: { error: "linking_not_configured" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_link_github.execute("c4", {}));
+    expect(out.error).toBe("linking_not_configured");
+    expect(out.message).toMatch(/not configured/);
+  });
+
+  it("surfaces identity_required as a configuration error", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 400, body: { error: "identity_required" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_link_github.execute("c5", {}));
+    expect(out.error).toBe("identity_required");
+    expect(out.message).toMatch(/configuration error/);
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -16,14 +16,23 @@ import {
 import {
   getApiToken,
   getIssue,
+  mapStateToUatKindPrefix,
   type PraxisIssueState,
+  startGithubLink,
   submitCommand,
+  submitVerdict,
+  type UatVerdictKind,
 } from "./praxis-write-client.js";
 
 // The cancel-family kinds Praxis accepts off-band. `manual_override` is deliberately
 // NOT here: it is too broad / terminal-state risky for a chat surface (spar MED) and is
 // rejected server-side too. `unblock` is its own tool.
 const CANCEL_KINDS = ["cancelled", "duplicate", "superseded", "source_closed"] as const;
+
+// The verdict values the model may supply; the tool maps them to the full kind
+// (uat1_pass / uat2_pass etc.) after reading the issue state.
+const VERDICT_VALUES = ["pass", "fail"] as const;
+type VerdictValue = (typeof VERDICT_VALUES)[number];
 
 const PraxisWriteConfigSchema = z.strictObject({
   allowedUsers: z.array(z.string()).optional(),
@@ -121,8 +130,9 @@ const plugin = {
   id: "praxis-write",
   name: "Praxis Write",
   description:
-    "Praxis operator write tools (hardened): unblock or cancel a stuck issue. Default-disabled, " +
-    "allowlist-gated, two-step dry-run/confirm.",
+    "Praxis operator write tools (hardened): unblock or cancel a stuck issue, submit UAT verdicts " +
+    "on behalf of the chat user, or start GitHub account linking. Default-disabled, " +
+    "allowlist-gated, two-step dry-run/confirm for destructive ops.",
   configSchema: buildPluginConfigSchema(PraxisWriteConfigSchema, {
     safeParse(value) {
       if (value === undefined) {
@@ -219,6 +229,202 @@ const plugin = {
           issueId: params.issue_id,
           actor,
           config,
+        });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_submit_verdict",
+      description:
+        "Submit a UAT verdict (pass or fail) on a Praxis issue on behalf of the chat user. The " +
+        "tool reads the issue's current state to determine the right UAT stage (dev_uat → uat1, " +
+        "user_uat → uat2) and rejects the call if the issue is not awaiting a verdict. The " +
+        "requester's verified Zoom identity is forwarded as channel_user_id — the server enforces " +
+        "that the identity is linked to a GitHub account with the reporter/owner role. If the " +
+        "identity is not linked, instruct the user to run praxis_link_github first. " +
+        "Allowlist-gated; no dry-run/confirm step (UAT states only exit on a human verdict, so " +
+        "the read→submit is race-safe). Deferred: needs_info answers (not wired server-side yet).",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+        verdict: Type.String({
+          description:
+            "pass — UAT succeeded; fail — UAT failed and the issue should return for fixes",
+        }),
+        reason: Type.String({
+          description: "Human-readable UAT verdict rationale (required, recorded for audit)",
+        }),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        // Policy gate: identity + allowlist
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+
+        // The verified Zoom sender id is the trusted identity we forward. Fail
+        // closed if the runtime didn't supply one (model cannot inject this).
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+
+        const verdictValue = typeof params.verdict === "string" ? params.verdict.trim() : "";
+        if (!(VERDICT_VALUES as readonly string[]).includes(verdictValue)) {
+          return jsonResult({
+            ok: false,
+            error: "unsupported_verdict",
+            allowed: VERDICT_VALUES,
+          });
+        }
+
+        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (!reason) {
+          return jsonResult({ ok: false, error: "reason_required" });
+        }
+
+        const issueId = Number(params.issue_id);
+        if (!Number.isInteger(issueId) || issueId <= 0) {
+          return jsonResult({ ok: false, error: "invalid_issue_id" });
+        }
+
+        // Read the issue state to determine the UAT kind prefix (uat1 or uat2).
+        // UAT states only exit on a human verdict, so reading then submitting is
+        // race-safe for this surface.
+        let issue: PraxisIssueState;
+        try {
+          issue = await getIssue(issueId);
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        const kindPrefix = mapStateToUatKindPrefix(issue.state);
+        if (!kindPrefix) {
+          return jsonResult({
+            ok: false,
+            error: "issue_not_awaiting_verdict",
+            state: issue.state,
+            message: `Issue #${issueId} is not awaiting a UAT verdict (state=${issue.state}). Only issues in dev_uat or user_uat can receive a verdict.`,
+          });
+        }
+
+        const kind: UatVerdictKind = `${kindPrefix}_${verdictValue as VerdictValue}`;
+
+        let res: Awaited<ReturnType<typeof submitVerdict>>;
+        try {
+          res = await submitVerdict(issueId, {
+            kind,
+            reason,
+            requested_by: channelUserId,
+            channel: "zoom",
+            channel_user_id: channelUserId,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        // Surface structured Praxis errors as user-friendly messages.
+        if (!res.ok) {
+          const body = res.data as Record<string, unknown>;
+          if (body.error === "identity_not_linked") {
+            return jsonResult({
+              ok: false,
+              error: "identity_not_linked",
+              message:
+                "Your Zoom identity is not yet linked to a GitHub account. " +
+                "Run praxis_link_github to get a link URL, tap it to authorize GitHub, then try again.",
+            });
+          }
+          if (res.status === 403) {
+            return jsonResult({
+              ok: false,
+              error: "unauthorized",
+              message:
+                "Your linked GitHub account does not have the reporter or owner role for this verdict. " +
+                "Contact an admin if you believe this is an error.",
+            });
+          }
+          if (body.error === "identity_required") {
+            return jsonResult({
+              ok: false,
+              error: "identity_required",
+              message:
+                "No verified identity was forwarded to Praxis. This is a configuration error.",
+            });
+          }
+        }
+
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_link_github",
+      description:
+        "Start a GitHub account linking flow for the chat user. Sends the user's verified Zoom " +
+        "identity to Praxis, which returns a URL the user must tap to authorize their GitHub account. " +
+        "Once linked, the user can submit UAT verdicts via praxis_submit_verdict. Takes no " +
+        "model-supplied identity arguments — the verified sender from the runtime context is used. " +
+        "Allowlist-gated.",
+      parameters: Type.Object({}),
+      async execute(toolCallId: string, _params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        // Policy gate: identity + allowlist
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+
+        let res: Awaited<ReturnType<typeof startGithubLink>>;
+        try {
+          res = await startGithubLink({ channel: "zoom", channel_user_id: channelUserId });
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        if (!res.ok) {
+          const body = res.data as Record<string, unknown>;
+          if (body.error === "linking_not_configured") {
+            return jsonResult({
+              ok: false,
+              error: "linking_not_configured",
+              message:
+                "GitHub linking is not configured on the Praxis server. " +
+                "Contact an admin to set up the GitHub OAuth app.",
+            });
+          }
+          if (body.error === "identity_required") {
+            return jsonResult({
+              ok: false,
+              error: "identity_required",
+              message:
+                "No verified identity was forwarded to Praxis. This is a configuration error.",
+            });
+          }
+        }
+
+        const body = res.data as Record<string, unknown>;
+        const url = typeof body.url === "string" ? body.url : undefined;
+        if (!url) {
+          return jsonResult({
+            ok: false,
+            error: "unexpected_response",
+            message: "Praxis did not return a linking URL. Contact an admin.",
+          });
+        }
+
+        return jsonResult({
+          ok: true,
+          status: res.status,
+          url,
+          message: `Tap this link to connect your GitHub account: ${url}`,
         });
       },
     }));

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "praxis-write",
   "name": "Praxis Write",
-  "description": "Praxis operator write tools (hardened): unblock or cancel a stuck issue. Default-disabled; each call is allowlist-gated, requires a reason, and runs a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "description": "Praxis operator write tools (hardened): unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -21,6 +21,8 @@
   "contracts": {
     "tools": [
       "praxis_cancel",
+      "praxis_link_github",
+      "praxis_submit_verdict",
       "praxis_unblock"
     ]
   }

--- a/extensions/praxis-write/praxis-write-client.test.ts
+++ b/extensions/praxis-write/praxis-write-client.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getApiToken, getIssue, praxisFetch, submitCommand } from "./praxis-write-client.js";
+import {
+  getApiToken,
+  getIssue,
+  mapStateToUatKindPrefix,
+  praxisFetch,
+  startGithubLink,
+  submitCommand,
+  submitVerdict,
+} from "./praxis-write-client.js";
 
 const BASE = "http://praxis:8000";
 
@@ -104,5 +112,96 @@ describe("submitCommand", () => {
     // No client-supplied payload or actor_id: the server derives + binds those.
     expect(sent.payload).toBeUndefined();
     expect(sent.actor_id).toBeUndefined();
+  });
+});
+
+describe("mapStateToUatKindPrefix", () => {
+  it("maps dev_uat to uat1", () => {
+    expect(mapStateToUatKindPrefix("dev_uat")).toBe("uat1");
+  });
+
+  it("maps user_uat to uat2", () => {
+    expect(mapStateToUatKindPrefix("user_uat")).toBe("uat2");
+  });
+
+  it("returns undefined for non-UAT states", () => {
+    expect(mapStateToUatKindPrefix("blocked")).toBeUndefined();
+    expect(mapStateToUatKindPrefix("in_progress")).toBeUndefined();
+    expect(mapStateToUatKindPrefix("done")).toBeUndefined();
+    expect(mapStateToUatKindPrefix("")).toBeUndefined();
+  });
+});
+
+describe("submitVerdict", () => {
+  it("POSTs the verdict body with channel_user_id and returns the raw result", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { applied: true, state: "done" } }),
+    );
+    const res = await submitVerdict(7, {
+      kind: "uat1_pass",
+      reason: "feature verified",
+      requested_by: "alice",
+      channel: "zoom",
+      channel_user_id: "alice",
+    });
+    expect(res).toEqual({ ok: true, status: 200, data: { applied: true, state: "done" } });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues/7/events`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({
+      kind: "uat1_pass",
+      reason: "feature verified",
+      requested_by: "alice",
+      channel: "zoom",
+      channel_user_id: "alice",
+    });
+  });
+
+  it("returns structured 403 on identity_not_linked without throwing", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
+    );
+    const res = await submitVerdict(7, {
+      kind: "uat2_fail",
+      reason: "broken",
+      requested_by: "alice",
+      channel: "zoom",
+      channel_user_id: "alice",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(403);
+    expect((res.data as Record<string, unknown>).error).toBe("identity_not_linked");
+  });
+});
+
+describe("startGithubLink", () => {
+  it("POSTs channel + channel_user_id and returns the url", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { url: "https://github.com/login/oauth/authorize?state=abc" },
+      }),
+    );
+    const res = await startGithubLink({ channel: "zoom", channel_user_id: "alice" });
+    expect(res.ok).toBe(true);
+    expect((res.data as Record<string, unknown>).url).toBe(
+      "https://github.com/login/oauth/authorize?state=abc",
+    );
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/identity/link`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({ channel: "zoom", channel_user_id: "alice" });
+  });
+
+  it("returns 400 linking_not_configured without throwing", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 400, body: { error: "linking_not_configured" } }),
+    );
+    const res = await startGithubLink({ channel: "zoom", channel_user_id: "alice" });
+    expect(res.ok).toBe(false);
+    expect((res.data as Record<string, unknown>).error).toBe("linking_not_configured");
   });
 });

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -97,3 +97,51 @@ export async function submitCommand(
     body: JSON.stringify(command),
   });
 }
+
+/** The UAT verdict kinds accepted by the events endpoint. uat1 = dev_uat stage,
+ * uat2 = user_uat stage. The correct kind is determined from the issue's current
+ * state, not passed by the model. */
+export type UatVerdictKind = "uat1_pass" | "uat1_fail" | "uat2_pass" | "uat2_fail";
+
+/** Map a Praxis issue state to its UAT kind prefix, or undefined when the issue
+ * is not currently awaiting a UAT verdict. Exported for testing. */
+export function mapStateToUatKindPrefix(state: string): "uat1" | "uat2" | undefined {
+  if (state === "dev_uat") {
+    return "uat1";
+  }
+  if (state === "user_uat") {
+    return "uat2";
+  }
+  return undefined;
+}
+
+/** Submit a UAT verdict event. `channel_user_id` is the verified Zoom sender id
+ * from the trusted runtime context — the server uses it for identity binding. */
+export async function submitVerdict(
+  issueId: number,
+  body: {
+    kind: UatVerdictKind;
+    reason: string;
+    requested_by: string;
+    channel: string;
+    channel_user_id: string;
+  },
+): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>(`/api/v1/issues/${issueId}/events`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/** Start a GitHub identity link flow for the given Zoom user. Returns the OAuth
+ * redirect URL the user must tap to authorize. The server binds the pending link
+ * to the channel_user_id so it resolves back to the right Zoom identity. */
+export async function startGithubLink(body: {
+  channel: string;
+  channel_user_id: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/identity/link", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## Summary
Adds two tools to the (default-disabled) `praxis-write` plugin so multiple chat users can act under **their own** GitHub identity instead of the bound operator's. Pairs with praxis PR cloudwarriors-ai/praxis#36 (server-side authz + Tier-2 verified linking).

- **`praxis_submit_verdict(issue_id, verdict, reason)`** — reads the issue state, maps `dev_uat`→`uat1` / `user_uat`→`uat2` (rejects when the issue isn't awaiting a verdict), and POSTs the verdict with the **verified** Zoom sender as `channel_user_id`. Identity is taken from the trusted tool context (`deriveActorContext().requestedBy`), **never a model arg**, and fails closed if absent. Surfaces `identity_not_linked` ("run praxis_link_github first") and `unauthorized` (role).
- **`praxis_link_github()`** — verified identity → `POST /api/v1/identity/link`, returns the tap-to-authorize URL.

Praxis resolves `channel_user_id` → `github_login` server-side and authorizes the human's real `ActorRole`; the chat layer never sends a login.

## Verification
- `52 vitest pass` (`node scripts/run-vitest.mjs extensions/praxis-write`)
- `oxlint` clean · `oxfmt --check` clean
- `pnpm tsgo:extensions` is pre-existing red repo-wide (hand-rolled `registerTool` plugins omit `label`); not introduced here.

## Notes
Branched fresh from `development` to avoid the squash-merge duplicate of the already-merged PR #61 base.

https://claude.ai/code/session_012SGoxRbwfHRcsSxFduetjs