### PR TITLE
Add praxis_self_heal bot tool (with operator note enrichment)

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
-import { mintConfirmToken, mintRepoConfirmToken } from "./policy.js";
+import { mintConfirmToken, mintRepoConfirmToken, mintSelfHealConfirmToken } from "./policy.js";
 
 type ToolDef = {
   name: string;
@@ -72,17 +72,18 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the six write tools, all optional", () => {
+  it("registers exactly the seven write tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
       "praxis_link_github",
       "praxis_link_status",
       "praxis_onboard",
+      "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(6);
+    expect(registerOpts).toHaveLength(7);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -608,6 +609,88 @@ describe("praxis_onboard", () => {
       maintainers: ["ann"],
       owns_dispatch: false,
       backfill: true,
+    });
+  });
+});
+
+describe("praxis_self_heal", () => {
+  const REPO = "cloudwarriors-ai/foo";
+
+  it("fails closed when the allowlist is unconfigured (no fetch)", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(await tools.praxis_self_heal.execute("c1", { reason: "scan" }));
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a reason", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_self_heal.execute("c1", { reason: " " }));
+    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown mode", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_self_heal.execute("c1", { mode: "explode", reason: "scan" }),
+    );
+    expect(out).toEqual({ ok: false, error: "invalid_mode" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run previews and makes no HTTP call at all", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_self_heal.execute("c1", { repo: REPO, reason: "scan" }));
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("self_heal");
+    expect(out.repo).toBe(REPO);
+    expect(out.mode).toBe("create-issues");
+    expect(typeof out.confirm_token).toBe("string");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("executes on a valid confirm token, POSTing the self-heal run", async () => {
+    const result = {
+      mode: "create-issues",
+      target_repo: REPO,
+      findings_detected: 2,
+      issues_created: 1,
+      issues_updated: 1,
+      errors: [],
+    };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: result }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintSelfHealConfirmToken({
+      secret: "test-token",
+      repo: REPO,
+      mode: "create-issues",
+    });
+
+    const out = parse(
+      await tools.praxis_self_heal.execute("c1", {
+        repo: REPO,
+        mode: "create-issues",
+        since_minutes: 90,
+        note: "Reporter flagged this after the deploy.",
+        reason: "scan",
+        confirm: token,
+      }),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.issues_created).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/api/v1/self-heal/run");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(init?.body as string);
+    expect(sent).toEqual({
+      repo: REPO,
+      mode: "create-issues",
+      since_minutes: 90,
+      notify: false,
+      note: "Reporter flagged this after the deploy.",
     });
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -11,6 +11,7 @@ import {
   idempotencyKey,
   mintConfirmToken,
   mintRepoConfirmToken,
+  mintSelfHealConfirmToken,
   resolveWritePolicyConfig,
   type WritePolicyConfig,
 } from "./policy.js";
@@ -21,6 +22,7 @@ import {
   mapStateToUatKindPrefix,
   onboardRepo,
   type PraxisIssueState,
+  runSelfHeal,
   startGithubLink,
   submitCommand,
   submitVerdict,
@@ -133,9 +135,10 @@ const plugin = {
   id: "praxis-write",
   name: "Praxis Write",
   description:
-    "Praxis operator write tools (hardened): unblock or cancel a stuck issue, submit UAT verdicts " +
-    "on behalf of the chat user, or start GitHub account linking. Default-disabled, " +
-    "allowlist-gated, two-step dry-run/confirm for destructive ops.",
+    "Praxis operator write tools (hardened): onboard a repo, run a self-heal scan that files " +
+    "deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts on behalf of the " +
+    "chat user, or start GitHub account linking. Default-disabled, allowlist-gated, two-step " +
+    "dry-run/confirm for onboarding/self-heal/destructive ops.",
   configSchema: buildPluginConfigSchema(PraxisWriteConfigSchema, {
     safeParse(value) {
       if (value === undefined) {
@@ -288,6 +291,120 @@ const plugin = {
             maintainers,
             owns_dispatch: ownsDispatch,
             backfill,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_self_heal",
+      description:
+        "Run a Praxis self-heal scan: detect recurring runtime failures from Praxis's own trace and " +
+        "(in create-issues mode, the default) file deduped GitHub issues into a repo. Two steps: " +
+        "call first with an optional repo/mode/since_minutes/min_occurrences and a reason to get a " +
+        "dry-run preview and a confirm_token, then call again passing that token in `confirm` to " +
+        "execute. mode create-issues writes GitHub issues; dry-run/record do not. Allowlist-gated; " +
+        "the human you are acting for is recorded for audit. If denied, surface the reason; do not retry.",
+      parameters: Type.Object({
+        repo: Type.Optional(
+          Type.String({
+            description:
+              "owner/name to file self-heal issues into (defaults to the configured " +
+              "self-heal repo)",
+          }),
+        ),
+        mode: Type.Optional(
+          Type.String({
+            description: "dry-run | record | create-issues (default create-issues)",
+          }),
+        ),
+        since_minutes: Type.Optional(
+          Type.Number({ description: "Trace window to scan, in minutes (default 60)" }),
+        ),
+        min_occurrences: Type.Optional(
+          Type.Number({ description: "Minimum recurrences before a finding is published" }),
+        ),
+        notify: Type.Optional(
+          Type.Boolean({ description: "Post a status update to the Praxis Zoom channel" }),
+        ),
+        note: Type.Optional(
+          Type.String({
+            description:
+              "Extra context to append to the filed issue(s) as an 'Operator Context' section " +
+              "(e.g. your analysis or the relevant chat detail). Optional but recommended.",
+          }),
+        ),
+        reason: Type.String({
+          description: "Operator justification for the self-heal run (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (!reason) {
+          return jsonResult({ ok: false, error: "reason_required" });
+        }
+        const repo = typeof params.repo === "string" ? params.repo.trim() : "";
+        const mode = typeof params.mode === "string" ? params.mode.trim() : "create-issues";
+        if (!["dry-run", "record", "create-issues"].includes(mode)) {
+          return jsonResult({ ok: false, error: "invalid_mode" });
+        }
+        const sinceMinutes =
+          typeof params.since_minutes === "number" ? params.since_minutes : undefined;
+        const minOccurrences =
+          typeof params.min_occurrences === "number" ? params.min_occurrences : undefined;
+        const notify = params.notify === true;
+        const note = typeof params.note === "string" ? params.note.trim() : "";
+
+        let token: string;
+        try {
+          token = getApiToken();
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        // Bind the confirm token to the repo+mode actually requested (empty repo => server default).
+        const expected = mintSelfHealConfirmToken({ secret: token, repo, mode });
+        const confirm = typeof params.confirm === "string" ? params.confirm : "";
+        if (!confirm || !confirmTokenMatches(confirm, expected)) {
+          return jsonResult({
+            ok: true,
+            preview: true,
+            action: "self_heal",
+            repo: repo || "(server default self-heal repo)",
+            mode,
+            requested_by: actor.requestedBy,
+            confirm_token: expected,
+            message:
+              `Dry run only — nothing changed. Re-call this tool with confirm="${expected}" to run ` +
+              `self-heal (mode=${mode})` +
+              (mode === "create-issues" ? " and file GitHub issues for recurring findings." : "."),
+          });
+        }
+
+        let res: Awaited<ReturnType<typeof runSelfHeal>>;
+        try {
+          res = await runSelfHeal({
+            ...(repo ? { repo } : {}),
+            mode,
+            ...(sinceMinutes !== undefined ? { since_minutes: sinceMinutes } : {}),
+            ...(minOccurrences !== undefined ? { min_occurrences: minOccurrences } : {}),
+            notify,
+            ...(note ? { note } : {}),
           });
         } catch (err) {
           return errorResult(err);

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "praxis-write",
   "name": "Praxis Write",
-  "description": "Praxis operator write tools (hardened): onboard a repo, unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "description": "Praxis operator write tools (hardened): onboard a repo, run a self-heal scan that files deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/self-heal/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -24,6 +24,7 @@
       "praxis_link_github",
       "praxis_link_status",
       "praxis_onboard",
+      "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock"
     ]

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -120,6 +120,18 @@ export function mintRepoConfirmToken(params: {
   return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
 }
 
+/** Confirm token for a self-heal run, bound to the target repo + mode so a dry-run preview can't be
+ * replayed against a different repo or a more destructive mode. */
+export function mintSelfHealConfirmToken(params: {
+  secret: string;
+  repo: string;
+  mode: string;
+}): string {
+  const { secret, repo, mode } = params;
+  const msg = `self-heal:${repo}:${mode}`;
+  return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
+}
+
 /** Constant-time compare of a presented confirm token against the expected one. */
 export function confirmTokenMatches(presented: string, expected: string): boolean {
   const a = Buffer.from(presented);

--- a/extensions/praxis-write/praxis-write-client.test.ts
+++ b/extensions/praxis-write/praxis-write-client.test.ts
@@ -4,6 +4,7 @@ import {
   getIssue,
   mapStateToUatKindPrefix,
   praxisFetch,
+  runSelfHeal,
   startGithubLink,
   submitCommand,
   submitVerdict,
@@ -203,5 +204,25 @@ describe("startGithubLink", () => {
     const res = await startGithubLink({ channel: "zoom", channel_user_id: "alice" });
     expect(res.ok).toBe(false);
     expect((res.data as Record<string, unknown>).error).toBe("linking_not_configured");
+  });
+});
+
+describe("runSelfHeal", () => {
+  it("POSTs the self-heal run body and returns the result", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { mode: "create-issues", target_repo: "cw/foo", issues_created: 1 },
+      }),
+    );
+    const res = await runSelfHeal({ repo: "cw/foo", mode: "create-issues", since_minutes: 90 });
+    expect(res.ok).toBe(true);
+    expect((res.data as Record<string, unknown>).issues_created).toBe(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/self-heal/run`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({ repo: "cw/foo", mode: "create-issues", since_minutes: 90 });
   });
 });

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -175,3 +175,17 @@ export async function onboardRepo(body: {
     body: JSON.stringify(body),
   });
 }
+
+export async function runSelfHeal(body: {
+  repo?: string;
+  mode?: string;
+  since_minutes?: number;
+  min_occurrences?: number;
+  notify?: boolean;
+  note?: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/self-heal/run", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}


### PR DESCRIPTION
## What

Adds the `praxis_self_heal` bot tool so the praxisbot can trigger a Praxis self-heal scan and file deduped GitHub issues from chat. The bot could already diagnose issues but had no tool to *create* a self-healing issue — that only existed as a management command run by the maintenance timer.

## How it works

Mirrors the hardened `praxis_onboard` pattern:
- Allowlist-gated, requires a `reason` (audited), two-step dry-run/confirm (confirm token bound to repo + mode).
- Calls the new Praxis endpoint `POST /api/v1/self-heal/run` (separate praxis PR).
- Params: `repo` (defaults to the server's self-heal repo), `mode` (dry-run | record | create-issues, default create-issues), `since_minutes`, `min_occurrences`, `notify`, and **`note`**.
- `note` is appended to the filed issue(s) as an "Operator Context" section, so the agent enriches the auto-detected finding with its own analysis / chat context rather than filing a trace-only issue.

## Gate

- 68 extension tests (incl. self-heal tool dry-run/confirm/deny/reason + client URL + note threading), oxfmt + oxlint clean.

## Deploy note

The tool is `optional: true` (default-off). To enable it for the praxisbot, add `praxis_self_heal` to the agent's `tools.allow` in `openclaw.json` (same as `praxis_onboard`).

Pairs with praxis PR #86 (the endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
