### PR TITLE
feat(praxis-write): add praxis_onboard tool for conversational repo onboarding

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
-import { mintConfirmToken } from "./policy.js";
+import { mintConfirmToken, mintRepoConfirmToken } from "./policy.js";
 
 type ToolDef = {
   name: string;
@@ -72,16 +72,17 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the five write tools, all optional", () => {
+  it("registers exactly the six write tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
       "praxis_link_github",
       "praxis_link_status",
+      "praxis_onboard",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(5);
+    expect(registerOpts).toHaveLength(6);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -510,5 +511,103 @@ describe("praxis_link_status", () => {
     expect(out.ok).toBe(true);
     expect(out.linked).toBe(false);
     expect(out.message).toMatch(/praxis_link_github/);
+  });
+});
+
+describe("praxis_onboard", () => {
+  const REPO = "cloudwarriors-ai/foo";
+
+  it("fails closed when the allowlist is unconfigured (no fetch)", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(
+      await tools.praxis_onboard.execute("c1", { full_name: REPO, reason: "track it" }),
+    );
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a reason", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_onboard.execute("c1", { full_name: REPO, reason: " " }));
+    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a full_name without owner/name", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_onboard.execute("c1", { full_name: "no-slash", reason: "track it" }),
+    );
+    expect(out).toEqual({ ok: false, error: "invalid_full_name" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run previews and makes no HTTP call at all", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_onboard.execute("c1", { full_name: REPO, reason: "track it" }),
+    );
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("onboard");
+    expect(out.repo).toBe(REPO);
+    expect(out.backfill).toBe(true);
+    expect(typeof out.confirm_token).toBe("string");
+    // The onboard token is bound to repo+backfill (no issue GET), so a preview hits nothing.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a wrong confirm token re-previews instead of executing", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_onboard.execute("c1", {
+        full_name: REPO,
+        reason: "track it",
+        confirm: "deadbeefdeadbeef",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("executes on a valid confirm token, POSTing the onboard request", async () => {
+    const result = {
+      repo_id: 3,
+      full_name: REPO,
+      created: true,
+      backfilled: [{ source_issue: 1, state: "assessing" }],
+      state_counts: { assessing: 1 },
+      webhook: {
+        required: true,
+        url: "",
+        events: ["issues", "issue_comment"],
+        instructions: "...",
+      },
+    };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: result }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintRepoConfirmToken({ secret: "test-token", fullName: REPO, backfill: true });
+
+    const out = parse(
+      await tools.praxis_onboard.execute("c1", {
+        full_name: REPO,
+        maintainers: ["ann"],
+        reason: "track it",
+        confirm: token,
+      }),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.webhook.required).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/api/v1/repos/onboard");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(init?.body as string);
+    expect(sent).toEqual({
+      full_name: REPO,
+      maintainers: ["ann"],
+      owns_dispatch: false,
+      backfill: true,
+    });
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -10,6 +10,7 @@ import {
   deriveActorContext,
   idempotencyKey,
   mintConfirmToken,
+  mintRepoConfirmToken,
   resolveWritePolicyConfig,
   type WritePolicyConfig,
 } from "./policy.js";
@@ -18,6 +19,7 @@ import {
   getIssue,
   getLinkStatus,
   mapStateToUatKindPrefix,
+  onboardRepo,
   type PraxisIssueState,
   startGithubLink,
   submitCommand,
@@ -190,6 +192,107 @@ const plugin = {
           actor,
           config,
         });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_onboard",
+      description:
+        "Onboard an EXISTING GitHub repo into Praxis so its issues are tracked: registers the repo " +
+        "and (by default) backfills its current open issues through intake. Two steps: call first " +
+        "with full_name (+ optional maintainers / owns_dispatch / backfill) and a reason to get a " +
+        "dry-run preview and a confirm_token, then call again passing that token in `confirm` to " +
+        "execute. Does NOT create the GitHub webhook (that needs repo-admin Praxis lacks) — the " +
+        "result returns a webhook instruction for a repo admin to finish. Allowlist-gated; the " +
+        "human you are acting for is recorded for audit. If denied, surface the reason; do not retry.",
+      parameters: Type.Object({
+        full_name: Type.String({ description: "owner/name, e.g. cloudwarriors-ai/foo" }),
+        maintainers: Type.Optional(
+          Type.Array(Type.String(), {
+            description: "Repo-wide maintainer GitHub logins (optional)",
+          }),
+        ),
+        owns_dispatch: Type.Optional(
+          Type.Boolean({
+            description: "Praxis writes the dispatch label for this repo (default false)",
+          }),
+        ),
+        backfill: Type.Optional(
+          Type.Boolean({
+            description: "Ingest the repo's existing open issues through intake (default true)",
+          }),
+        ),
+        reason: Type.String({
+          description: "Operator justification for onboarding (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (!reason) {
+          return jsonResult({ ok: false, error: "reason_required" });
+        }
+        const fullName = typeof params.full_name === "string" ? params.full_name.trim() : "";
+        if (!fullName.includes("/")) {
+          return jsonResult({ ok: false, error: "invalid_full_name" });
+        }
+        const backfill = params.backfill === undefined ? true : params.backfill === true;
+        const ownsDispatch = params.owns_dispatch === true;
+        const maintainers = Array.isArray(params.maintainers)
+          ? params.maintainers.filter((m): m is string => typeof m === "string")
+          : [];
+
+        let token: string;
+        try {
+          token = getApiToken();
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        const expected = mintRepoConfirmToken({ secret: token, fullName, backfill });
+        const confirm = typeof params.confirm === "string" ? params.confirm : "";
+        if (!confirm || !confirmTokenMatches(confirm, expected)) {
+          return jsonResult({
+            ok: true,
+            preview: true,
+            action: "onboard",
+            repo: fullName,
+            backfill,
+            owns_dispatch: ownsDispatch,
+            maintainers,
+            requested_by: actor.requestedBy,
+            confirm_token: expected,
+            message:
+              `Dry run only — nothing changed. Re-call this tool with confirm="${expected}" to ` +
+              `onboard ${fullName}` +
+              (backfill ? " and backfill its open issues." : ".") +
+              " A repo admin must still create the GitHub webhook (instructions returned in the result).",
+          });
+        }
+
+        let res: Awaited<ReturnType<typeof onboardRepo>>;
+        try {
+          res = await onboardRepo({
+            full_name: fullName,
+            maintainers,
+            owns_dispatch: ownsDispatch,
+            backfill,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
       },
     }));
 

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "praxis-write",
   "name": "Praxis Write",
-  "description": "Praxis operator write tools (hardened): unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "description": "Praxis operator write tools (hardened): onboard a repo, unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -23,6 +23,7 @@
       "praxis_cancel",
       "praxis_link_github",
       "praxis_link_status",
+      "praxis_onboard",
       "praxis_submit_verdict",
       "praxis_unblock"
     ]

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -107,6 +107,19 @@ export function mintConfirmToken(params: {
   return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
 }
 
+/** Confirm token for repo onboarding. There is no issue state to bind to, so it binds to the
+ * repo + backfill flag. Derived from the API token secret, so the model cannot forge it without
+ * first calling the dry-run that returns it. */
+export function mintRepoConfirmToken(params: {
+  secret: string;
+  fullName: string;
+  backfill: boolean;
+}): string {
+  const { secret, fullName, backfill } = params;
+  const msg = `onboard:${fullName}:${backfill}`;
+  return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
+}
+
 /** Constant-time compare of a presented confirm token against the expected one. */
 export function confirmTokenMatches(presented: string, expected: string): boolean {
   const a = Buffer.from(presented);

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -159,3 +159,19 @@ export async function getLinkStatus(params: {
   }).toString();
   return praxisFetch<Record<string, unknown>>(`/api/v1/identity/status?${qs}`);
 }
+
+/** Onboard an EXISTING repo into Praxis: register it and (by default) backfill its open
+ * issues through the live intake path. The server does NOT create the GitHub webhook (that
+ * needs repo-admin the Praxis token lacks) — the result carries a `webhook` instruction for a
+ * repo admin to finish. Returns the raw result + HTTP status so the tool surfaces it verbatim. */
+export async function onboardRepo(body: {
+  full_name: string;
+  maintainers?: string[];
+  owns_dispatch?: boolean;
+  backfill?: boolean;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/repos/onboard", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## What
Adds **`praxis_onboard`** — a sixth hardened tool in the `praxis-write` extension — so an operator can onboard an existing repo into Praxis from chat: *"@Praxis Support onboard cloudwarriors-ai/foo — reason: tracking it"*. It registers the repo and backfills its open issues via the new Praxis `POST /api/v1/repos/onboard` endpoint, then returns the one webhook step a repo admin must finish.

## Guardrails (same model as the other write tools)
- **Allowlist-gated** (`checkPolicy`) + **required reason** + **two-step dry-run/confirm**.
- Identity from the trusted runtime context (`deriveActorContext`), never model args.
- **Repo-bound confirm token** (`mintRepoConfirmToken`) — there's no issue state to bind to, so it binds to repo+backfill, derived from the API token; the model can't forge it without the dry-run.
- Dry-run makes **zero HTTP calls**.
- `optional: true` / default-off — dormant until enabled + allowlisted + configured.

## Notes
- The webhook itself is **not** created by the tool (Praxis's token lacks `repository_hooks`); the result returns a webhook instruction for a repo admin.
- **Depends on cloudwarriors-ai/praxis#79** (the `/api/v1/repos/onboard` endpoint) being deployed before the tool functions. Since the tool is optional/default-off, this PR is inert until both land + it's enabled.

## Tests
- 6 new `praxis_onboard` tests (policy gate, reason, invalid full_name, dry-run-makes-no-fetch, wrong-token re-preview, valid-confirm POSTs the right body) + updated the "registers exactly N tools" assertion 5→6.
- Full extension suite: **62 passed**. oxfmt + oxlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)