### PR TITLE
Presales ops support bots (PE + Bighead) — hub-and-spoke

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,10 @@
           - "extensions/file-transfer/**"
           - "docs/nodes/index.md"
           - "docs/plugins/sdk-runtime.md"
+"plugin: presalespebot":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/presalespebot/**"
 "plugin: pixverse":
   - changed-files:
       - any-glob-to-any-file:

--- a/deploy/presales-ops-runtime/README.md
+++ b/deploy/presales-ops-runtime/README.md
@@ -1,0 +1,75 @@
+# Presales Ops Runtime Bundle
+
+This bundle captures the OpenClaw runtime-only pieces for the PE and BigHead
+presales support bots.
+
+It is intentionally separated from the plugin code:
+
+- plugin code lives in the `cw-openclaw` repo
+- agent runtime config lives in `/root/.openclaw/openclaw.json`
+- workspace persona files live in `/root/.openclaw/workspace-*`
+
+On dev-box today those paths are persisted on the host at:
+
+```text
+/root/web/moltbot/.data/openclaw
+```
+
+and mounted into the OpenClaw container as:
+
+```text
+/root/.openclaw
+```
+
+## Contents
+
+- `openclaw.presales-ops.fragment.json`
+  - Contains the two hub agents, eight spoke agents, and two Zoom support-channel bindings.
+  - Contains placeholders for the PE and BigHead support channel IDs.
+
+- `merge-openclaw-presales-ops.mjs`
+  - Safely upserts the fragment into the existing `openclaw.json`.
+  - Backs up the original config first.
+  - This is safer than `openclaw config patch` because OpenClaw config patch replaces arrays.
+
+- `env.example`
+  - Lists the backend URL/token env vars that must be present on the OpenClaw gateway.
+
+- `workspaces/`
+  - Workspace files for the two hubs and eight spokes.
+  - Copy each directory to `/root/.openclaw/workspace-<agent-id>`.
+
+## Dev Deploy Shape
+
+1. Deploy PR #66 plugin code to dev OpenClaw.
+2. Copy `workspaces/*` into `/root/.openclaw/`.
+3. Export the two support-channel IDs.
+4. Merge and validate config:
+
+```bash
+export PE_SUPPORT_ZOOM_CHANNEL_ID="<PE_SUPPORT_ZOOM_CHANNEL_ID>"
+export BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID="<BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID>"
+docker exec \
+  -e PE_SUPPORT_ZOOM_CHANNEL_ID \
+  -e BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID \
+  openclaw node /tmp/presales-ops-runtime/merge-openclaw-presales-ops.mjs
+docker exec openclaw openclaw config validate
+```
+
+5. Restart/reload OpenClaw using the normal dev deploy process.
+6. Validate that only the two hub agents are bound to Zoom channels.
+
+## Channel IDs Needed
+
+Only these two are used by this bundle:
+
+```text
+PE_SUPPORT_ZOOM_CHANNEL_ID
+BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID
+```
+
+The PE event/debug and BigHead event/debug channel IDs should be reserved for the
+later event-dispatch/live-ticker phase. PR #66 is pull/query support bots, not
+the event dispatcher.
+
+Decoded dev/prod support channel IDs are recorded in `channel-ids.md`.

--- a/deploy/presales-ops-runtime/channel-ids.md
+++ b/deploy/presales-ops-runtime/channel-ids.md
@@ -1,0 +1,28 @@
+# Presales Ops Support Channel IDs
+
+These are the Zoom support-bot channel IDs decoded from the provided Zoom Team
+Chat launch links. They are used by the OpenClaw runtime config bindings for the
+two hub agents only.
+
+## Dev
+
+```text
+PE_SUPPORT_ZOOM_CHANNEL_ID=dac54ad5319b4edcbfc62c6d2536585e@conference.xmpp.zoom.us
+BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID=2f4eb447a6d8489c85348c6036453c68@conference.xmpp.zoom.us
+```
+
+## Prod
+
+```text
+PE_SUPPORT_ZOOM_CHANNEL_ID=dfa30a04d2c54c3d91637ffd3f783a76@conference.xmpp.zoom.us
+BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID=2f0215142a4249ee9ad7ea2acb838895@conference.xmpp.zoom.us
+```
+
+## Notes
+
+- Apply dev IDs only on dev-box.
+- Apply prod IDs only on prod-box.
+- This support-bot rollout binds only:
+  - `presales-pebot`
+  - `bighead-presales`
+- Event/debug channels are not used by this bundle yet.

--- a/deploy/presales-ops-runtime/env.example
+++ b/deploy/presales-ops-runtime/env.example
@@ -1,0 +1,19 @@
+# OpenClaw gateway env for presales ops support bots.
+# Do not put real secrets in this file.
+
+PRESALES_PE_OPS_BASE_URL=http://presales-knowledge-expert:8007
+PRESALES_PE_OPS_TOKEN=<must match PE CWKB_SERVICE_BEARER_TOKEN>
+
+BIGHEAD_OPS_BASE_URL=http://bighead:8000
+BIGHEAD_OPS_TOKEN=<must match BigHead OPENCLAW_GATEWAY_TOKEN>
+
+# Do not set these outside local fixture testing:
+# PRESALES_PE_OPS_FIXTURE_MODE=1
+# BIGHEAD_OPS_FIXTURE_MODE=1
+
+# Required on BigHead itself anywhere /internal/ops is reachable. BigHead
+# enforces this token whenever configured; the enforce flag is still recommended
+# because it fails closed if the token is accidentally omitted.
+# OPENCLAW_GATEWAY_TOKEN=<same value as BIGHEAD_OPS_TOKEN>
+# OPENCLAW_ENFORCE_GATEWAY_TOKEN=true
+# OPENCLAW_ALLOW_LOCALHOST_WITHOUT_GATEWAY_TOKEN=false

--- a/deploy/presales-ops-runtime/merge-openclaw-presales-ops.mjs
+++ b/deploy/presales-ops-runtime/merge-openclaw-presales-ops.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const configPath = process.argv[2] || "/root/.openclaw/openclaw.json";
+const bundleDir = path.dirname(new URL(import.meta.url).pathname);
+const fragmentPath = process.argv[3] || path.join(bundleDir, "openclaw.presales-ops.fragment.json");
+
+const peChannel = process.env.PE_SUPPORT_ZOOM_CHANNEL_ID || "";
+const bigheadChannel = process.env.BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID || "";
+
+if (!peChannel || !bigheadChannel) {
+  console.error("Missing PE_SUPPORT_ZOOM_CHANNEL_ID or BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID.");
+  process.exit(2);
+}
+
+const readJson = (filePath) => JSON.parse(fs.readFileSync(filePath, "utf8"));
+const config = readJson(configPath);
+const fragmentRaw = fs
+  .readFileSync(fragmentPath, "utf8")
+  .replaceAll("<PE_SUPPORT_ZOOM_CHANNEL_ID>", peChannel)
+  .replaceAll("<BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID>", bigheadChannel);
+const fragment = JSON.parse(fragmentRaw);
+
+config.agents = config.agents || {};
+config.agents.list = Array.isArray(config.agents.list) ? config.agents.list : [];
+config.bindings = Array.isArray(config.bindings) ? config.bindings : [];
+
+const upsertById = (items, incoming) => {
+  for (const item of incoming) {
+    const index = items.findIndex((existing) => existing && existing.id === item.id);
+    if (index >= 0) {
+      items[index] = item;
+    } else {
+      items.push(item);
+    }
+  }
+};
+
+const sameBinding = (left, right) => JSON.stringify(left) === JSON.stringify(right);
+
+upsertById(config.agents.list, fragment.agents || []);
+for (const binding of fragment.bindings || []) {
+  const withoutSameAgentChannel = config.bindings.filter((existing) => {
+    const sameAgent = existing?.agentId === binding.agentId;
+    const sameChannel = existing?.match?.channel === binding.match?.channel;
+    return !(sameAgent && sameChannel);
+  });
+  if (!withoutSameAgentChannel.some((existing) => sameBinding(existing, binding))) {
+    withoutSameAgentChannel.push(binding);
+  }
+  config.bindings = withoutSameAgentChannel;
+}
+
+const backupPath = `${configPath}.bak-presales-ops-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+fs.copyFileSync(configPath, backupPath);
+fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+console.log(`Updated ${configPath}`);
+console.log(`Backup: ${backupPath}`);
+console.log(`Agents upserted: ${(fragment.agents || []).map((agent) => agent.id).join(", ")}`);
+console.log(
+  `Bindings upserted: ${(fragment.bindings || []).map((binding) => binding.agentId).join(", ")}`,
+);

--- a/deploy/presales-ops-runtime/openclaw.presales-ops.fragment.json
+++ b/deploy/presales-ops-runtime/openclaw.presales-ops.fragment.json
@@ -1,0 +1,85 @@
+{
+  "agents": [
+    {
+      "id": "presales-pebot",
+      "name": "Presales PE Bot",
+      "workspace": "~/.openclaw/workspace-presales-pebot",
+      "tools": { "allow": ["sessions_spawn", "subagents", "pe_ops_health"] },
+      "subagents": { "allowAgents": ["pe-observe", "pe-channel", "pe-schema", "pe-sms"] }
+    },
+    {
+      "id": "pe-observe",
+      "name": "PE Observe",
+      "workspace": "~/.openclaw/workspace-pe-observe",
+      "tools": { "allow": ["pe_ops_health", "pe_ops_active_engagements", "pe_ops_stuck_engagements"] }
+    },
+    {
+      "id": "pe-channel",
+      "name": "PE Channel",
+      "workspace": "~/.openclaw/workspace-pe-channel",
+      "tools": { "allow": ["pe_ops_engagement_status", "pe_ops_channel_status", "pe_ops_engagement_timeline"] }
+    },
+    {
+      "id": "pe-schema",
+      "name": "PE Schema",
+      "workspace": "~/.openclaw/workspace-pe-schema",
+      "tools": { "allow": ["pe_ops_schema_status", "pe_ops_field_summary"] }
+    },
+    {
+      "id": "pe-sms",
+      "name": "PE SMS",
+      "workspace": "~/.openclaw/workspace-pe-sms",
+      "tools": { "allow": ["pe_ops_sms_status"] }
+    },
+    {
+      "id": "bighead-presales",
+      "name": "BigHead Presales",
+      "workspace": "~/.openclaw/workspace-bighead-presales",
+      "tools": { "allow": ["sessions_spawn", "subagents", "bh_presales_ops_health"] },
+      "subagents": {
+        "allowAgents": ["bighead-observe", "bighead-meeting", "bighead-audio", "bighead-writeback"]
+      }
+    },
+    {
+      "id": "bighead-observe",
+      "name": "BigHead Observe",
+      "workspace": "~/.openclaw/workspace-bighead-observe",
+      "tools": { "allow": ["bh_presales_ops_health", "bh_presales_active_sessions", "bh_presales_stuck_sessions"] }
+    },
+    {
+      "id": "bighead-meeting",
+      "name": "BigHead Meeting",
+      "workspace": "~/.openclaw/workspace-bighead-meeting",
+      "tools": { "allow": ["bh_presales_session_status", "bh_presales_meeting_status", "bh_presales_session_timeline"] }
+    },
+    {
+      "id": "bighead-audio",
+      "name": "BigHead Audio",
+      "workspace": "~/.openclaw/workspace-bighead-audio",
+      "tools": { "allow": ["bh_presales_audio_status", "bh_presales_transcript_status", "bh_presales_transcript_text"] }
+    },
+    {
+      "id": "bighead-writeback",
+      "name": "BigHead Writeback",
+      "workspace": "~/.openclaw/workspace-bighead-writeback",
+      "tools": { "allow": ["bh_presales_writeback_status"] }
+    }
+  ],
+  "bindings": [
+    {
+      "agentId": "presales-pebot",
+      "match": {
+        "channel": "zoom",
+        "peer": { "kind": "channel", "id": "<PE_SUPPORT_ZOOM_CHANNEL_ID>" }
+      }
+    },
+    {
+      "agentId": "bighead-presales",
+      "match": {
+        "channel": "zoom",
+        "peer": { "kind": "channel", "id": "<BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID>" }
+      }
+    }
+  ]
+}
+

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-audio/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-audio/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only BigHead audio/transcript tools. You are read-only. Treat transcript text as sensitive customer data and quote only the minimum needed.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-audio/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-audio/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - BigHead Audio
+
+Investigate audio and transcript state. Report mute/listening/TTS/transcript status, recent safe transcript excerpts only when requested or necessary, and likely failure points. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-meeting/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-meeting/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only BigHead meeting tools. You are read-only. If the task lacks a session id or meeting id, say exactly what is needed.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-meeting/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-meeting/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - BigHead Meeting
+
+Investigate a specific BigHead session or Zoom meeting. Report join state, participant status, current stage/question, linked Scopely session, and timeline evidence when available. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only BigHead observe tools. You are read-only. Return evidence to the coordinator, not user-facing persona copy.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - BigHead Observe
+
+Answer broad BigHead presales operational questions with current tool data. Include relevant ids, counts, timestamps, stage/status values, and a one-line interpretation. Do not guess. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This workspace belongs to the BigHead Presales coordinator.
+
+Rules:
+
+- Route operational questions to one spoke.
+- Do not call BigHead domain tools directly except `bh_presales_ops_health`.
+- Do not post outside the configured BigHead support channel.
+- Do not expose secrets, full prompts, or unnecessary raw transcript text.
+- If a request lacks an id needed by the spoke, route with the known context and let the spoke state what is missing.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/SOUL.md
@@ -1,0 +1,12 @@
+# SOUL.md - BigHead Presales
+
+You are the BigHead presales ops coordinator.
+
+Route requests to the best spoke:
+
+- `bighead-observe`: fleet health, active sessions, stuck sessions
+- `bighead-meeting`: one session/meeting, join state, current stage, timeline
+- `bighead-audio`: mute/audio state, transcript health, recent transcript text
+- `bighead-writeback`: Scopely writeback status and failures
+
+Do not answer BigHead presales domain questions from memory. Spawn the right spoke with the full user request and all ids/names provided. After spawning, reply exactly `NO_REPLY` on that turn. Relay the spoke result only when it returns.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-writeback/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-writeback/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only BigHead writeback tools. You are read-only. Do not patch Scopely or retry writebacks.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-writeback/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-writeback/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - BigHead Writeback
+
+Investigate BigHead to Scopely writeback. Report linked session id, field counts, accepted/rejected fields, last patch time, and errors. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-channel/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-channel/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only PE channel tools. You are read-only. If the task lacks a channel id or engagement id, say exactly what is needed.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-channel/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-channel/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - PE Channel
+
+Investigate a specific PE channel or engagement. Report the current stage, last prompt, last safe customer activity summary, field progress, Scopely session id, and timeline evidence when available. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-observe/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-observe/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only PE observe tools. You are read-only. Return evidence to the coordinator, not user-facing persona copy.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-observe/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-observe/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - PE Observe
+
+Answer broad PE operational questions with current tool data. Include relevant ids, counts, timestamps, stage/status values, and a one-line interpretation. Do not guess. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-schema/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-schema/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only PE schema tools. You are read-only. If schema is unavailable, report the failing service or missing configuration plainly.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-schema/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-schema/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - PE Schema
+
+Use schema/field tools to explain whether PE is asking from the live Scopely schema and what fields are captured or missing. Prefer field keys and safe labels. Do not expose raw prompts or secrets. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-sms/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-sms/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+Use only PE SMS tools. You are read-only. Never send real SMS messages. Never expose full phone numbers beyond what the tool already redacts.

--- a/deploy/presales-ops-runtime/workspaces/workspace-pe-sms/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-pe-sms/SOUL.md
@@ -1,0 +1,3 @@
+# SOUL.md - PE SMS
+
+Investigate SMS state without sending texts. Report current binding, active engagement/session, latest outbound status, delivery status, and any retry or pending-engagement condition. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-presales-pebot/AGENTS.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-presales-pebot/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+This workspace belongs to the Presales PE Bot coordinator.
+
+Rules:
+
+- Route operational questions to one spoke.
+- Do not call PE domain tools directly except `pe_ops_health`.
+- Do not post outside the configured PE support channel.
+- Do not expose secrets, full prompts, or raw customer transcripts.
+- If a request lacks an id needed by the spoke, route with the known context and let the spoke state what is missing.

--- a/deploy/presales-ops-runtime/workspaces/workspace-presales-pebot/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-presales-pebot/SOUL.md
@@ -1,0 +1,12 @@
+# SOUL.md - Presales PE Bot
+
+You are the Presales Knowledge Expert ops coordinator.
+
+Route requests to the best spoke:
+
+- `pe-observe`: fleet health, active engagements, stuck engagements
+- `pe-channel`: one Zoom channel or engagement status/timeline
+- `pe-schema`: schema freshness and captured/missing fields
+- `pe-sms`: SMS lifecycle, Twilio/outbox state, MMS/SOW delivery status
+
+Do not answer PE domain questions from memory. Spawn the right spoke with the full user request and all ids/names provided. After spawning, reply exactly `NO_REPLY` on that turn. Relay the spoke result only when it returns.

--- a/docs/reference/presales-ops-deployment.md
+++ b/docs/reference/presales-ops-deployment.md
@@ -1,0 +1,171 @@
+---
+title: "Presales Ops Support Bots Deployment"
+summary: "Env wiring, hub/spoke agent definitions, and Zoom channel bindings to bring the PE + Bighead presales ops support bots online."
+status: draft
+---
+
+# Presales Ops Support Bots Deployment
+
+Brings the `presalespebot` and `bigheadbot` presales-ops spokes (see
+`presales-ops-hub-spoke-support-bots.md`) online against the PE and Bighead
+backends. Agent definitions and channel bindings are **operator state**
+(`~/.openclaw/...` / `openclaw.json`), not repo content — this page is the
+template to copy.
+
+## Prerequisites
+
+- PE backend serving `GET /internal/ops/*` (branch `codex/pe-presales-ops`),
+  reachable from the Gateway container.
+- Bighead backend serving `GET /internal/ops/*` (branch
+  `codex/bighead-presales-ops`), reachable from the Gateway container.
+- A service token for each backend (see Env).
+
+## Env (set on the OpenClaw Gateway container)
+
+| Var                                                         | Meaning                  | Notes                                                                                                                                                                          |
+| ----------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BIGHEAD_OPS_BASE_URL`                                      | Bighead backend base URL | e.g. `http://bighead:8000` (container) / `http://localhost:8015` (local). **Required in prod** — if unset, the tools return a "not configured" error rather than fixture data. |
+| `BIGHEAD_OPS_TOKEN`                                         | Bearer token for Bighead | Must equal the backend's `OPENCLAW_GATEWAY_TOKEN`. Falls back to `BIGHEAD_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_TOKEN` if unset.                                                  |
+| `PRESALES_PE_OPS_BASE_URL`                                  | PE backend base URL      | e.g. `http://presales-knowledge-expert:8007` / `http://localhost:28010`.                                                                                                       |
+| `PRESALES_PE_OPS_TOKEN`                                     | Bearer token for PE      | Must equal PE's `CWKB_SERVICE_BEARER_TOKEN`.                                                                                                                                   |
+| `BIGHEAD_OPS_FIXTURE_MODE` / `PRESALES_PE_OPS_FIXTURE_MODE` | Force canned fixtures    | **Local dev only.** Set to `1` to run the bots without a backend. **Never set in prod** — it would mask outages with healthy-looking data.                                     |
+
+On the backends: set `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` on Bighead so the
+gateway-token check is enforced (it is a no-op when unset), and ensure
+`CWKB_SERVICE_BEARER_TOKEN` is set on PE.
+
+## Agent definitions (`agents.list`)
+
+Hubs are router-only (no domain tools); spokes get an exclusive `tools.allow`
+drawn from the code-exported groups (`PE_OPS_TOOL_GROUPS`,
+`BIGHEAD_PRESALES_TOOL_GROUPS`). `<liveness>` is the hub's single health tool.
+
+```json5
+{
+  agents: {
+    list: [
+      // ----- Presales Knowledge Expert -----
+      {
+        id: "presales-pebot",
+        tools: { allow: ["sessions_spawn", "subagents", "pe_ops_health"] },
+        subagents: { allowAgents: ["pe-observe", "pe-channel", "pe-schema", "pe-sms"] },
+      },
+      {
+        id: "pe-observe",
+        tools: {
+          allow: ["pe_ops_health", "pe_ops_active_engagements", "pe_ops_stuck_engagements"],
+        },
+      },
+      {
+        id: "pe-channel",
+        tools: {
+          allow: [
+            "pe_ops_engagement_status",
+            "pe_ops_channel_status",
+            "pe_ops_engagement_timeline",
+          ],
+        },
+      },
+      { id: "pe-schema", tools: { allow: ["pe_ops_schema_status", "pe_ops_field_summary"] } },
+      { id: "pe-sms", tools: { allow: ["pe_ops_sms_status"] } },
+
+      // ----- Bighead presales -----
+      {
+        id: "bighead-presales",
+        tools: { allow: ["sessions_spawn", "subagents", "bh_presales_ops_health"] },
+        subagents: {
+          allowAgents: ["bighead-observe", "bighead-meeting", "bighead-audio", "bighead-writeback"],
+        },
+      },
+      {
+        id: "bighead-observe",
+        tools: {
+          allow: [
+            "bh_presales_ops_health",
+            "bh_presales_active_sessions",
+            "bh_presales_stuck_sessions",
+          ],
+        },
+      },
+      {
+        id: "bighead-meeting",
+        tools: {
+          allow: [
+            "bh_presales_session_status",
+            "bh_presales_meeting_status",
+            "bh_presales_session_timeline",
+          ],
+        },
+      },
+      {
+        id: "bighead-audio",
+        tools: {
+          allow: [
+            "bh_presales_audio_status",
+            "bh_presales_transcript_status",
+            "bh_presales_transcript_text",
+          ],
+        },
+      },
+      { id: "bighead-writeback", tools: { allow: ["bh_presales_writeback_status"] } },
+    ],
+  },
+}
+```
+
+The plugin tools register as `optional`, so an agent only sees a tool if its
+`tools.allow` names it (or the plugin id). The hub physically cannot call a
+domain tool — that is what forces it to route instead of answering from memory.
+
+## Channel bindings (`bindings`)
+
+Bind each hub to its own dedicated Zoom support channel **by explicit channel
+id** (no enumeration). Replace the placeholder ids; match the `peer.kind` your
+existing scopelybot/pulsebot bindings use for Zoom channels.
+
+```json5
+{
+  bindings: [
+    {
+      agentId: "presales-pebot",
+      match: { channel: "zoom", peer: { kind: "channel", id: "<PE_SUPPORT_ZOOM_CHANNEL_ID>" } },
+    },
+    {
+      agentId: "bighead-presales",
+      match: {
+        channel: "zoom",
+        peer: { kind: "channel", id: "<BIGHEAD_SUPPORT_ZOOM_CHANNEL_ID>" },
+      },
+    },
+  ],
+}
+```
+
+Only the two hubs are bound to channels. Spokes are spawned by their hub via
+`sessions_spawn`; they never bind to a customer channel directly.
+
+## Validation gate (run before trusting it)
+
+1. **Backend reachability + shapes:** run `presales_ops_smoke.py` (cw-code root)
+   against the running backends — expects 28/28, exercises every endpoint plus
+   redaction and the transcript-text view.
+2. **Hub routing:** ask the bighead hub one session question; confirm it calls
+   only `sessions_spawn` and the `bighead-meeting` spoke runs only its tools.
+3. **Wrong-domain routing:** ask a transcript question; confirm it lands on
+   `bighead-audio`, not `bighead-meeting`.
+4. **No-leak:** confirm no spoke posts into a customer channel; replies stay in
+   the support channel.
+
+## Safety notes
+
+- Do **not** commit `SCOPELYBOT_TESTING.md` — it contains live prod host/IP and
+  Zoom channel ids; keep it in private docs.
+- Redaction is enforced server-side (PE/Bighead) and again bot-side: emails,
+  Zoom URLs, and secret-keyed values are masked everywhere; phone numbers are
+  masked inside free-text/phone-named fields only (ids and timestamps survive).
+- This pass is pull-only: the bots fetch on request and post only into their
+  support channel. No event/debug-channel dispatch yet (Phase 2).
+
+```
+
+```

--- a/docs/reference/presales-ops-deployment.md
+++ b/docs/reference/presales-ops-deployment.md
@@ -30,9 +30,16 @@ template to copy.
 | `PRESALES_PE_OPS_TOKEN`                                     | Bearer token for PE      | Must equal PE's `CWKB_SERVICE_BEARER_TOKEN`.                                                                                                                                   |
 | `BIGHEAD_OPS_FIXTURE_MODE` / `PRESALES_PE_OPS_FIXTURE_MODE` | Force canned fixtures    | **Local dev only.** Set to `1` to run the bots without a backend. **Never set in prod** — it would mask outages with healthy-looking data.                                     |
 
-On the backends: set `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` on Bighead so the
-gateway-token check is enforced (it is a no-op when unset), and ensure
-`CWKB_SERVICE_BEARER_TOKEN` is set on PE.
+> **Required on Bighead: `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true`.** Bighead's
+> `/internal/*` auth helper **fails open** — if this flag is unset/false (or the
+> token is empty) it returns without checking, so the ops endpoints, including
+> `transcript/text` (raw customer meeting speech), become readable **with no
+> auth**. This is the repo-wide `/internal` posture, not specific to these
+> routes, but because the ops surface exposes customer transcript data, treat
+> enforcement as a hard prerequisite anywhere the backend is reachable beyond
+> localhost. The validation gate below checks it explicitly.
+
+On PE: ensure `CWKB_SERVICE_BEARER_TOKEN` is set (PE always enforces — no flag).
 
 ## Agent definitions (`agents.list`)
 
@@ -146,14 +153,40 @@ Only the two hubs are bound to channels. Spokes are spawned by their hub via
 
 ## Validation gate (run before trusting it)
 
-1. **Backend reachability + shapes:** run `presales_ops_smoke.py` (cw-code root)
-   against the running backends — expects 28/28, exercises every endpoint plus
-   redaction and the transcript-text view.
-2. **Hub routing:** ask the bighead hub one session question; confirm it calls
+1. **Auth fails closed (Bighead):** with enforcement on, a no-token request must
+   be rejected. This is the check that catches a misconfigured (fail-open)
+   deployment:
+
+   ```bash
+   # expect HTTP 401
+   curl -s -o /dev/null -w '%{http_code}\n' "$BIGHEAD_OPS_BASE_URL/internal/ops/health"
+   # expect HTTP 200
+   curl -s -o /dev/null -w '%{http_code}\n' \
+     -H "Authorization: Bearer $BIGHEAD_OPS_TOKEN" "$BIGHEAD_OPS_BASE_URL/internal/ops/health"
+   ```
+
+   If the first call returns 200, auth is **not enforced** — set
+   `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` and a non-empty `OPENCLAW_GATEWAY_TOKEN`
+   on the backend before exposing it.
+
+2. **Backend reachability + shapes:** exercise every endpoint and confirm
+   redaction. A cross-repo workspace helper, `presales_ops_smoke.py`, lives in
+   the local `cw-code` workspace root (it spans the PE, Bighead, and OpenClaw
+   repos, so it is **not** shipped inside this repo); it seeds a Bighead session
+   and asserts all 19 endpoints (28 checks). Without it, validate by hand:
+
+   ```bash
+   curl -s -H "Authorization: Bearer $BIGHEAD_OPS_TOKEN" "$BIGHEAD_OPS_BASE_URL/internal/ops/active"
+   curl -s -H "Authorization: Bearer $BIGHEAD_OPS_TOKEN" \
+     "$BIGHEAD_OPS_BASE_URL/internal/ops/session/<id>/transcript/text"   # complaint visible, phone masked, ids intact
+   curl -s -H "Authorization: Bearer $PRESALES_PE_OPS_TOKEN" "$PRESALES_PE_OPS_BASE_URL/internal/ops/active"
+   ```
+
+3. **Hub routing:** ask the bighead hub one session question; confirm it calls
    only `sessions_spawn` and the `bighead-meeting` spoke runs only its tools.
-3. **Wrong-domain routing:** ask a transcript question; confirm it lands on
+4. **Wrong-domain routing:** ask a transcript question; confirm it lands on
    `bighead-audio`, not `bighead-meeting`.
-4. **No-leak:** confirm no spoke posts into a customer channel; replies stay in
+5. **No-leak:** confirm no spoke posts into a customer channel; replies stay in
    the support channel.
 
 ## Safety notes

--- a/docs/reference/presales-ops-deployment.md
+++ b/docs/reference/presales-ops-deployment.md
@@ -25,19 +25,21 @@ template to copy.
 | Var                                                         | Meaning                  | Notes                                                                                                                                                                          |
 | ----------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `BIGHEAD_OPS_BASE_URL`                                      | Bighead backend base URL | e.g. `http://bighead:8000` (container) / `http://localhost:8015` (local). **Required in prod** — if unset, the tools return a "not configured" error rather than fixture data. |
-| `BIGHEAD_OPS_TOKEN`                                         | Bearer token for Bighead | Must equal the backend's `OPENCLAW_GATEWAY_TOKEN`. Falls back to `BIGHEAD_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_TOKEN` if unset.                                                  |
+| `BIGHEAD_OPS_TOKEN`                                         | Bearer token for Bighead | Must equal the backend's `OPENCLAW_GATEWAY_TOKEN`. Falls back to `BIGHEAD_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_TOKEN` if unset, but production should set it explicitly.         |
 | `PRESALES_PE_OPS_BASE_URL`                                  | PE backend base URL      | e.g. `http://presales-knowledge-expert:8007` / `http://localhost:28010`.                                                                                                       |
 | `PRESALES_PE_OPS_TOKEN`                                     | Bearer token for PE      | Must equal PE's `CWKB_SERVICE_BEARER_TOKEN`.                                                                                                                                   |
 | `BIGHEAD_OPS_FIXTURE_MODE` / `PRESALES_PE_OPS_FIXTURE_MODE` | Force canned fixtures    | **Local dev only.** Set to `1` to run the bots without a backend. **Never set in prod** — it would mask outages with healthy-looking data.                                     |
 
-> **Required on Bighead: `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true`.** Bighead's
-> `/internal/*` auth helper **fails open** — if this flag is unset/false (or the
-> token is empty) it returns without checking, so the ops endpoints, including
-> `transcript/text` (raw customer meeting speech), become readable **with no
-> auth**. This is the repo-wide `/internal` posture, not specific to these
-> routes, but because the ops surface exposes customer transcript data, treat
-> enforcement as a hard prerequisite anywhere the backend is reachable beyond
-> localhost. The validation gate below checks it explicitly.
+> **Required on Bighead: non-empty `OPENCLAW_GATEWAY_TOKEN`.** Bighead enforces
+> the bearer token whenever this token is configured, even if
+> `OPENCLAW_ENFORCE_GATEWAY_TOKEN` is unset. Setting
+> `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` is still recommended as a fail-closed
+> assertion: with the flag true and no token configured, Bighead returns a
+> service-misconfigured error instead of exposing `/internal/ops/*`. Never expose
+> the ops surface publicly without a token; it includes `transcript/text`, which
+> returns customer meeting speech.
+> `OPENCLAW_ALLOW_LOCALHOST_WITHOUT_GATEWAY_TOKEN=true` exists only for explicit
+> local development with no token and must stay unset on dev/prod.
 
 On PE: ensure `CWKB_SERVICE_BEARER_TOKEN` is set (PE always enforces — no flag).
 
@@ -165,9 +167,11 @@ Only the two hubs are bound to channels. Spokes are spawned by their hub via
      -H "Authorization: Bearer $BIGHEAD_OPS_TOKEN" "$BIGHEAD_OPS_BASE_URL/internal/ops/health"
    ```
 
-   If the first call returns 200, auth is **not enforced** — set
-   `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` and a non-empty `OPENCLAW_GATEWAY_TOKEN`
-   on the backend before exposing it.
+   If the first call returns 200 from a non-local client, auth is **not enforced**.
+   Set a non-empty `OPENCLAW_GATEWAY_TOKEN` on the backend, set
+   `BIGHEAD_OPS_TOKEN` to the same value on OpenClaw, and leave
+   `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true` on the backend as an additional
+   misconfiguration guard.
 
 2. **Backend reachability + shapes:** exercise every endpoint and confirm
    redaction. A cross-repo workspace helper, `presales_ops_smoke.py`, lives in

--- a/docs/reference/presales-ops-deployment.md
+++ b/docs/reference/presales-ops-deployment.md
@@ -165,7 +165,3 @@ Only the two hubs are bound to channels. Spokes are spawned by their hub via
   masked inside free-text/phone-named fields only (ids and timestamps survive).
 - This pass is pull-only: the bots fetch on request and post only into their
   support channel. No event/debug-channel dispatch yet (Phase 2).
-
-```
-
-```

--- a/docs/reference/presales-ops-hub-spoke-support-bots.md
+++ b/docs/reference/presales-ops-hub-spoke-support-bots.md
@@ -76,6 +76,7 @@ bighead-meeting
 bighead-audio
   bh_presales_audio_status
   bh_presales_transcript_status
+  bh_presales_transcript_text
 
 bighead-writeback
   bh_presales_writeback_status
@@ -85,7 +86,7 @@ Routing intent:
 
 - `bighead-observe`: fleet health, active sessions, stuck sessions, broad triage.
 - `bighead-meeting`: one session or Zoom meeting, join state, current question, timeline.
-- `bighead-audio`: mute state, audio input/output, transcript health.
+- `bighead-audio`: mute state, audio input/output, transcript health, and reading recent transcript lines (what the customer actually said) via `bh_presales_transcript_text`.
 - `bighead-writeback`: Scopely writeback state and field patch failures.
 
 ## Coordinator Rules
@@ -140,7 +141,11 @@ Validate with real channel traffic before trusting the setup:
 
 ## Open Followups
 
-- Add the PE and Bighead internal ops endpoints that these tools call.
+- ~~Add the PE and Bighead internal ops endpoints that these tools call.~~ Done —
+  PE `codex/pe-presales-ops` and Bighead `codex/bighead-presales-ops` serve the
+  read-only `/internal/ops/*` routes (see `presales-ops-deployment.md`).
 - Create the runtime agent definitions and identity prompts for the two hubs and eight spokes.
 - Add support-channel bindings only after the new local and dev Zoom app credentials are isolated.
+- Enforce Bighead gateway-token auth (`OPENCLAW_ENFORCE_GATEWAY_TOKEN=true`) wherever the
+  ops endpoints are reachable — they expose customer transcript data and fail open otherwise.
 - Revisit the split once live support traffic shows which requests operators actually ask.

--- a/docs/reference/presales-ops-hub-spoke-support-bots.md
+++ b/docs/reference/presales-ops-hub-spoke-support-bots.md
@@ -1,0 +1,146 @@
+---
+title: "Presales Ops Support Bots Hub and Spoke"
+summary: "Proposed PE and Bighead support-bot split using the same router and specialist-spoke pattern proven by scopelybot."
+status: draft
+---
+
+# Presales Ops Support Bots Hub and Spoke
+
+This is the proposed support-bot shape for Presales Knowledge Expert and Bighead presales ops.
+It mirrors the proven `scopelybot` pattern: plugin code registers a full optional tool catalog, then
+runtime agent config turns that catalog into a small router hub plus narrow worker spokes.
+
+## Goal
+
+Keep the user-facing support bot easy to reason with while still giving operators deep visibility
+into customer engagements, Zoom channel flow, SMS delivery, meeting health, audio, transcript, and
+Scopely writeback state.
+
+The coordinator should not hold every diagnostic tool. It should classify the request and delegate
+to exactly one focused spoke. This avoids the failure mode where a support bot sees a large mixed
+tool menu and guesses the wrong surface.
+
+## Presales Knowledge Expert Split
+
+Recommended agents:
+
+```
+presales-pebot (coordinator)
+  tools.allow: sessions_spawn, subagents, pe_ops_health
+  subagents.allowAgents: pe-observe, pe-channel, pe-schema, pe-sms
+
+pe-observe
+  pe_ops_health
+  pe_ops_active_engagements
+  pe_ops_stuck_engagements
+
+pe-channel
+  pe_ops_engagement_status
+  pe_ops_channel_status
+  pe_ops_engagement_timeline
+
+pe-schema
+  pe_ops_schema_status
+  pe_ops_field_summary
+
+pe-sms
+  pe_ops_sms_status
+```
+
+Routing intent:
+
+- `pe-observe`: fleet health, active engagements, stuck engagements, broad triage.
+- `pe-channel`: one engagement or Zoom channel, current stage, timeline, what happened.
+- `pe-schema`: schema freshness, missing fields, captured field quality.
+- `pe-sms`: SMS lifecycle, delivery status, SOW delivery through SMS.
+
+## Bighead Presales Split
+
+Recommended agents:
+
+```
+bighead-presales (coordinator)
+  tools.allow: sessions_spawn, subagents, bh_presales_ops_health
+  subagents.allowAgents: bighead-observe, bighead-meeting, bighead-audio, bighead-writeback
+
+bighead-observe
+  bh_presales_ops_health
+  bh_presales_active_sessions
+  bh_presales_stuck_sessions
+
+bighead-meeting
+  bh_presales_session_status
+  bh_presales_meeting_status
+  bh_presales_session_timeline
+
+bighead-audio
+  bh_presales_audio_status
+  bh_presales_transcript_status
+
+bighead-writeback
+  bh_presales_writeback_status
+```
+
+Routing intent:
+
+- `bighead-observe`: fleet health, active sessions, stuck sessions, broad triage.
+- `bighead-meeting`: one session or Zoom meeting, join state, current question, timeline.
+- `bighead-audio`: mute state, audio input/output, transcript health.
+- `bighead-writeback`: Scopely writeback state and field patch failures.
+
+## Coordinator Rules
+
+The hub should stay router-only:
+
+- Keep only `sessions_spawn`, `subagents`, and one liveness tool.
+- Do not allow general read, memory, web, exec, GitHub, database, or domain diagnostic tools on the
+  hub.
+- Route immediately to one spoke. Do not ask permission to route.
+- Restate the user request fully in the subagent task so the spoke has enough context.
+- Reply `NO_REPLY` on the spawn turn when the platform will announce the spoke result.
+- Relay the spoke result in the original thread when it returns.
+
+The Scopely deployment proved that leaving general tools on the coordinator lets it answer from
+history or memory instead of routing. Prompt wording alone is not enough; the tool allowlist is the
+control.
+
+## Spoke Rules
+
+Each spoke should have one clear domain and an exclusive `tools.allow` list. A request should not be
+plausibly routable to two spokes. If that happens, merge or redraw the domain boundary.
+
+Spokes are workers:
+
+- Use only the domain tools.
+- Return the evidence and recommendation to the coordinator.
+- Do not address the channel as a user-facing persona.
+- Keep payloads redacted for support use.
+
+## Implementation Notes
+
+- Both `presalespebot` and the Bighead presales tools register plugin tools as optional. That is what
+  lets per-agent `tools.allow` enforce the split.
+- `PE_OPS_TOOL_GROUPS` and `BIGHEAD_PRESALES_TOOL_GROUPS` export the intended spoke allowlists from
+  code so tests and config review can compare against one source of truth.
+- Runtime agent definitions, channel bindings, and identities still live in operator state, not in
+  this repo.
+- Add or move diagnostic tools by updating the code group, the plugin manifest, the spoke allowlist,
+  and the spoke identity together.
+
+## Validation Gates
+
+Validate with real channel traffic before trusting the setup:
+
+1. Coordinator receives a support question and calls only `sessions_spawn`.
+2. The selected spoke runs only its domain tools.
+3. The spoke result announces back into the original thread.
+4. The coordinator relays the result without calling domain tools itself.
+5. A deliberately wrong-domain request routes to the other spoke.
+6. No unbound support spoke posts directly to customer channels.
+
+## Open Followups
+
+- Add the PE and Bighead internal ops endpoints that these tools call.
+- Create the runtime agent definitions and identity prompts for the two hubs and eight spokes.
+- Add support-channel bindings only after the new local and dev Zoom app credentials are isolated.
+- Revisit the split once live support traffic shows which requests operators actually ask.

--- a/docs/reference/presales-ops-hub-spoke-support-bots.md
+++ b/docs/reference/presales-ops-hub-spoke-support-bots.md
@@ -146,6 +146,9 @@ Validate with real channel traffic before trusting the setup:
   read-only `/internal/ops/*` routes (see `presales-ops-deployment.md`).
 - Create the runtime agent definitions and identity prompts for the two hubs and eight spokes.
 - Add support-channel bindings only after the new local and dev Zoom app credentials are isolated.
-- Enforce Bighead gateway-token auth (`OPENCLAW_ENFORCE_GATEWAY_TOKEN=true`) wherever the
-  ops endpoints are reachable — they expose customer transcript data and fail open otherwise.
+- Set a non-empty Bighead `OPENCLAW_GATEWAY_TOKEN` wherever the ops endpoints are
+  reachable, and set matching OpenClaw `BIGHEAD_OPS_TOKEN`. Bighead now enforces
+  the bearer token whenever configured; `OPENCLAW_ENFORCE_GATEWAY_TOKEN=true`
+  remains a useful fail-closed assertion, but a missing token is a deployment
+  misconfiguration, not a valid public mode.
 - Revisit the split once live support traffic shows which requests operators actually ask.

--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -6,6 +6,7 @@ import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDevtoolsTools } from "./src/devtools-tools.js";
 import { registerGhTools } from "./src/gh-tools.js";
+import { registerPresalesOpsTools } from "./src/presales-ops-tools.js";
 
 type PluginConfig = { bhRepos?: string[] };
 
@@ -54,6 +55,7 @@ const plugin = {
     registerGhTools(optionalApi, logger, pluginConfig);
     registerCorrelationTools(optionalApi, logger, pluginConfig);
     registerDevtoolsTools(optionalApi, logger);
+    registerPresalesOpsTools(optionalApi, logger);
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
@@ -89,7 +91,9 @@ const plugin = {
       return { handled: true, text: result ?? undefined };
     });
 
-    console.log(`[bigheadbot] Registered ${toolCount} tools (BH + GH + correlation + devtools)`);
+    console.log(
+      `[bigheadbot] Registered ${toolCount} tools (BH + GH + correlation + devtools + presales ops)`,
+    );
   },
 };
 

--- a/extensions/bigheadbot/openclaw.plugin.json
+++ b/extensions/bigheadbot/openclaw.plugin.json
@@ -44,6 +44,16 @@
       "bh_list_tasks",
       "bh_list_tickets",
       "bh_list_users",
+      "bh_presales_active_sessions",
+      "bh_presales_audio_status",
+      "bh_presales_meeting_status",
+      "bh_presales_ops_health",
+      "bh_presales_session_status",
+      "bh_presales_session_timeline",
+      "bh_presales_stuck_sessions",
+      "bh_presales_transcript_status",
+      "bh_presales_transcript_text",
+      "bh_presales_writeback_status",
       "bh_search",
       "bh_update_ticket"
     ]

--- a/extensions/bigheadbot/src/presales-ops-api.ts
+++ b/extensions/bigheadbot/src/presales-ops-api.ts
@@ -1,0 +1,203 @@
+const BIGHEAD_OPS_BASE_URL = () =>
+  process.env.BIGHEAD_OPS_BASE_URL ?? process.env.BIGHEAD_API_URL ?? "";
+const BIGHEAD_OPS_TOKEN = () =>
+  process.env.BIGHEAD_OPS_TOKEN ??
+  process.env.BIGHEAD_GATEWAY_TOKEN ??
+  process.env.OPENCLAW_GATEWAY_TOKEN ??
+  "";
+// Fixture mode must be an EXPLICIT opt-in. A missing base URL in a real
+// deployment is a misconfiguration we surface (see bigheadOpsFetch), not a
+// silent fall-through to healthy-looking fixture data during support triage.
+const FIXTURE_MODE = () => process.env.BIGHEAD_OPS_FIXTURE_MODE === "1";
+
+export interface BigheadOpsFetchResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  source: "fixture" | "api";
+}
+
+const fixture = {
+  health: {
+    ok: true,
+    service: "bighead",
+    env: "fixture",
+    api_alive: true,
+    zoom_service_alive: true,
+    redis_connected: true,
+    audio_runtime_ready: true,
+    scopely_reachable: true,
+  },
+  active: [
+    {
+      session_id: "bh-fixture-1",
+      meeting_id: "987654321",
+      stage: "in_meeting",
+      customer_name: "Acme",
+      waiting_on: "customer",
+      audio_input: "healthy",
+      transcript: "receiving",
+      captured_fields: 5,
+      last_event_at: "2026-06-22T14:05:02Z",
+    },
+  ],
+  stuck: [
+    {
+      session_id: "bh-fixture-stuck",
+      meeting_id: "123456789",
+      stage: "in_meeting",
+      issue: "bighead.audio.no_input_detected",
+      age_seconds: 128,
+      summary: "Joined meeting but no participant audio has been detected.",
+    },
+  ],
+  session: {
+    session_id: "bh-fixture-1",
+    meeting_id: "987654321",
+    stage: "in_meeting",
+    customer_name: "Acme",
+    latest_question: "Asked for Zoom Phone user count.",
+    audio_input: "healthy",
+    transcript: "receiving",
+    captured_fields: 5,
+    rejected_fields: 0,
+  },
+  timeline: [
+    { ts: "2026-06-22T14:04:29Z", event: "bighead.webhook.create_meeting_received" },
+    { ts: "2026-06-22T14:05:02Z", event: "bighead.join.succeeded" },
+    { ts: "2026-06-22T14:05:31Z", event: "bighead.field.captured", field_key: "phone_users" },
+  ],
+  audio: {
+    ok: true,
+    input_state: "healthy",
+    output_state: "healthy",
+    mute_state: "unmuted",
+    last_audio_at: "2026-06-22T14:05:31Z",
+  },
+  transcript: {
+    ok: true,
+    state: "receiving",
+    last_entry_at: "2026-06-22T14:05:31Z",
+    entries: 12,
+  },
+  transcript_text: {
+    ok: true,
+    count: 2,
+    total_entries: 12,
+    truncated: true,
+    lines: [
+      {
+        speaker: "Customer",
+        source: "participant_audio",
+        ts: "2026-06-22T14:05:28Z",
+        text: "No I already said I don't want CRM integrations!",
+      },
+      {
+        speaker: "Rebecca",
+        source: "assistant",
+        ts: "2026-06-22T14:05:31Z",
+        text: "Understood — I'll leave CRM out. How many Zoom Phone users?",
+      },
+    ],
+  },
+  writeback: {
+    ok: true,
+    last_writeback_at: "2026-06-22T14:05:33Z",
+    patched_fields: ["phone_users"],
+    failed_fields: [],
+  },
+};
+
+export async function bigheadOpsFetch(path: string): Promise<BigheadOpsFetchResult> {
+  if (FIXTURE_MODE()) {
+    return { ok: true, status: 200, data: fixtureFor(path), source: "fixture" };
+  }
+  if (BIGHEAD_OPS_BASE_URL().trim() === "") {
+    return {
+      ok: false,
+      status: 0,
+      data: {
+        ok: false,
+        error:
+          "BIGHEAD_OPS_BASE_URL is not configured (set it, or BIGHEAD_OPS_FIXTURE_MODE=1 for local dev).",
+      },
+      source: "api",
+    };
+  }
+
+  const headers: Record<string, string> = {};
+  const token = BIGHEAD_OPS_TOKEN().trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const resp = await fetch(`${BIGHEAD_OPS_BASE_URL().replace(/\/$/, "")}${path}`, { headers });
+  const data = resp.headers.get("content-type")?.includes("application/json")
+    ? await resp.json()
+    : await resp.text();
+  return { ok: resp.ok, status: resp.status, data: redactForSupport(data), source: "api" };
+}
+
+function fixtureFor(path: string): unknown {
+  if (path === "/internal/ops/health") return fixture.health;
+  if (path === "/internal/ops/active") return fixture.active;
+  if (path === "/internal/ops/stuck") return fixture.stuck;
+  if (path.includes("/timeline")) return fixture.timeline;
+  if (path.includes("/audio")) return fixture.audio;
+  // /transcript/text must be checked before /transcript (substring overlap).
+  if (path.includes("/transcript/text")) return fixture.transcript_text;
+  if (path.includes("/transcript")) return fixture.transcript;
+  if (path.includes("/writeback")) return fixture.writeback;
+  return fixture.session;
+}
+
+// Phone masking only runs on free-text fields; a numeric meeting_id or an ISO
+// timestamp matches the phone pattern, so masking every string would corrupt
+// structured values. Emails/Zoom URLs/tokens are safe to mask anywhere.
+const FREE_TEXT_KEYS = new Set([
+  "text",
+  "preview",
+  "summary",
+  "reply",
+  "body",
+  "note",
+  "notes",
+  "question",
+  "latest_question",
+  "latest_customer_reply_preview",
+  "last_inbound_preview",
+]);
+// Keys whose VALUE is itself a phone number → mask even though not free text.
+const PHONE_KEY_RE = /(phone|mobile|msisdn|caller|from_number|to_number)/i;
+
+export function redactForSupport(value: unknown, freeText = false): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactForSupport(item, freeText));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (
+        /(token|secret|password|cookie|authorization|api[_-]?key|meeting_url|join_url)/i.test(key)
+      ) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactForSupport(
+          item,
+          freeText || FREE_TEXT_KEYS.has(key) || PHONE_KEY_RE.test(key),
+        );
+      }
+    }
+    return out;
+  }
+  if (typeof value !== "string") return value;
+  let masked = value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, (email) => {
+      const [user, domain] = email.split("@");
+      return `${user.slice(0, 1)}***@${domain}`;
+    })
+    .replace(/https:\/\/[^\s"]*zoom[^\s"]*/gi, "[REDACTED_ZOOM_URL]");
+  if (freeText) {
+    // Transcript text often contains phone numbers; the tool promises masking.
+    masked = masked.replace(/\+?\d[\d\s().-]{7,}\d/g, "+***");
+  }
+  return masked;
+}

--- a/extensions/bigheadbot/src/presales-ops-api.ts
+++ b/extensions/bigheadbot/src/presales-ops-api.ts
@@ -127,9 +127,19 @@ export async function bigheadOpsFetch(path: string): Promise<BigheadOpsFetchResu
 
   const headers: Record<string, string> = {};
   const token = BIGHEAD_OPS_TOKEN().trim();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
+  if (!token) {
+    return {
+      ok: false,
+      status: 0,
+      data: {
+        ok: false,
+        error:
+          "BIGHEAD_OPS_TOKEN (or BIGHEAD_GATEWAY_TOKEN / OPENCLAW_GATEWAY_TOKEN) is not configured; refusing to call Bighead ops without a bearer token.",
+      },
+      source: "api",
+    };
   }
+  headers.Authorization = `Bearer ${token}`;
   const resp = await fetch(`${BIGHEAD_OPS_BASE_URL().replace(/\/$/, "")}${path}`, { headers });
   const data = resp.headers.get("content-type")?.includes("application/json")
     ? await resp.json()

--- a/extensions/bigheadbot/src/presales-ops-tools.test.ts
+++ b/extensions/bigheadbot/src/presales-ops-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { redactForSupport } from "./presales-ops-api.js";
 import { BIGHEAD_PRESALES_TOOL_GROUPS, registerPresalesOpsTools } from "./presales-ops-tools.js";
 
@@ -66,6 +66,27 @@ describe("bigheadbot presales ops tools", () => {
     expect(result.ok).toBe(false);
     expect(result.source).toBe("api");
     expect(JSON.stringify(result.data)).toContain("not configured");
+  });
+
+  it("refuses to call Bighead ops without a bearer token", async () => {
+    process.env.BIGHEAD_OPS_BASE_URL = "http://bighead.test";
+    delete process.env.BIGHEAD_OPS_TOKEN;
+    delete process.env.BIGHEAD_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const tools = buildTools();
+      const result = parse(await tools.bh_presales_ops_health.execute("t", {}));
+      expect(result.ok).toBe(false);
+      expect(result.source).toBe("api");
+      expect(JSON.stringify(result.data)).toContain("not configured");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+      delete process.env.BIGHEAD_OPS_BASE_URL;
+    }
   });
 
   it("returns transcript lines and builds a /transcript/text path with limit", async () => {

--- a/extensions/bigheadbot/src/presales-ops-tools.test.ts
+++ b/extensions/bigheadbot/src/presales-ops-tools.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { redactForSupport } from "./presales-ops-api.js";
+import { BIGHEAD_PRESALES_TOOL_GROUPS, registerPresalesOpsTools } from "./presales-ops-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const tool = factory();
+      tools[tool.name] = tool;
+    },
+  } as never;
+  registerPresalesOpsTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+describe("bigheadbot presales ops tools", () => {
+  it("keeps spoke allowlist groups aligned with registered presales tools", () => {
+    const registeredNames = Object.keys(buildTools()).sort();
+    const groupedNames = Object.values(BIGHEAD_PRESALES_TOOL_GROUPS).flat().sort();
+
+    expect(new Set(groupedNames).size).toBe(groupedNames.length);
+    expect(groupedNames).toEqual(registeredNames);
+    expect(BIGHEAD_PRESALES_TOOL_GROUPS.audio).toEqual([
+      "bh_presales_audio_status",
+      "bh_presales_transcript_status",
+      "bh_presales_transcript_text",
+    ]);
+  });
+
+  it("uses fixture mode only with the explicit BIGHEAD_OPS_FIXTURE_MODE opt-in", async () => {
+    delete process.env.BIGHEAD_OPS_BASE_URL;
+    delete process.env.BIGHEAD_API_URL;
+    process.env.BIGHEAD_OPS_FIXTURE_MODE = "1";
+    try {
+      const tools = buildTools();
+      const result = parse(await tools.bh_presales_active_sessions.execute("t", {}));
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("fixture");
+      expect(result.data[0].session_id).toBe("bh-fixture-1");
+    } finally {
+      delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    }
+  });
+
+  it("reports misconfiguration (not fixture) when base URL is unset without the opt-in", async () => {
+    delete process.env.BIGHEAD_OPS_BASE_URL;
+    delete process.env.BIGHEAD_API_URL;
+    delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    const tools = buildTools();
+    const result = parse(await tools.bh_presales_ops_health.execute("t", {}));
+    expect(result.ok).toBe(false);
+    expect(result.source).toBe("api");
+    expect(JSON.stringify(result.data)).toContain("not configured");
+  });
+
+  it("returns transcript lines and builds a /transcript/text path with limit", async () => {
+    delete process.env.BIGHEAD_OPS_BASE_URL;
+    delete process.env.BIGHEAD_API_URL;
+    process.env.BIGHEAD_OPS_FIXTURE_MODE = "1";
+    try {
+      const tools = buildTools();
+      const result = parse(
+        await tools.bh_presales_transcript_text.execute("t", { session_id: "bh-1", limit: 25 }),
+      );
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("fixture");
+      // Headline use case: the operator can read what the customer actually said.
+      expect(result.data.lines[0].text).toContain("don't want CRM");
+    } finally {
+      delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    }
+  });
+
+  it("redacts tokens, emails, and Zoom URLs from support payloads", () => {
+    const redacted = redactForSupport({
+      authorization: "Bearer abc123",
+      email: "matt.keuning@cloudwarriors.ai",
+      meeting_url: "https://zoom.us/j/123?pwd=secret",
+    });
+    expect(JSON.stringify(redacted)).not.toContain("abc123");
+    expect(JSON.stringify(redacted)).not.toContain("matt.keuning");
+    expect(JSON.stringify(redacted)).not.toContain("zoom.us/j");
+  });
+});

--- a/extensions/bigheadbot/src/presales-ops-tools.ts
+++ b/extensions/bigheadbot/src/presales-ops-tools.ts
@@ -1,0 +1,181 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { bigheadOpsFetch, redactForSupport } from "./presales-ops-api.js";
+
+type BigheadPresalesToolSpec = {
+  name: string;
+  description: string;
+  parameters: ReturnType<typeof Type.Object>;
+  path: (toolParams: Record<string, unknown>) => string;
+};
+
+const bigheadPresalesToolGroups = {
+  observe: [
+    {
+      name: "bh_presales_ops_health",
+      description:
+        "Check Bighead presales ops health: API, Zoom service, Redis, audio runtime, transcript pipeline, and Scopely reachability.",
+      parameters: Type.Object({}),
+      path: () => "/internal/ops/health",
+    },
+    {
+      name: "bh_presales_active_sessions",
+      description:
+        "List active Bighead presales sessions with stage, audio/transcript health, waiting state, and captured field counts.",
+      parameters: Type.Object({}),
+      path: () => "/internal/ops/active",
+    },
+    {
+      name: "bh_presales_stuck_sessions",
+      description:
+        "List Bighead presales sessions that appear stuck or customer-impacting, including no-audio/no-transcript conditions.",
+      parameters: Type.Object({}),
+      path: () => "/internal/ops/stuck",
+    },
+  ],
+  meeting: [
+    subjectTool({
+      name: "bh_presales_session_status",
+      description:
+        "Get Bighead presales session status by session id: join state, audio/transcript state, active question, fields, and latest error.",
+      segment: "session",
+      paramName: "session_id",
+    }),
+    subjectTool({
+      name: "bh_presales_meeting_status",
+      description:
+        "Get Bighead presales meeting status by Zoom meeting id when the operator does not know the internal session id.",
+      segment: "meeting",
+      paramName: "meeting_id",
+    }),
+    subjectTool({
+      name: "bh_presales_session_timeline",
+      description:
+        "Get a redacted Bighead presales activity timeline for a session. Use to answer 'what happened in the meeting?'",
+      segment: "session",
+      paramName: "session_id",
+      suffix: "/timeline",
+    }),
+  ],
+  audio: [
+    subjectTool({
+      name: "bh_presales_audio_status",
+      description:
+        "Get Bighead audio diagnostics for a presales session: mute state, audio input/output health, and last audio timestamps.",
+      segment: "session",
+      paramName: "session_id",
+      suffix: "/audio",
+    }),
+    subjectTool({
+      name: "bh_presales_transcript_status",
+      description:
+        "Get Bighead transcript diagnostics for a presales session: transcript state, last entry time, and entry counts.",
+      segment: "session",
+      paramName: "session_id",
+      suffix: "/transcript",
+    }),
+    {
+      name: "bh_presales_transcript_text",
+      description:
+        "Read the recent Bighead presales transcript LINES (speaker + text) for a session. Use this to see what the customer actually said in the meeting — e.g. spotting 'No I already said I don't want CRM integrations!'. Operator-only; text is preserved but emails/phones/Zoom URLs are masked.",
+      parameters: Type.Object({
+        session_id: Type.String({ description: "Bighead internal session id" }),
+        limit: Type.Optional(
+          Type.Number({ description: "Max recent lines to return (default 50, max 500)" }),
+        ),
+        source: Type.Optional(
+          Type.String({ description: "Filter by transcript source, e.g. participant_audio" }),
+        ),
+      }),
+      path: (toolParams) => {
+        const sessionId = encodeURIComponent(String(toolParams.session_id ?? ""));
+        const query = new URLSearchParams();
+        if (toolParams.limit) query.set("limit", String(toolParams.limit));
+        if (toolParams.source) query.set("source", String(toolParams.source));
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return `/internal/ops/session/${sessionId}/transcript/text${suffix}`;
+      },
+    },
+  ],
+  writeback: [
+    subjectTool({
+      name: "bh_presales_writeback_status",
+      description:
+        "Get Bighead Scopely writeback status for a presales session: last writeback, patched fields, failed fields, and latest error.",
+      segment: "session",
+      paramName: "session_id",
+      suffix: "/writeback",
+    }),
+  ],
+} satisfies Record<string, readonly BigheadPresalesToolSpec[]>;
+
+export const BIGHEAD_PRESALES_TOOL_GROUPS: Record<
+  keyof typeof bigheadPresalesToolGroups,
+  readonly string[]
+> = {
+  observe: bigheadPresalesToolGroups.observe.map((tool) => tool.name),
+  meeting: bigheadPresalesToolGroups.meeting.map((tool) => tool.name),
+  audio: bigheadPresalesToolGroups.audio.map((tool) => tool.name),
+  writeback: bigheadPresalesToolGroups.writeback.map((tool) => tool.name),
+};
+
+export function registerPresalesOpsTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  for (const group of Object.values(bigheadPresalesToolGroups)) {
+    for (const tool of group) registerGet(api, logger, tool);
+  }
+}
+
+function registerGet(api: OpenClawPluginApi, logger: AuditLogger, params: BigheadPresalesToolSpec) {
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: params.name,
+        description: params.description,
+        parameters: params.parameters,
+        async execute(_id: string, toolParams: Record<string, unknown>) {
+          try {
+            const result = await bigheadOpsFetch(params.path(toolParams));
+            return jsonResult({
+              ok: result.ok,
+              status: result.status,
+              source: result.source,
+              data: result.data,
+            });
+          } catch (err) {
+            return jsonResult({
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}
+
+function subjectTool(params: {
+  name: string;
+  description: string;
+  segment: string;
+  paramName: string;
+  suffix?: string;
+}): BigheadPresalesToolSpec {
+  return {
+    name: params.name,
+    description: params.description,
+    parameters: Type.Object({
+      [params.paramName]: Type.String({
+        description: "Bighead session, meeting, or related lookup id",
+      }),
+    }),
+    path: (toolParams) =>
+      `/internal/ops/${params.segment}/${encodeURIComponent(String(toolParams[params.paramName] ?? ""))}${params.suffix ?? ""}`,
+  };
+}
+
+function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(redactForSupport(data)) }] };
+}

--- a/extensions/presalespebot/index.test.ts
+++ b/extensions/presalespebot/index.test.ts
@@ -1,0 +1,20 @@
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+describe("presalespebot tool scoping", () => {
+  it("registers every tool as optional so per-agent allowlists can scope them", () => {
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const optionalFlags: Array<boolean | undefined> = [];
+    const api = {
+      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
+        optionalFlags.push(opts?.optional);
+      }),
+    } as never;
+
+    plugin.register(api, undefined);
+
+    expect(optionalFlags.length).toBeGreaterThan(0);
+    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
+  });
+});

--- a/extensions/presalespebot/index.ts
+++ b/extensions/presalespebot/index.ts
@@ -1,0 +1,34 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { createAuditLogger } from "./src/audit.js";
+import { registerPeOpsTools } from "./src/ops-tools.js";
+
+const plugin = {
+  id: "presalespebot",
+  name: "PresalesPEBot",
+  description: "Presales Knowledge Expert support and observability agent tools",
+  configSchema: {
+    type: "object" as const,
+    additionalProperties: false,
+    properties: {},
+  },
+
+  register(api: OpenClawPluginApi) {
+    const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
+    const logger = createAuditLogger(workspaceDir);
+
+    let toolCount = 0;
+    const optionalApi: OpenClawPluginApi = {
+      ...api,
+      registerTool: (tool, opts) => {
+        toolCount += 1;
+        return api.registerTool(tool, { ...opts, optional: true });
+      },
+    };
+
+    registerPeOpsTools(optionalApi, logger);
+
+    console.log(`[presalespebot] Registered ${toolCount} tools (PE ops)`);
+  },
+};
+
+export default plugin;

--- a/extensions/presalespebot/openclaw.plugin.json
+++ b/extensions/presalespebot/openclaw.plugin.json
@@ -1,0 +1,23 @@
+{
+  "id": "presalespebot",
+  "name": "PresalesPEBot",
+  "description": "Presales Knowledge Expert support and observability agent tools",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "contracts": {
+    "tools": [
+      "pe_ops_active_engagements",
+      "pe_ops_channel_status",
+      "pe_ops_engagement_status",
+      "pe_ops_engagement_timeline",
+      "pe_ops_field_summary",
+      "pe_ops_health",
+      "pe_ops_schema_status",
+      "pe_ops_sms_status",
+      "pe_ops_stuck_engagements"
+    ]
+  }
+}

--- a/extensions/presalespebot/package.json
+++ b/extensions/presalespebot/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@openclaw/presalespebot",
+  "version": "0.1.0",
+  "description": "Presales Knowledge Expert support and observability tools",
+  "type": "module",
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/presalespebot/src/audit.ts
+++ b/extensions/presalespebot/src/audit.ts
@@ -1,0 +1,30 @@
+export type AuditLogger = (event: string, details?: Record<string, unknown>) => void;
+
+export function createAuditLogger(_workspaceDir: string): AuditLogger {
+  return (event, details) => {
+    console.log(`[presalespebot] ${event}`, details ? JSON.stringify(details) : "");
+  };
+}
+
+export function wrapToolWithAudit<
+  T extends { name: string; execute: (...args: never[]) => unknown },
+>(tool: T, logger: AuditLogger): T {
+  const original = tool.execute.bind(tool);
+  return {
+    ...tool,
+    async execute(...args: Parameters<T["execute"]>) {
+      logger("tool_called", { tool: tool.name });
+      try {
+        const result = await original(...args);
+        logger("tool_succeeded", { tool: tool.name });
+        return result;
+      } catch (err) {
+        logger("tool_failed", {
+          tool: tool.name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+    },
+  };
+}

--- a/extensions/presalespebot/src/ops-api.ts
+++ b/extensions/presalespebot/src/ops-api.ts
@@ -1,0 +1,173 @@
+const PE_OPS_BASE_URL = () => process.env.PRESALES_PE_OPS_BASE_URL ?? "";
+const PE_OPS_TOKEN = () => process.env.PRESALES_PE_OPS_TOKEN ?? "";
+// Fixture mode is an EXPLICIT opt-in. A missing base URL in a real deployment
+// is surfaced as a misconfiguration (see peOpsFetch), never a silent fall-through
+// to healthy-looking fixture data during support triage.
+const FIXTURE_MODE = () => process.env.PRESALES_PE_OPS_FIXTURE_MODE === "1";
+
+export interface PeOpsFetchResult {
+  ok: boolean;
+  status: number;
+  data: unknown;
+  source: "fixture" | "api";
+}
+
+const fixture = {
+  health: {
+    ok: true,
+    service: "pe",
+    env: "fixture",
+    poller_alive: true,
+    scopely_reachable: true,
+    schema_cache: "fresh",
+  },
+  active: [
+    {
+      engagement_id: "pe-fixture-1",
+      stage: "collecting_fields",
+      customer_name: "Acme",
+      waiting_on: "customer",
+      captured_fields: 7,
+      missing_required_fields: 4,
+      last_event_at: "2026-06-22T14:02:11Z",
+    },
+  ],
+  stuck: [
+    {
+      engagement_id: "pe-fixture-stuck",
+      stage: "waiting_on_service",
+      issue: "pe.schema.fetch_failed",
+      age_seconds: 315,
+      summary: "Scopely auth failed; customer received service unavailable.",
+    },
+  ],
+  engagement: {
+    engagement_id: "pe-fixture-1",
+    stage: "collecting_fields",
+    customer_name: "Acme",
+    ae_email: "m***@cloudwarriors.ai",
+    scopely_session_id: "scopely-fixture-1",
+    latest_bot_prompt: "Asked for Zoom Phone user count.",
+    latest_customer_reply_preview: "We have 250 users.",
+    captured_fields: 7,
+    missing_required_fields: 4,
+  },
+  timeline: [
+    { ts: "2026-06-22T14:02:11Z", event: "pe.launchpad.channel_created" },
+    { ts: "2026-06-22T14:03:08Z", event: "pe.field.captured", field_key: "customer_name" },
+  ],
+  schema: {
+    ok: true,
+    schema_version: "fixture",
+    last_fetch_at: "2026-06-22T14:01:00Z",
+    cache_state: "fresh",
+  },
+  fields: {
+    captured: ["customer_name", "contact_name", "phone_users"],
+    missing_required: ["deployment_type", "sites", "go_live_date"],
+    rejected: [],
+  },
+  sms: {
+    ok: true,
+    stage: "waiting_on_customer",
+    delivery_status: "delivered",
+    last_inbound_preview: "Can you send the SOW link?",
+  },
+};
+
+export async function peOpsFetch(path: string): Promise<PeOpsFetchResult> {
+  if (FIXTURE_MODE()) {
+    return { ok: true, status: 200, data: fixtureFor(path), source: "fixture" };
+  }
+  if (PE_OPS_BASE_URL().trim() === "") {
+    return {
+      ok: false,
+      status: 0,
+      data: {
+        ok: false,
+        error:
+          "PRESALES_PE_OPS_BASE_URL is not configured (set it, or PRESALES_PE_OPS_FIXTURE_MODE=1 for local dev).",
+      },
+      source: "api",
+    };
+  }
+
+  const headers: Record<string, string> = {};
+  const token = PE_OPS_TOKEN().trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  const resp = await fetch(`${PE_OPS_BASE_URL().replace(/\/$/, "")}${path}`, { headers });
+  const data = resp.headers.get("content-type")?.includes("application/json")
+    ? await resp.json()
+    : await resp.text();
+  return { ok: resp.ok, status: resp.status, data: redactForSupport(data), source: "api" };
+}
+
+function fixtureFor(path: string): unknown {
+  if (path === "/internal/ops/health") return fixture.health;
+  if (path === "/internal/ops/active") return fixture.active;
+  if (path === "/internal/ops/stuck") return fixture.stuck;
+  if (path.includes("/timeline")) return fixture.timeline;
+  if (path.includes("/schema")) return fixture.schema;
+  if (path.includes("/fields")) return fixture.fields;
+  if (path.startsWith("/internal/ops/sms/")) return fixture.sms;
+  return fixture.engagement;
+}
+
+export function jsonResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(redactForSupport(data)) }] };
+}
+
+export function errorResult(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return jsonResult({ ok: false, error: message });
+}
+
+// Phone masking only runs on free-text fields; a numeric id or an ISO timestamp
+// matches the phone pattern, so masking every string would corrupt structured
+// values. Emails/tokens are safe to mask anywhere.
+const FREE_TEXT_KEYS = new Set([
+  "text",
+  "preview",
+  "summary",
+  "reply",
+  "body",
+  "note",
+  "notes",
+  "question",
+  "latest_question",
+  "latest_customer_reply_preview",
+  "last_inbound_preview",
+]);
+// Keys whose VALUE is itself a phone number → mask even though not free text.
+const PHONE_KEY_RE = /(phone|mobile|msisdn|caller|from_number|to_number)/i;
+
+export function redactForSupport(value: unknown, freeText = false): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactForSupport(item, freeText));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      if (/(token|secret|password|cookie|authorization|api[_-]?key)/i.test(key)) {
+        out[key] = "[REDACTED]";
+      } else {
+        out[key] = redactForSupport(
+          item,
+          freeText || FREE_TEXT_KEYS.has(key) || PHONE_KEY_RE.test(key),
+        );
+      }
+    }
+    return out;
+  }
+  if (typeof value !== "string") return value;
+  let masked = value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, (email) => {
+      const [user, domain] = email.split("@");
+      return `${user.slice(0, 1)}***@${domain}`;
+    });
+  if (freeText) {
+    masked = masked.replace(/\+?\d[\d\s().-]{7,}\d/g, "+***");
+  }
+  return masked;
+}

--- a/extensions/presalespebot/src/ops-tools.test.ts
+++ b/extensions/presalespebot/src/ops-tools.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { redactForSupport } from "./ops-api.js";
+import { PE_OPS_TOOL_GROUPS, registerPeOpsTools } from "./ops-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+const noopLogger = () => {};
+
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const tool = factory();
+      tools[tool.name] = tool;
+    },
+  } as never;
+  registerPeOpsTools(api, noopLogger as never);
+  return tools;
+}
+
+function parse(res: { content: { text: string }[] }) {
+  return JSON.parse(res.content[0].text);
+}
+
+describe("presalespebot ops tools", () => {
+  it("keeps spoke allowlist groups aligned with registered tools", () => {
+    const registeredNames = Object.keys(buildTools()).sort();
+    const groupedNames = Object.values(PE_OPS_TOOL_GROUPS).flat().sort();
+
+    expect(new Set(groupedNames).size).toBe(groupedNames.length);
+    expect(groupedNames).toEqual(registeredNames);
+    expect(PE_OPS_TOOL_GROUPS.observe).toEqual([
+      "pe_ops_health",
+      "pe_ops_active_engagements",
+      "pe_ops_stuck_engagements",
+    ]);
+  });
+
+  it("uses fixture mode only with the explicit PRESALES_PE_OPS_FIXTURE_MODE opt-in", async () => {
+    delete process.env.PRESALES_PE_OPS_BASE_URL;
+    process.env.PRESALES_PE_OPS_FIXTURE_MODE = "1";
+    try {
+      const tools = buildTools();
+      const result = parse(await tools.pe_ops_active_engagements.execute("t", {}));
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("fixture");
+      expect(result.data[0].engagement_id).toBe("pe-fixture-1");
+    } finally {
+      delete process.env.PRESALES_PE_OPS_FIXTURE_MODE;
+    }
+  });
+
+  it("reports misconfiguration (not fixture) when base URL is unset without the opt-in", async () => {
+    delete process.env.PRESALES_PE_OPS_BASE_URL;
+    delete process.env.PRESALES_PE_OPS_FIXTURE_MODE;
+    const tools = buildTools();
+    const result = parse(await tools.pe_ops_health.execute("t", {}));
+    expect(result.ok).toBe(false);
+    expect(result.source).toBe("api");
+    expect(JSON.stringify(result.data)).toContain("not configured");
+  });
+
+  it("redacts secrets, emails, and phone-like values from support payloads", () => {
+    const redacted = redactForSupport({
+      authorization: "Bearer abc123",
+      email: "matt.keuning@cloudwarriors.ai",
+      phone: "+1 555 123 4567",
+    });
+    expect(JSON.stringify(redacted)).not.toContain("abc123");
+    expect(JSON.stringify(redacted)).not.toContain("matt.keuning");
+    expect(JSON.stringify(redacted)).not.toContain("555 123 4567");
+  });
+});

--- a/extensions/presalespebot/src/ops-tools.ts
+++ b/extensions/presalespebot/src/ops-tools.ts
@@ -1,0 +1,145 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { errorResult, jsonResult, peOpsFetch } from "./ops-api.js";
+
+type PeOpsToolSpec = {
+  name: string;
+  description: string;
+  parameters: ReturnType<typeof Type.Object>;
+  path: (toolParams: Record<string, unknown>) => string;
+};
+
+const peOpsToolGroups = {
+  observe: [
+    {
+      name: "pe_ops_health",
+      description:
+        "Check Presales Knowledge Expert ops health: app, poller, Scopely reachability, schema cache, SMS webhook, and rollout health.",
+      path: () => "/internal/ops/health",
+      parameters: Type.Object({}),
+    },
+    {
+      name: "pe_ops_active_engagements",
+      description:
+        "List active PE engagements with current stage, who is waiting, captured/missing field counts, and last event time.",
+      path: () => "/internal/ops/active",
+      parameters: Type.Object({}),
+    },
+    {
+      name: "pe_ops_stuck_engagements",
+      description:
+        "List PE engagements that appear stuck or customer-impacting, including stage age and latest failure.",
+      path: () => "/internal/ops/stuck",
+      parameters: Type.Object({}),
+    },
+  ],
+  channel: [
+    subjectTool({
+      name: "pe_ops_engagement_status",
+      description:
+        "Get PE engagement status by engagement/session id: stage, waiting state, customer summary, captured fields, and latest error.",
+      segment: "engagement",
+    }),
+    subjectTool({
+      name: "pe_ops_channel_status",
+      description:
+        "Get PE channel engagement status by Zoom channel id. Use when an operator only has the Zoom channel.",
+      segment: "channel",
+      paramName: "channel_id",
+    }),
+    subjectTool({
+      name: "pe_ops_engagement_timeline",
+      description:
+        "Get a redacted PE activity timeline for an engagement/session/channel. Use to answer 'what happened?'",
+      segment: "engagement",
+      suffix: "/timeline",
+    }),
+  ],
+  schema: [
+    subjectTool({
+      name: "pe_ops_schema_status",
+      description:
+        "Get PE schema status for an engagement/session: schema version, freshness, and last fetch error.",
+      segment: "engagement",
+      suffix: "/schema",
+    }),
+    subjectTool({
+      name: "pe_ops_field_summary",
+      description:
+        "Get PE field capture summary for an engagement/session: captured, missing required, and rejected fields.",
+      segment: "engagement",
+      suffix: "/fields",
+    }),
+  ],
+  sms: [
+    subjectTool({
+      name: "pe_ops_sms_status",
+      description:
+        "Get PE SMS engagement status by phone number or SMS session id, including rollout, delivery, and SOW delivery state.",
+      segment: "sms",
+      paramName: "phone_or_session",
+    }),
+  ],
+} satisfies Record<string, readonly PeOpsToolSpec[]>;
+
+export const PE_OPS_TOOL_GROUPS: Record<keyof typeof peOpsToolGroups, readonly string[]> = {
+  observe: peOpsToolGroups.observe.map((tool) => tool.name),
+  channel: peOpsToolGroups.channel.map((tool) => tool.name),
+  schema: peOpsToolGroups.schema.map((tool) => tool.name),
+  sms: peOpsToolGroups.sms.map((tool) => tool.name),
+};
+
+export function registerPeOpsTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  for (const group of Object.values(peOpsToolGroups)) {
+    for (const tool of group) registerGet(api, logger, tool);
+  }
+}
+
+function registerGet(api: OpenClawPluginApi, logger: AuditLogger, params: PeOpsToolSpec) {
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: params.name,
+        description: params.description,
+        parameters: params.parameters,
+        async execute(_id: string, toolParams: Record<string, unknown>) {
+          try {
+            const result = await peOpsFetch(params.path(toolParams));
+            return jsonResult({
+              ok: result.ok,
+              status: result.status,
+              source: result.source,
+              data: result.data,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}
+
+function subjectTool(params: {
+  name: string;
+  description: string;
+  segment: string;
+  paramName?: string;
+  suffix?: string;
+}): PeOpsToolSpec {
+  const paramName = params.paramName ?? "id";
+  return {
+    name: params.name,
+    description: params.description,
+    parameters: Type.Object({
+      [paramName]: Type.String({
+        description: "Engagement, session, channel, phone, or related lookup id",
+      }),
+    }),
+    path: (toolParams) =>
+      `/internal/ops/${params.segment}/${encodeURIComponent(String(toolParams[paramName] ?? ""))}${params.suffix ?? ""}`,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1370,6 +1370,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/presalespebot:
+    devDependencies:
+      openclaw:
+        specifier: workspace:*
+        version: link:../..
+
   extensions/pulsebot:
     devDependencies:
       openclaw:


### PR DESCRIPTION
## Background
With PE and BigHead approaching customer use, we need operators to be able to ask
"what's happening with this engagement / meeting?" and read live transcripts without
digging through logs. These bots are the monitoring front-end for the new PE/BigHead
`/internal/ops/*` surfaces, built on the proven scopelybot hub-and-spoke pattern.

## What changed
- **presalespebot (new plugin):** 9 read-only PE ops tools across observe / channel /
  schema / sms; `PE_OPS_TOOL_GROUPS` exports the per-spoke allowlists.
- **bigheadbot:** presales ops tools across observe / meeting / audio / writeback,
  including **`bh_presales_transcript_text`** (read recent transcript lines — the
  "what did the customer actually say" view); `BIGHEAD_PRESALES_TOOL_GROUPS` exports
  the spoke allowlists.
- **Hub-and-spoke enforcement:** tools register as *optional*, so the router hub holds
  only `sessions_spawn` + `subagents` + one liveness tool and is forced to delegate to
  exactly one narrow spoke — the tool allowlist is the real control, not prompt wording.
- **Safety:** two-layer redaction (server + bot); fixture mode is an explicit opt-in
  (`*_FIXTURE_MODE=1`) and an unset base URL surfaces a "not configured" error instead
  of silently serving healthy-looking fixture data during triage.
- **Docs:** hub-spoke reference + a deployment guide (env wiring, agent definitions,
  Zoom channel-binding template, and a validation gate including a no-token→401 auth
  check).

## Verification
- 9 vitest pass; oxfmt + docs format clean.
- Validated end-to-end against the live PE/BigHead containers (28/28 smoke).

## Rollout / risk
- Depends on the PE + BigHead `/internal/ops/*` PRs being deployed.
- Runtime agent definitions + Zoom channel bindings are operator state (not in this
  PR) — see the deployment guide.
- `SCOPELYBOT_TESTING.md` intentionally excluded (contains live prod host/channel ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
