### PR TITLE
Add BigHead recent session discovery tool

### DIFF
--- a/deploy/presales-ops-runtime/openclaw.presales-ops.fragment.json
+++ b/deploy/presales-ops-runtime/openclaw.presales-ops.fragment.json
@@ -44,7 +44,7 @@
       "id": "bighead-observe",
       "name": "BigHead Observe",
       "workspace": "~/.openclaw/workspace-bighead-observe",
-      "tools": { "allow": ["bh_presales_ops_health", "bh_presales_active_sessions", "bh_presales_stuck_sessions"] }
+      "tools": { "allow": ["bh_presales_ops_health", "bh_presales_active_sessions", "bh_presales_recent_sessions", "bh_presales_stuck_sessions"] }
     },
     {
       "id": "bighead-meeting",
@@ -82,4 +82,3 @@
     }
   ]
 }
-

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-observe/SOUL.md
@@ -1,3 +1,3 @@
 # SOUL.md - BigHead Observe
 
-Answer broad BigHead presales operational questions with current tool data. Include relevant ids, counts, timestamps, stage/status values, and a one-line interpretation. Do not guess. Do not mutate anything.
+Answer broad BigHead presales operational questions with current tool data. Include relevant ids, counts, timestamps, stage/status values, and a one-line interpretation. When the operator asks for the latest/recent meeting or transcript without a BigHead session id or Zoom meeting id, call `bh_presales_recent_sessions` first and prefer rows with `transcript_entries > 0`. Do not guess. Do not mutate anything.

--- a/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/SOUL.md
+++ b/deploy/presales-ops-runtime/workspaces/workspace-bighead-presales/SOUL.md
@@ -4,9 +4,9 @@ You are the BigHead presales ops coordinator.
 
 Route requests to the best spoke:
 
-- `bighead-observe`: fleet health, active sessions, stuck sessions
+- `bighead-observe`: fleet health, active sessions, recent sessions, stuck sessions
 - `bighead-meeting`: one session/meeting, join state, current stage, timeline
 - `bighead-audio`: mute/audio state, transcript health, recent transcript text
 - `bighead-writeback`: Scopely writeback status and failures
 
-Do not answer BigHead presales domain questions from memory. Spawn the right spoke with the full user request and all ids/names provided. After spawning, reply exactly `NO_REPLY` on that turn. Relay the spoke result only when it returns.
+Do not answer BigHead presales domain questions from memory. Spawn the right spoke with the full user request and all ids/names provided. If the request asks for the latest/recent transcript or status without a BigHead session id or Zoom meeting id, route to `bighead-observe` first to resolve candidate sessions; do not use the OpenClaw support-channel conversation id as a BigHead session id. After spawning, reply exactly `NO_REPLY` on that turn. Relay the spoke result only when it returns.

--- a/extensions/bigheadbot/openclaw.plugin.json
+++ b/extensions/bigheadbot/openclaw.plugin.json
@@ -48,6 +48,7 @@
       "bh_presales_audio_status",
       "bh_presales_meeting_status",
       "bh_presales_ops_health",
+      "bh_presales_recent_sessions",
       "bh_presales_session_status",
       "bh_presales_session_timeline",
       "bh_presales_stuck_sessions",

--- a/extensions/bigheadbot/src/presales-ops-api.ts
+++ b/extensions/bigheadbot/src/presales-ops-api.ts
@@ -41,6 +41,22 @@ const fixture = {
       last_event_at: "2026-06-22T14:05:02Z",
     },
   ],
+  recent: [
+    {
+      session_id: "bh-fixture-ended",
+      meeting_id: "88531799696",
+      scopely_session_id: 1865,
+      status: "ended",
+      stage: "complete",
+      session_role: "worker",
+      interaction_mode: "voice",
+      initiated_by: "auto_join_worker",
+      transcript_entries: 548,
+      created_at: "2026-07-06T13:41:27.745050",
+      ended_at: "2026-07-06T13:49:22.124633",
+      is_active: false,
+    },
+  ],
   stuck: [
     {
       session_id: "bh-fixture-stuck",
@@ -150,6 +166,7 @@ export async function bigheadOpsFetch(path: string): Promise<BigheadOpsFetchResu
 function fixtureFor(path: string): unknown {
   if (path === "/internal/ops/health") return fixture.health;
   if (path === "/internal/ops/active") return fixture.active;
+  if (path.startsWith("/internal/ops/recent")) return fixture.recent;
   if (path === "/internal/ops/stuck") return fixture.stuck;
   if (path.includes("/timeline")) return fixture.timeline;
   if (path.includes("/audio")) return fixture.audio;

--- a/extensions/bigheadbot/src/presales-ops-tools.test.ts
+++ b/extensions/bigheadbot/src/presales-ops-tools.test.ts
@@ -35,6 +35,7 @@ describe("bigheadbot presales ops tools", () => {
 
     expect(new Set(groupedNames).size).toBe(groupedNames.length);
     expect(groupedNames).toEqual(registeredNames);
+    expect(BIGHEAD_PRESALES_TOOL_GROUPS.observe).toContain("bh_presales_recent_sessions");
     expect(BIGHEAD_PRESALES_TOOL_GROUPS.audio).toEqual([
       "bh_presales_audio_status",
       "bh_presales_transcript_status",
@@ -104,6 +105,58 @@ describe("bigheadbot presales ops tools", () => {
       expect(result.data.lines[0].text).toContain("don't want CRM");
     } finally {
       delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    }
+  });
+
+  it("returns recent sessions in fixture mode for latest-meeting discovery", async () => {
+    delete process.env.BIGHEAD_OPS_BASE_URL;
+    delete process.env.BIGHEAD_API_URL;
+    process.env.BIGHEAD_OPS_FIXTURE_MODE = "1";
+    try {
+      const tools = buildTools();
+      const result = parse(
+        await tools.bh_presales_recent_sessions.execute("t", {
+          limit: 5,
+          with_transcript: true,
+        }),
+      );
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("fixture");
+      expect(result.data[0].session_id).toBe("bh-fixture-ended");
+      expect(result.data[0].transcript_entries).toBe(548);
+    } finally {
+      delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    }
+  });
+
+  it("builds the recent sessions API path with transcript filtering", async () => {
+    process.env.BIGHEAD_OPS_BASE_URL = "http://bighead.test";
+    process.env.BIGHEAD_OPS_TOKEN = "ops-token";
+    delete process.env.BIGHEAD_OPS_FIXTURE_MODE;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      json: async () => [{ session_id: "bh-real", transcript_entries: 3 }],
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const tools = buildTools();
+      const result = parse(
+        await tools.bh_presales_recent_sessions.execute("t", {
+          limit: 5,
+          with_transcript: true,
+        }),
+      );
+      expect(result.ok).toBe(true);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://bighead.test/internal/ops/recent?limit=5&with_transcript=true",
+        { headers: { Authorization: "Bearer ops-token" } },
+      );
+    } finally {
+      vi.unstubAllGlobals();
+      delete process.env.BIGHEAD_OPS_BASE_URL;
+      delete process.env.BIGHEAD_OPS_TOKEN;
     }
   });
 

--- a/extensions/bigheadbot/src/presales-ops-tools.ts
+++ b/extensions/bigheadbot/src/presales-ops-tools.ts
@@ -28,6 +28,28 @@ const bigheadPresalesToolGroups = {
       path: () => "/internal/ops/active",
     },
     {
+      name: "bh_presales_recent_sessions",
+      description:
+        "List recent Bighead presales sessions, including ended meetings, with meeting id, Scopely session id, status, timestamps, and transcript entry counts. Use this before transcript/status lookups when the operator asks for the latest meeting but does not provide a Bighead session id.",
+      parameters: Type.Object({
+        limit: Type.Optional(
+          Type.Number({ description: "Max recent sessions to return (default 20, max 100)" }),
+        ),
+        with_transcript: Type.Optional(
+          Type.Boolean({
+            description: "When true, return only sessions that have transcript entries.",
+          }),
+        ),
+      }),
+      path: (toolParams) => {
+        const query = new URLSearchParams();
+        if (toolParams.limit) query.set("limit", String(toolParams.limit));
+        if (toolParams.with_transcript === true) query.set("with_transcript", "true");
+        const suffix = query.toString() ? `?${query.toString()}` : "";
+        return `/internal/ops/recent${suffix}`;
+      },
+    },
+    {
       name: "bh_presales_stuck_sessions",
       description:
         "List Bighead presales sessions that appear stuck or customer-impacting, including no-audio/no-transcript conditions.",


### PR DESCRIPTION
## Summary
- Add `bh_presales_recent_sessions` for metadata-only recent BigHead presales session lookup
- Wire the tool into the BigHead observe spoke and plugin contract
- Update BigHead support-bot instructions to resolve latest/recent sessions before transcript/status lookup

## Validation
- `npm test -- --run extensions/bigheadbot/src/presales-ops-tools.test.ts`
- `git diff --check`

## Notes
- `npm run tsgo:extensions` remains blocked by pre-existing repo-wide extension contract errors, including missing `label` on several tool factories and existing `2fa-github` issues; the focused BigHeadBot test passes.
