### PR TITLE
praxis-write: praxis_provide_info + reconcile hand-deployed extension state

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
-import { mintConfirmToken, mintRepoConfirmToken, mintSelfHealConfirmToken } from "./policy.js";
+import {
+  mintConfirmToken,
+  mintFileIssueConfirmToken,
+  mintIngestConfirmToken,
+  mintRepoConfirmToken,
+  mintSelfHealConfirmToken,
+} from "./policy.js";
 
 type ToolDef = {
   name: string;
@@ -72,18 +78,21 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the seven write tools, all optional", () => {
+  it("registers exactly the nine write tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
+      "praxis_file_issue",
+      "praxis_ingest",
       "praxis_link_github",
       "praxis_link_status",
       "praxis_onboard",
+      "praxis_provide_info",
       "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(7);
+    expect(registerOpts).toHaveLength(10);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -613,6 +622,282 @@ describe("praxis_onboard", () => {
   });
 });
 
+describe("praxis_ingest", () => {
+  const REPO = "cloudwarriors-ai/scopely";
+
+  it("fails closed when the allowlist is unconfigured (no fetch)", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 1015, reason: "track it" }),
+    );
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a reason", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 1015, reason: " " }),
+    );
+    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a full_name without owner/name", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: "no-slash",
+        number: 1015,
+        reason: "track it",
+      }),
+    );
+    expect(out).toEqual({ ok: false, error: "invalid_full_name" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive / non-integer issue number", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const zero = parse(
+      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 0, reason: "track it" }),
+    );
+    expect(zero).toEqual({ ok: false, error: "invalid_issue_number" });
+    const nan = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: "abc",
+        reason: "track it",
+      }),
+    );
+    expect(nan).toEqual({ ok: false, error: "invalid_issue_number" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run previews and makes no HTTP call at all", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 1015, reason: "track it" }),
+    );
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("ingest");
+    expect(out.repo).toBe(REPO);
+    expect(out.number).toBe(1015);
+    expect(typeof out.confirm_token).toBe("string");
+    // The ingest token is bound to repo+number (no issue GET), so a preview hits nothing.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a wrong confirm token re-previews instead of executing", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "track it",
+        confirm: "deadbeefdeadbeef",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("executes on a valid confirm token, POSTing the ingest request with audit context", async () => {
+    const result = {
+      ingested: true,
+      full_name: REPO,
+      source_issue: 1015,
+      state: "assessing",
+      already_tracked: false,
+    };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: result }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintIngestConfirmToken({ secret: "test-token", fullName: REPO, number: 1015 });
+
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "reporter says it isn't tracked",
+        confirm: token,
+      }),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.source_issue).toBe(1015);
+    expect(out.state).toBe("assessing");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/api/v1/issues/ingest");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(init?.body as string);
+    expect(sent).toEqual({
+      full_name: REPO,
+      number: 1015,
+      requested_by: "alice",
+      channel: "dev_praxis",
+      message_id: "1",
+      idempotency_key: "ingest:cloudwarriors-ai/scopely:1015",
+    });
+  });
+
+  it("surfaces repo_not_onboarded with a pointer to praxis_onboard", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 404, body: { error: "repo_not_onboarded" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintIngestConfirmToken({ secret: "test-token", fullName: REPO, number: 1015 });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "track it",
+        confirm: token,
+      }),
+    );
+    expect(out.error).toBe("repo_not_onboarded");
+    expect(out.message).toMatch(/praxis_onboard/);
+  });
+
+  it("surfaces issue_not_open when GitHub says the issue is closed/missing", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 409, body: { error: "issue_not_open" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintIngestConfirmToken({ secret: "test-token", fullName: REPO, number: 1015 });
+    const out = parse(
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "track it",
+        confirm: token,
+      }),
+    );
+    expect(out.error).toBe("issue_not_open");
+    expect(out.message).toMatch(/not open/);
+  });
+});
+
+describe("praxis_file_issue", () => {
+  const PRAXIS_REPO = "cloudwarriors-ai/praxis";
+
+  it("fails closed when the allowlist is unconfigured (no fetch)", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(
+      await tools.praxis_file_issue.execute("c1", { title: "fix it", reason: "self-improve" }),
+    );
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a reason and a title", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const noReason = parse(
+      await tools.praxis_file_issue.execute("c1", { title: "fix it", reason: " " }),
+    );
+    expect(noReason).toEqual({ ok: false, error: "reason_required" });
+    const noTitle = parse(
+      await tools.praxis_file_issue.execute("c1", { title: "  ", reason: "self-improve" }),
+    );
+    expect(noTitle).toEqual({ ok: false, error: "title_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run previews with the Praxis repo as the default target and makes no HTTP call", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_file_issue.execute("c1", {
+        title: "Fix flaky outbox retry",
+        reason: "self-improve",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(out.action).toBe("file_issue");
+    expect(out.repo).toBe(PRAXIS_REPO);
+    expect(out.title).toBe("Fix flaky outbox retry");
+    expect(typeof out.confirm_token).toBe("string");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("a wrong confirm token re-previews instead of filing", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_file_issue.execute("c1", {
+        title: "t",
+        reason: "self-improve",
+        confirm: "deadbeefdeadbeef",
+      }),
+    );
+    expect(out.preview).toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("executes on a valid token, POSTing to the Praxis repo with no labels key (server default)", async () => {
+    const result = {
+      filed: true,
+      full_name: PRAXIS_REPO,
+      number: 101,
+      url: `https://github.com/${PRAXIS_REPO}/issues/101`,
+      labels: ["praxis:self-improvement"],
+    };
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: result }));
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintFileIssueConfirmToken({
+      secret: "test-token",
+      fullName: PRAXIS_REPO,
+      title: "Improve reconciler logging",
+    });
+
+    const out = parse(
+      await tools.praxis_file_issue.execute("c1", {
+        title: "Improve reconciler logging",
+        body: "add context to the retry log line",
+        reason: "self-improve",
+        confirm: token,
+      }),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.number).toBe(101);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/api/v1/issues/file");
+    expect(init?.method).toBe("POST");
+    const sent = JSON.parse(init?.body as string);
+    expect(sent).toEqual({
+      full_name: PRAXIS_REPO,
+      title: "Improve reconciler logging",
+      body: "add context to the retry log line",
+      requested_by: "alice",
+      channel: "dev_praxis",
+      message_id: "1",
+      idempotency_key: `file-issue:${PRAXIS_REPO}:Improve reconciler logging`,
+    });
+    expect(sent.labels).toBeUndefined(); // omitted so the server applies its default marker
+  });
+
+  it("honors an explicit repo + labels", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { filed: true, number: 5 } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const token = mintFileIssueConfirmToken({
+      secret: "test-token",
+      fullName: "cw/other",
+      title: "t",
+    });
+    await tools.praxis_file_issue.execute("c1", {
+      title: "t",
+      repo: "cw/other",
+      labels: ["enhancement"],
+      reason: "self-improve",
+      confirm: token,
+    });
+    const sent = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(sent.full_name).toBe("cw/other");
+    expect(sent.labels).toEqual(["enhancement"]);
+  });
+});
+
 describe("praxis_self_heal", () => {
   const REPO = "cloudwarriors-ai/foo";
 
@@ -692,5 +977,129 @@ describe("praxis_self_heal", () => {
       notify: false,
       note: "Reporter flagged this after the deploy.",
     });
+  });
+});
+
+describe("praxis_provide_info", () => {
+  it("fails policy gate when unconfigured", async () => {
+    const { tools } = buildTools({ pluginConfig: undefined });
+    const out = parse(
+      await tools.praxis_provide_info.execute("c1", { issue_id: 7, answer: "the login page" }),
+    );
+    expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty answer before any fetch", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("c1", { issue_id: 7, answer: "   " }),
+    );
+    expect(out).toEqual({ ok: false, error: "answer_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts kind=info_provided with the trusted Zoom identity and the toolCallId as idempotency key", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { applied: true, state: "assessing" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("call-42", {
+        issue_id: 7,
+        answer: "the checkout page, POST /api/cart",
+      }),
+    );
+    expect(out.ok).toBe(true);
+    expect(out.applied).toBe(true);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://praxis:8000/api/v1/issues/7/events");
+    expect((init as RequestInit).method).toBe("POST");
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent).toEqual({
+      kind: "info_provided",
+      reason: "the checkout page, POST /api/cart",
+      requested_by: "alice",
+      channel: "zoom",
+      channel_user_id: "alice",
+      idempotency_key: "call-42",
+    });
+  });
+
+  it("resolves an owner/repo#N ref to the praxis id via the issues list", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { issues: [{ id: 182, source_issue: 65 }, { id: 9, source_issue: 2 }] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "assessing" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("call-7", {
+        issue: "cloudwarriors-ai/praxis-e2e-sandbox#65",
+        answer: "no console errors",
+      }),
+    );
+    expect(out.ok).toBe(true);
+
+    const [lookupUrl] = fetchMock.mock.calls[0];
+    expect(lookupUrl).toBe(
+      "http://praxis:8000/api/v1/issues?repo=cloudwarriors-ai%2Fpraxis-e2e-sandbox",
+    );
+    const [postUrl, postInit] = fetchMock.mock.calls[1];
+    expect(postUrl).toBe("http://praxis:8000/api/v1/issues/182/events");
+    const sent = JSON.parse((postInit as RequestInit).body as string);
+    expect(sent.kind).toBe("info_provided");
+    expect(sent.channel_user_id).toBe("alice");
+  });
+
+  it("returns issue_not_tracked when the ref resolves to nothing", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: true, status: 200, body: { issues: [] } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("call-8", {
+        issue: "cw/app#404",
+        answer: "no console errors",
+      }),
+    );
+    expect(out.error).toBe("issue_not_tracked");
+    expect(out.message).toContain("cw/app#404");
+  });
+
+  it("surfaces identity_not_linked with the link instruction", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("c3", { issue_id: 7, answer: "the login page" }),
+    );
+    expect(out.error).toBe("identity_not_linked");
+    expect(out.message).toContain("praxis_link_github");
+  });
+
+  it("surfaces issue_not_awaiting_info with the issue state", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: false,
+        status: 409,
+        body: { error: "issue_not_awaiting_info", state: "in_progress" },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("c4", { issue_id: 7, answer: "the login page" }),
+    );
+    expect(out.error).toBe("issue_not_awaiting_info");
+    expect(out.state).toBe("in_progress");
+    expect(out.message).toContain("in_progress");
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -10,21 +10,27 @@ import {
   deriveActorContext,
   idempotencyKey,
   mintConfirmToken,
+  mintFileIssueConfirmToken,
+  mintIngestConfirmToken,
   mintRepoConfirmToken,
   mintSelfHealConfirmToken,
   resolveWritePolicyConfig,
   type WritePolicyConfig,
 } from "./policy.js";
 import {
+  fileIssue,
   getApiToken,
   getIssue,
   getLinkStatus,
+  ingestIssue,
   mapStateToUatKindPrefix,
   onboardRepo,
   type PraxisIssueState,
   runSelfHeal,
   startGithubLink,
   submitCommand,
+  resolveIssueRef,
+  submitNeedsInfoAnswer,
   submitVerdict,
   type UatVerdictKind,
 } from "./praxis-write-client.js";
@@ -38,6 +44,11 @@ const CANCEL_KINDS = ["cancelled", "duplicate", "superseded", "source_closed"] a
 // (uat1_pass / uat2_pass etc.) after reading the issue state.
 const VERDICT_VALUES = ["pass", "fail"] as const;
 type VerdictValue = (typeof VERDICT_VALUES)[number];
+
+// Default target for praxis_file_issue: the Praxis repo itself, so a self-improvement issue Praxis
+// can then work lands in its own repo. Mirrors the server's PRAXIS_SELF_HEAL_REPO default; kept
+// concrete here so the dry-run preview + confirm token bind to a real target. Overridable per call.
+const PRAXIS_SELF_IMPROVEMENT_REPO = "cloudwarriors-ai/praxis";
 
 const PraxisWriteConfigSchema = z.strictObject({
   allowedUsers: z.array(z.string()).optional(),
@@ -300,6 +311,239 @@ const plugin = {
     }));
 
     optionalApi.registerTool((toolContext) => ({
+      name: "praxis_ingest",
+      description:
+        "Force-ingest a SINGLE GitHub issue into Praxis when the issue exists on GitHub but Praxis " +
+        "does not know about it yet (its repo is already onboarded, but the issue never got tracked " +
+        "— a missed webhook delivery, or it predates the webhook). Reach for this when a human says " +
+        "an issue isn't showing up / isn't started / 'give it to Praxis' and praxis_get_issue can't " +
+        "find it. Two steps: call first with full_name + number + reason to get a dry-run preview " +
+        "and a confirm_token, then call again passing that token in `confirm` to execute. " +
+        "Idempotent — re-ingesting an already-tracked issue is a no-op. Onboard the repo first with " +
+        "praxis_onboard if this returns repo_not_onboarded. Allowlist-gated; the human you are " +
+        "acting for is recorded for audit. If denied, surface the reason; do not retry.",
+      parameters: Type.Object({
+        full_name: Type.String({ description: "owner/name, e.g. cloudwarriors-ai/scopely" }),
+        number: Type.Number({
+          description: "The GitHub issue NUMBER (e.g. 1015), not the Praxis issue id",
+        }),
+        reason: Type.String({
+          description: "Operator justification for the manual ingest (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (!reason) {
+          return jsonResult({ ok: false, error: "reason_required" });
+        }
+        const fullName = typeof params.full_name === "string" ? params.full_name.trim() : "";
+        if (!fullName.includes("/")) {
+          return jsonResult({ ok: false, error: "invalid_full_name" });
+        }
+        const number = Number(params.number);
+        if (!Number.isInteger(number) || number <= 0) {
+          return jsonResult({ ok: false, error: "invalid_issue_number" });
+        }
+
+        let token: string;
+        try {
+          token = getApiToken();
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        // Bind the confirm token to the repo + issue number so a preview can't be replayed against
+        // a different issue. Ingest can post a needs_info comment to GitHub (a real side effect), so
+        // it takes the same two-step dry-run/confirm as the other side-effecting write tools.
+        const expected = mintIngestConfirmToken({ secret: token, fullName, number });
+        const confirm = typeof params.confirm === "string" ? params.confirm : "";
+        if (!confirm || !confirmTokenMatches(confirm, expected)) {
+          return jsonResult({
+            ok: true,
+            preview: true,
+            action: "ingest",
+            repo: fullName,
+            number,
+            requested_by: actor.requestedBy,
+            confirm_token: expected,
+            message:
+              `Dry run only — nothing changed. Re-call this tool with confirm="${expected}" to ` +
+              `ingest ${fullName}#${number} into Praxis. If the repo is not onboarded this returns ` +
+              `repo_not_onboarded — run praxis_onboard first.`,
+          });
+        }
+
+        let res: Awaited<ReturnType<typeof ingestIssue>>;
+        try {
+          res = await ingestIssue({
+            full_name: fullName,
+            number,
+            requested_by: actor.requestedBy,
+            channel: actor.channel,
+            message_id: actor.messageId,
+            // Stable per logical ingest so a double-confirm dedupes the server-side audit row.
+            idempotency_key: `ingest:${fullName}:${number}`,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        // Surface Praxis's structured guards as actionable messages.
+        if (!res.ok) {
+          const body = res.data as Record<string, unknown>;
+          if (body.error === "repo_not_onboarded") {
+            return jsonResult({
+              ok: false,
+              error: "repo_not_onboarded",
+              message:
+                `Praxis is not tracking ${fullName} yet. Onboard it first with praxis_onboard, ` +
+                `then re-run this ingest.`,
+            });
+          }
+          if (body.error === "issue_not_open") {
+            return jsonResult({
+              ok: false,
+              error: "issue_not_open",
+              message:
+                `GitHub issue ${fullName}#${number} is not open (closed or missing), so Praxis ` +
+                `won't ingest it. Only open issues enter the intake flow.`,
+            });
+          }
+        }
+
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_file_issue",
+      description:
+        "Author and file a single GitHub issue INTO THE PRAXIS REPO ITSELF (the default), so Praxis " +
+        "can then work it — this is how Praxis self-heals and improves itself. Use it to file a " +
+        "specific self-healing fix or self-improvement idea you (or a human) identified, distinct " +
+        "from praxis_self_heal which only files failures its automated trace-scan detects. Two " +
+        "steps: call first with title (+ optional body/labels/repo) and a reason to get a dry-run " +
+        "preview and a confirm_token, then call again passing that token in `confirm` to execute. " +
+        "Defaults to cloudwarriors-ai/praxis; pass `repo` to target another repo. Allowlist-gated; " +
+        "the human you are acting for is recorded for audit. If denied, surface the reason; do not retry.",
+      parameters: Type.Object({
+        title: Type.String({ description: "The GitHub issue title (required)" }),
+        body: Type.Optional(
+          Type.String({
+            description:
+              "The issue body (markdown). Include repro/what-to-fix so Praxis can act on it.",
+          }),
+        ),
+        labels: Type.Optional(
+          Type.Array(Type.String(), {
+            description:
+              "GitHub labels (optional). Omit to apply the default 'praxis:self-improvement' marker.",
+          }),
+        ),
+        repo: Type.Optional(
+          Type.String({
+            description: `Target repo owner/name (default ${PRAXIS_SELF_IMPROVEMENT_REPO})`,
+          }),
+        ),
+        reason: Type.String({
+          description: "Operator justification for filing the issue (required, audited)",
+        }),
+        confirm: Type.Optional(
+          Type.String({
+            description:
+              "Confirmation token from the dry-run preview. Omit on the first call to preview; " +
+              "pass the returned confirm_token to execute.",
+          }),
+        ),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (!reason) {
+          return jsonResult({ ok: false, error: "reason_required" });
+        }
+        const title = typeof params.title === "string" ? params.title.trim() : "";
+        if (!title) {
+          return jsonResult({ ok: false, error: "title_required" });
+        }
+        const fullName =
+          typeof params.repo === "string" && params.repo.trim()
+            ? params.repo.trim()
+            : PRAXIS_SELF_IMPROVEMENT_REPO;
+        if (!fullName.includes("/")) {
+          return jsonResult({ ok: false, error: "invalid_repo" });
+        }
+        const issueBody = typeof params.body === "string" ? params.body : "";
+        // Only forward labels when the model supplied them, so the server applies its default
+        // self-improvement marker on omission (an explicit [] would suppress the marker).
+        const labels = Array.isArray(params.labels)
+          ? params.labels.filter((l): l is string => typeof l === "string")
+          : undefined;
+
+        let token: string;
+        try {
+          token = getApiToken();
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        // Bind the confirm token to the repo + title so a preview can't be replayed against a
+        // different target or a different issue. Filing an issue is a real external side effect, so
+        // it takes the same two-step dry-run/confirm as the other side-effecting write tools.
+        const expected = mintFileIssueConfirmToken({ secret: token, fullName, title });
+        const confirm = typeof params.confirm === "string" ? params.confirm : "";
+        if (!confirm || !confirmTokenMatches(confirm, expected)) {
+          return jsonResult({
+            ok: true,
+            preview: true,
+            action: "file_issue",
+            repo: fullName,
+            title,
+            labels: labels ?? ["praxis:self-improvement (default)"],
+            requested_by: actor.requestedBy,
+            confirm_token: expected,
+            message:
+              `Dry run only — nothing filed. Re-call this tool with confirm="${expected}" to file ` +
+              `the issue "${title}" into ${fullName}.`,
+          });
+        }
+
+        let res: Awaited<ReturnType<typeof fileIssue>>;
+        try {
+          res = await fileIssue({
+            full_name: fullName,
+            title,
+            body: issueBody,
+            ...(labels !== undefined ? { labels } : {}),
+            requested_by: actor.requestedBy,
+            channel: actor.channel,
+            message_id: actor.messageId,
+            idempotency_key: `file-issue:${fullName}:${title}`,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
       name: "praxis_self_heal",
       description:
         "Run a Praxis self-heal scan: detect recurring runtime failures from Praxis's own trace and " +
@@ -464,7 +708,7 @@ const plugin = {
         "that the identity is linked to a GitHub account with the reporter/owner role. If the " +
         "identity is not linked, instruct the user to run praxis_link_github first. " +
         "Allowlist-gated; no dry-run/confirm step (UAT states only exit on a human verdict, so " +
-        "the read→submit is race-safe). Deferred: needs_info answers (not wired server-side yet).",
+        "the read→submit is race-safe). For needs-info answers use praxis_provide_info.",
       parameters: Type.Object({
         issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
         verdict: Type.String({
@@ -572,6 +816,123 @@ const plugin = {
               error: "identity_required",
               message:
                 "No verified identity was forwarded to Praxis. This is a configuration error.",
+            });
+          }
+        }
+
+        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_provide_info",
+      description:
+        "Relay a human's answer to a Praxis needs-info question. Use when a user replies (in the " +
+        "issue's thread or addressed to you) with the detail Praxis asked for on an issue in the " +
+        "needs_info state. The requester's verified Zoom identity is forwarded as " +
+        "channel_user_id — the server verifies it is the asked reporter or a maintainer, consumes " +
+        "the open question, applies the answer to the question's stored field, and mirrors the " +
+        "answer to the GitHub issue. If the identity is not linked, instruct the user to run " +
+        "praxis_link_github first. Allowlist-gated.",
+      parameters: Type.Object({
+        issue: Type.Optional(
+          Type.String({
+            description:
+              'The GitHub issue ref "owner/repo#N" (as shown in the thread root) — preferred',
+          }),
+        ),
+        issue_id: Type.Optional(
+          Type.Number({ description: "The Praxis issue id, if already known" }),
+        ),
+        answer: Type.String({
+          description: "The user's answer text, verbatim (do not paraphrase or embellish)",
+        }),
+      }),
+      async execute(toolCallId: string, params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        // Policy gate: identity + allowlist
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+
+        // The verified Zoom sender id is the trusted identity we forward. Fail
+        // closed if the runtime didn't supply one (model cannot inject this).
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+
+        const answer = typeof params.answer === "string" ? params.answer.trim() : "";
+        if (!answer) {
+          return jsonResult({ ok: false, error: "answer_required" });
+        }
+
+        // Resolve the issue: prefer the thread-root "owner/repo#N" ref (what humans and the
+        // root card speak); fall back to an explicit praxis id.
+        let issueId = Number(params.issue_id);
+        const ref = typeof params.issue === "string" ? params.issue.trim() : "";
+        if ((!Number.isInteger(issueId) || issueId <= 0) && ref) {
+          let resolved: number | undefined;
+          try {
+            resolved = await resolveIssueRef(ref);
+          } catch (err) {
+            return errorResult(err);
+          }
+          if (!resolved) {
+            return jsonResult({
+              ok: false,
+              error: "issue_not_tracked",
+              message: `Praxis is not tracking ${ref}.`,
+            });
+          }
+          issueId = resolved;
+        }
+        if (!Number.isInteger(issueId) || issueId <= 0) {
+          return jsonResult({ ok: false, error: "invalid_issue_id" });
+        }
+
+        let res: Awaited<ReturnType<typeof submitNeedsInfoAnswer>>;
+        try {
+          // toolCallId as idempotency key: a model retry of the same call never
+          // double-applies the answer.
+          res = await submitNeedsInfoAnswer(issueId, {
+            reason: answer,
+            requested_by: channelUserId,
+            channel: "zoom",
+            channel_user_id: channelUserId,
+            idempotency_key: toolCallId,
+          });
+        } catch (err) {
+          return errorResult(err);
+        }
+
+        if (!res.ok) {
+          const body = res.data as Record<string, unknown>;
+          if (body.error === "identity_not_linked") {
+            return jsonResult({
+              ok: false,
+              error: "identity_not_linked",
+              message:
+                "Your Zoom identity is not yet linked to a GitHub account. " +
+                "Run praxis_link_github to get a link URL, tap it to authorize GitHub, then try again.",
+            });
+          }
+          if (body.error === "issue_not_awaiting_info") {
+            return jsonResult({
+              ok: false,
+              error: "issue_not_awaiting_info",
+              state: body.state,
+              message: `Issue #${issueId} is not waiting for information (state=${String(body.state)}).`,
+            });
+          }
+          if (res.status === 403) {
+            return jsonResult({
+              ok: false,
+              error: "unauthorized",
+              message:
+                "Your linked GitHub account is not the asked reporter or a maintainer for this issue.",
             });
           }
         }

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,19 +1,23 @@
 {
   "id": "praxis-write",
   "name": "Praxis Write",
-  "description": "Praxis operator write tools (hardened): onboard a repo, run a self-heal scan that files deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/self-heal/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "description": "Praxis operator write tools (hardened): onboard a repo, ingest a single untracked GitHub issue, file a self-improvement issue into the Praxis repo, run a self-heal scan that files deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts or relay needs-info answers on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/ingest/file-issue/self-heal/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
     "properties": {
       "allowedUsers": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Chat sender ids permitted to issue write commands. Each configured dimension (users/channels) must match; an empty allowlist authorizes nobody (fail closed)."
       },
       "allowedChannels": {
         "type": "array",
-        "items": { "type": "string" },
+        "items": {
+          "type": "string"
+        },
         "description": "Channel ids in which write commands are permitted. Each configured dimension (users/channels) must match; an empty allowlist authorizes nobody (fail closed)."
       }
     }
@@ -21,9 +25,12 @@
   "contracts": {
     "tools": [
       "praxis_cancel",
+      "praxis_file_issue",
+      "praxis_ingest",
       "praxis_link_github",
       "praxis_link_status",
       "praxis_onboard",
+      "praxis_provide_info",
       "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock"

--- a/extensions/praxis-write/policy.test.ts
+++ b/extensions/praxis-write/policy.test.ts
@@ -6,6 +6,8 @@ import {
   deriveActorContext,
   idempotencyKey,
   mintConfirmToken,
+  mintFileIssueConfirmToken,
+  mintIngestConfirmToken,
   resolveWritePolicyConfig,
 } from "./policy.js";
 import type { PraxisIssueState } from "./praxis-write-client.js";
@@ -167,5 +169,53 @@ describe("idempotencyKey", () => {
   it("is one logical command per issue version", () => {
     expect(idempotencyKey("unblock", issue)).toBe("unblock:5:12");
     expect(idempotencyKey("cancelled", { ...issue, version: 13 })).toBe("cancelled:5:13");
+  });
+});
+
+describe("mintIngestConfirmToken", () => {
+  const secret = "server-only-secret";
+
+  it("verifies against the same repo + number", () => {
+    const a = mintIngestConfirmToken({ secret, fullName: "cw/foo", number: 1015 });
+    const b = mintIngestConfirmToken({ secret, fullName: "cw/foo", number: 1015 });
+    expect(confirmTokenMatches(a, b)).toBe(true);
+  });
+
+  it("is bound to the issue number (a different issue gets a different token)", () => {
+    const a = mintIngestConfirmToken({ secret, fullName: "cw/foo", number: 1015 });
+    const b = mintIngestConfirmToken({ secret, fullName: "cw/foo", number: 1016 });
+    expect(a).not.toBe(b);
+  });
+
+  it("is bound to the repo and cannot be forged without the secret", () => {
+    const a = mintIngestConfirmToken({ secret, fullName: "cw/foo", number: 1015 });
+    const otherRepo = mintIngestConfirmToken({ secret, fullName: "cw/bar", number: 1015 });
+    const otherSecret = mintIngestConfirmToken({ secret: "x", fullName: "cw/foo", number: 1015 });
+    expect(a).not.toBe(otherRepo);
+    expect(a).not.toBe(otherSecret);
+  });
+});
+
+describe("mintFileIssueConfirmToken", () => {
+  const secret = "server-only-secret";
+
+  it("verifies against the same repo + title", () => {
+    const a = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix x" });
+    const b = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix x" });
+    expect(confirmTokenMatches(a, b)).toBe(true);
+  });
+
+  it("is bound to the title (a different issue gets a different token)", () => {
+    const a = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix x" });
+    const b = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix y" });
+    expect(a).not.toBe(b);
+  });
+
+  it("is bound to the repo and cannot be forged without the secret", () => {
+    const a = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix x" });
+    const otherRepo = mintFileIssueConfirmToken({ secret, fullName: "cw/other", title: "Fix x" });
+    const otherSecret = mintFileIssueConfirmToken({ secret: "x", fullName: "cw/praxis", title: "Fix x" });
+    expect(a).not.toBe(otherRepo);
+    expect(a).not.toBe(otherSecret);
   });
 });

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -120,6 +120,32 @@ export function mintRepoConfirmToken(params: {
   return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
 }
 
+/** Confirm token for a single-issue ingest, bound to the repo + issue number so a dry-run preview
+ * can't be replayed against a different issue. Derived from the API token secret, so the model
+ * cannot forge it without first calling the dry-run that returns it. */
+export function mintIngestConfirmToken(params: {
+  secret: string;
+  fullName: string;
+  number: number;
+}): string {
+  const { secret, fullName, number } = params;
+  const msg = `ingest:${fullName}:${number}`;
+  return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
+}
+
+/** Confirm token for authoring+filing an issue, bound to the target repo + title so a dry-run
+ * preview can't be replayed against a different repo or a different issue. Derived from the API
+ * token secret, so the model cannot forge it without first calling the dry-run that returns it. */
+export function mintFileIssueConfirmToken(params: {
+  secret: string;
+  fullName: string;
+  title: string;
+}): string {
+  const { secret, fullName, title } = params;
+  const msg = `file-issue:${fullName}:${title}`;
+  return createHmac("sha256", secret).update(msg).digest("hex").slice(0, 16);
+}
+
 /** Confirm token for a self-heal run, bound to the target repo + mode so a dry-run preview can't be
  * replayed against a different repo or a more destructive mode. */
 export function mintSelfHealConfirmToken(params: {

--- a/extensions/praxis-write/praxis-write-client.test.ts
+++ b/extensions/praxis-write/praxis-write-client.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  fileIssue,
   getApiToken,
   getIssue,
+  ingestIssue,
   mapStateToUatKindPrefix,
   praxisFetch,
   runSelfHeal,
@@ -224,5 +226,104 @@ describe("runSelfHeal", () => {
     expect(init.method).toBe("POST");
     const sent = JSON.parse(init.body as string);
     expect(sent).toEqual({ repo: "cw/foo", mode: "create-issues", since_minutes: 90 });
+  });
+});
+
+describe("ingestIssue", () => {
+  it("POSTs the ingest body with audit context and returns the raw result", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { ingested: true, source_issue: 1015, state: "assessing", already_tracked: false },
+      }),
+    );
+    const res = await ingestIssue({
+      full_name: "cw/foo",
+      number: 1015,
+      requested_by: "john",
+      channel: "zoom:room",
+      message_id: "m-9",
+      idempotency_key: "ingest:cw/foo:1015",
+    });
+    expect(res.ok).toBe(true);
+    expect((res.data as Record<string, unknown>).source_issue).toBe(1015);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues/ingest`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent).toEqual({
+      full_name: "cw/foo",
+      number: 1015,
+      requested_by: "john",
+      channel: "zoom:room",
+      message_id: "m-9",
+      idempotency_key: "ingest:cw/foo:1015",
+    });
+  });
+
+  it("returns a structured 404 repo_not_onboarded without throwing", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 404, body: { error: "repo_not_onboarded" } }),
+    );
+    const res = await ingestIssue({
+      full_name: "cw/ghost",
+      number: 5,
+      requested_by: "john",
+      channel: "zoom",
+      message_id: "m-1",
+      idempotency_key: "ingest:cw/ghost:5",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(404);
+    expect((res.data as Record<string, unknown>).error).toBe("repo_not_onboarded");
+  });
+});
+
+describe("fileIssue", () => {
+  it("POSTs the file body (omitting labels when not given) and returns the raw result", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { filed: true, full_name: "cloudwarriors-ai/praxis", number: 42 },
+      }),
+    );
+    const res = await fileIssue({
+      full_name: "cloudwarriors-ai/praxis",
+      title: "Fix retry",
+      body: "details",
+      requested_by: "john",
+      channel: "zoom:room",
+      message_id: "m-9",
+      idempotency_key: "file-issue:cloudwarriors-ai/praxis:Fix retry",
+    });
+    expect(res.ok).toBe(true);
+    expect((res.data as Record<string, unknown>).number).toBe(42);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${BASE}/api/v1/issues/file`);
+    expect(init.method).toBe("POST");
+    const sent = JSON.parse(init.body as string);
+    expect(sent.full_name).toBe("cloudwarriors-ai/praxis");
+    expect(sent.title).toBe("Fix retry");
+    expect(sent.labels).toBeUndefined();
+  });
+
+  it("includes labels when provided", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: true, status: 200, body: { filed: true, number: 1 } }),
+    );
+    await fileIssue({
+      full_name: "cw/other",
+      title: "t",
+      body: "",
+      labels: ["bug"],
+      requested_by: "john",
+      channel: "zoom",
+      message_id: "m-1",
+      idempotency_key: "file-issue:cw/other:t",
+    });
+    const sent = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(sent.labels).toEqual(["bug"]);
   });
 });

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -133,6 +133,40 @@ export async function submitVerdict(
   });
 }
 
+/** Resolve an "owner/repo#N" GitHub ref to the praxis issue id via the issues list
+ * (issue_dict exposes id + repo + source_issue). Returns undefined when not tracked. */
+export async function resolveIssueRef(ref: string): Promise<number | undefined> {
+  const m = /^([\w.-]+\/[\w.-]+)#(\d+)$/.exec(ref.trim());
+  if (!m) return undefined;
+  const repo = m[1];
+  const number = Number(m[2]);
+  const res = await praxisGet<{ issues: Array<{ id: number; source_issue: number }> }>(
+    `/api/v1/issues?repo=${encodeURIComponent(repo)}`,
+  );
+  const hit = (res.issues ?? []).find((i) => i.source_issue === number);
+  return hit?.id;
+}
+
+/** Submit a needs-info answer on behalf of a verified Zoom user. The server resolves
+ * the identity, verifies reporter/maintainer authz, consumes the OPEN question, and applies
+ * info_provided with the question's stored field — the caller supplies only the answer text
+ * (kind/reason contract of POST /issues/{id}/events). */
+export async function submitNeedsInfoAnswer(
+  issueId: number,
+  body: {
+    reason: string;
+    requested_by: string;
+    channel: string;
+    channel_user_id: string;
+    idempotency_key?: string;
+  },
+): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>(`/api/v1/issues/${issueId}/events`, {
+    method: "POST",
+    body: JSON.stringify({ kind: "info_provided", ...body }),
+  });
+}
+
 /** Start a GitHub identity link flow for the given Zoom user. Returns the OAuth
  * redirect URL the user must tap to authorize. The server binds the pending link
  * to the channel_user_id so it resolves back to the right Zoom identity. */
@@ -185,6 +219,46 @@ export async function runSelfHeal(body: {
   note?: string;
 }): Promise<PraxisResponse<Record<string, unknown>>> {
   return praxisFetch<Record<string, unknown>>("/api/v1/self-heal/run", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/** Force-ingest a single GitHub issue into an already-onboarded repo through Praxis's live intake
+ * path — the per-issue complement to onboardRepo's bulk backfill. The server resolves the repo,
+ * fetches the one open issue, and runs the same intake bridge (idempotent). Returns the raw result
+ * + HTTP status so the tool surfaces Praxis's outcome (ingested / repo_not_onboarded /
+ * issue_not_open) verbatim. The requester + channel travel as audit context the server records. */
+export async function ingestIssue(body: {
+  full_name: string;
+  number: number;
+  requested_by: string;
+  channel: string;
+  message_id: string;
+  idempotency_key: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/issues/ingest", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/** Author and file a single GitHub issue into a repo (default: the Praxis self-heal repo) — the
+ * direct, agent-authored complement to runSelfHeal's scan-detected issues. Lets the agent seed a
+ * self-healing / self-improvement issue Praxis can then work. `labels` is omitted from the body
+ * when undefined so the server applies its default self-improvement marker. Returns the raw result
+ * + HTTP status ({filed, full_name, number, url, labels}) verbatim. */
+export async function fileIssue(body: {
+  full_name: string;
+  title: string;
+  body: string;
+  labels?: string[];
+  requested_by: string;
+  channel: string;
+  message_id: string;
+  idempotency_key: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/issues/file", {
     method: "POST",
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
Reconciles the praxis-write extension state that runs live on noob-root into git (the box's worktree carried it uncommitted), plus the new tool from the one-thread-per-issue work:

- **praxis_provide_info** — relays a needs-info answer from a verified Zoom user to praxis (`kind=info_provided`). Accepts the `owner/repo#N` ref threads speak (`resolveIssueRef` via `GET /issues?repo=`) — first live run proved models pass GitHub numbers, not praxis pks. Trusted `channel_user_id` pattern (same as submit_verdict), toolCallId idempotency.
- Cumulative prior hand-deployed evolution: policy-gate hardening, link_github/link_status, submit_verdict.
- Manifest `contracts.tools` + description updated.

Evidence: 100/100 vitest in the openclaw container (host node 20 can't load index.test.ts — pre-existing undici mismatch). Live loop proven on praxis-e2e-sandbox#65: in-thread answer → praxisbot → provide_info → `applied:true` → GitHub mirror → question consumed.

NOTE: noob-root's local `development` is 1 commit ahead with exactly this commit — merging this PR lets the box `git pull --ff-only` cleanly.

https://claude.ai/code/session_019kqLhWDRhyHP3ZeXKWG1rm