### PR TITLE
fix(praxis-write): gate on room (deliveryContext.to) + add praxis_link_status

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -72,15 +72,16 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the four write tools, all optional", () => {
+  it("registers exactly the five write tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
       "praxis_link_github",
+      "praxis_link_status",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(4);
+    expect(registerOpts).toHaveLength(5);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -467,5 +468,47 @@ describe("praxis_link_github", () => {
     const out = parse(await tools.praxis_link_github.execute("c5", {}));
     expect(out.error).toBe("identity_required");
     expect(out.message).toMatch(/configuration error/);
+  });
+});
+
+describe("praxis_link_status", () => {
+  it("denies when no requester identity in runtime context", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(await tools.praxis_link_status.execute("c1", {}));
+    expect(out.denied).toBe("no_requester_identity");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports linked with the github login, GETting the verified identity", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { linked: true, github_login: "alice-gh" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_link_status.execute("c2", {}));
+    expect(out).toEqual({
+      ok: true,
+      linked: true,
+      github_login: "alice-gh",
+      message: "Your Zoom identity is linked to GitHub as alice-gh.",
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "http://praxis:8000/api/v1/identity/status?channel=zoom&channel_user_id=alice",
+    );
+    expect((init as RequestInit | undefined)?.method ?? "GET").toBe("GET");
+  });
+
+  it("reports not linked and points the user at praxis_link_github", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { linked: false, github_login: null } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_link_status.execute("c3", {}));
+    expect(out.ok).toBe(true);
+    expect(out.linked).toBe(false);
+    expect(out.message).toMatch(/praxis_link_github/);
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   getApiToken,
   getIssue,
+  getLinkStatus,
   mapStateToUatKindPrefix,
   type PraxisIssueState,
   startGithubLink,
@@ -425,6 +426,56 @@ const plugin = {
           status: res.status,
           url,
           message: `Tap this link to connect your GitHub account: ${url}`,
+        });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_link_status",
+      description:
+        "Check whether the chat user's verified identity is already linked to a GitHub account in " +
+        "Praxis. Uses the verified runtime identity (no model-supplied arguments) and returns whether " +
+        "they are linked and, if linked, the GitHub login. Use this to confirm a link succeeded or to " +
+        "decide whether to prompt the user to run praxis_link_github. Allowlist-gated.",
+      parameters: Type.Object({}),
+      async execute(toolCallId: string, _params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        // Policy gate: identity + allowlist
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+
+        let res: Awaited<ReturnType<typeof getLinkStatus>>;
+        try {
+          res = await getLinkStatus({ channel: "zoom", channel_user_id: channelUserId });
+        } catch (err) {
+          return errorResult(err);
+        }
+        if (!res.ok) {
+          return jsonResult({
+            ok: false,
+            status: res.status,
+            ...(res.data as Record<string, unknown>),
+          });
+        }
+
+        const body = res.data as Record<string, unknown>;
+        const linked = body.linked === true;
+        const githubLogin = typeof body.github_login === "string" ? body.github_login : undefined;
+        return jsonResult({
+          ok: true,
+          linked,
+          github_login: githubLogin,
+          message: linked
+            ? `Your Zoom identity is linked to GitHub as ${githubLogin}.`
+            : "Your Zoom identity is not linked to a GitHub account yet. Run praxis_link_github to link it.",
         });
       },
     }));

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -22,6 +22,7 @@
     "tools": [
       "praxis_cancel",
       "praxis_link_github",
+      "praxis_link_status",
       "praxis_submit_verdict",
       "praxis_unblock"
     ]

--- a/extensions/praxis-write/policy.test.ts
+++ b/extensions/praxis-write/policy.test.ts
@@ -116,6 +116,18 @@ describe("deriveActorContext", () => {
       toolCallId: "call-8",
     });
   });
+
+  it("gates on the room (deliveryContext.to), not the platform channel", () => {
+    // The runtime sets deliveryContext.channel to the PLATFORM ("zoom") and puts the specific
+    // room (the Zoom channel JID) in deliveryContext.to. The allowlist gates on the room, so `to`
+    // wins — gating on the platform would (wrongly) allow every Zoom channel. Regression guard.
+    const ctx = {
+      requesterSenderId: "alice",
+      messageChannel: "zoom",
+      deliveryContext: { channel: "zoom", to: "room-jid@conference.xmpp.zoom.us", threadId: 1 },
+    };
+    expect(deriveActorContext(ctx, "call-9").channel).toBe("room-jid@conference.xmpp.zoom.us");
+  });
 });
 
 describe("confirm token", () => {

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -20,7 +20,7 @@ import type { PraxisIssueState } from "./praxis-write-client.js";
 export interface ToolRequestContext {
   requesterSenderId?: string;
   messageChannel?: string;
-  deliveryContext?: { channel?: string; threadId?: string | number };
+  deliveryContext?: { channel?: string; to?: string; threadId?: string | number };
   sessionId?: string;
 }
 
@@ -58,7 +58,11 @@ export function resolveWritePolicyConfig(raw: unknown): WritePolicyConfig {
 /** Build the actor context from the TRUSTED runtime context, not tool args. The
  * model can pick the issue + reason, but never who/where the request came from. */
 export function deriveActorContext(ctx: ToolRequestContext, toolCallId: string): ActorContext {
-  const channel = ctx.deliveryContext?.channel ?? ctx.messageChannel ?? "";
+  // The room/peer is the gating identity for allowedChannels — the runtime puts the specific room
+  // (e.g. a Zoom channel JID) in deliveryContext.to, while deliveryContext.channel is the PLATFORM
+  // ("zoom"). Gate on the room; fall back to platform only when no peer is present.
+  const channel =
+    ctx.deliveryContext?.to ?? ctx.deliveryContext?.channel ?? ctx.messageChannel ?? "";
   const threadId = ctx.deliveryContext?.threadId;
   const messageId =
     threadId !== undefined && threadId !== null ? String(threadId) : (ctx.sessionId ?? "");

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -145,3 +145,17 @@ export async function startGithubLink(body: {
     body: JSON.stringify(body),
   });
 }
+
+/** Check whether a verified Zoom identity is linked to a GitHub account. The server
+ * resolves the caller's OWN forwarded channel_user_id, so it only ever returns that
+ * user's mapping. Returns { linked, github_login }. */
+export async function getLinkStatus(params: {
+  channel: string;
+  channel_user_id: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  const qs = new URLSearchParams({
+    channel: params.channel,
+    channel_user_id: params.channel_user_id,
+  }).toString();
+  return praxisFetch<Record<string, unknown>>(`/api/v1/identity/status?${qs}`);
+}


### PR DESCRIPTION
## Summary
Two changes from live testing of the verified-identity flow in `dev_praxis`:

1. **Channel-allowlist fix (live bug).** `deriveActorContext` gated `allowedChannels` against `deliveryContext.channel`, which the runtime sets to the **platform** (`"zoom"`) — the actual room JID lives in `deliveryContext.to`. So `allowedChannels` could never match and **every** write-family tool (`praxis_unblock`/`praxis_cancel`/`praxis_submit_verdict`/`praxis_link_github`) denied with `channel_not_allowlisted` in real chat. The CLI smokes never caught it because they bypass channel ingestion. Now gates on the room (`to`), falling back to platform only when no peer is present. Regression test added.

2. **`praxis_link_status` tool.** Lets the agent **validate** a user's link state (the gap found right after the OAuth round-trip worked). Uses the verified runtime identity (no model args), calls `GET /api/v1/identity/status`, and reports linked + the GitHub login, or points the user at `praxis_link_github`. Pairs with praxis cloudwarriors-ai/praxis#37.

## Verification
- `56 vitest pass` (`node scripts/run-vitest.mjs extensions/praxis-write`)
- `oxlint` + `oxfmt --check` clean
- The fix is already running as a live hotfix on noob-root; this lands it properly.

https://claude.ai/code/session_012SGoxRbwfHRcsSxFduetjs