### PR TITLE
praxis ext: address issues by repo + GitHub number

### DIFF
--- a/extensions/praxis/index.test.ts
+++ b/extensions/praxis/index.test.ts
@@ -108,3 +108,29 @@ describe("praxis tool handlers", () => {
     expect(out.error).toMatch(/Praxis API 404/);
   });
 });
+
+describe("by-number addressing (2026-07-08 pk/number conflation incident)", () => {
+  it("praxis_diagnose_issue hits the by-number route when given repo + number", async () => {
+    fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body: { id: 37 } }));
+
+    const { tools } = buildTools();
+    const out = parse(
+      await tools.praxis_diagnose_issue.execute("call-4", {
+        repo: "cloudwarriors-ai/scopely",
+        number: 837,
+      }),
+    );
+
+    expect(out).toEqual({ id: 37 });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://praxis:8000/api/v1/repos/cloudwarriors-ai/scopely/issues/837/diagnose",
+    );
+  });
+
+  it("praxis_get_issue errors clearly when neither addressing form is given", async () => {
+    const { tools } = buildTools();
+    const out = parse(await tools.praxis_get_issue.execute("call-5", {}));
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/repo \+ number|issue_id/);
+  });
+});

--- a/extensions/praxis/index.ts
+++ b/extensions/praxis/index.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
-import { listIssuesPath, praxisGet, praxisHealth } from "./praxis-client.js";
+import { issuePath, listIssuesPath, praxisGet, praxisHealth } from "./praxis-client.js";
 
 function jsonResult(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
@@ -76,14 +76,44 @@ const plugin = {
     optionalApi.registerTool(() => ({
       name: "praxis_get_issue",
       description:
-        "Get one Praxis issue by its Praxis id: current state, fuse counters, risk score, and its " +
-        "most recent events.",
+        "Get one Praxis issue: current state, fuse counters, risk score, and its most recent " +
+        "events. Address it by repo + GitHub issue number (preferred - e.g. repo " +
+        "'cloudwarriors-ai/scopely', number 837) or by Praxis's internal issue_id.",
       parameters: Type.Object({
-        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+        repo: Type.Optional(
+          Type.String({
+            description: "Repo full name, e.g. 'cloudwarriors-ai/scopely'. Use with `number`.",
+          }),
+        ),
+        number: Type.Optional(
+          Type.Number({
+            description:
+              "The GitHub issue number (the number in 'repo#123' references). Use with `repo`. " +
+              "PREFER this form - it is the reference humans give you.",
+          }),
+        ),
+        issue_id: Type.Optional(
+          Type.Number({
+            description:
+              "Praxis's INTERNAL issue id (from praxis_list_issues). NOT the GitHub issue " +
+              "number - feeding a GitHub number here returns a misleading 404.",
+          }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         try {
-          return jsonResult(await praxisGet(`/api/v1/issues/${params.issue_id as number}`));
+          return jsonResult(
+            await praxisGet(
+              issuePath(
+                {
+                  repo: params.repo as string | undefined,
+                  number: params.number as number | undefined,
+                  issue_id: params.issue_id as number | undefined,
+                },
+                "",
+              ),
+            ),
+          );
         } catch (err) {
           return errorResult(err);
         }
@@ -96,13 +126,43 @@ const plugin = {
       description:
         "Get the full event trace (append-only audit trail) for a Praxis issue: every state " +
         "transition with actor, from/to state, and reason. Use this to reconstruct how an issue " +
-        "reached its current state.",
+        "reached its current state. Address by repo + GitHub issue number (preferred) or " +
+        "Praxis internal issue_id.",
       parameters: Type.Object({
-        issue_id: Type.Number({ description: "The Praxis issue id" }),
+        repo: Type.Optional(
+          Type.String({
+            description: "Repo full name, e.g. 'cloudwarriors-ai/scopely'. Use with `number`.",
+          }),
+        ),
+        number: Type.Optional(
+          Type.Number({
+            description:
+              "The GitHub issue number (the number in 'repo#123' references). Use with `repo`. " +
+              "PREFER this form - it is the reference humans give you.",
+          }),
+        ),
+        issue_id: Type.Optional(
+          Type.Number({
+            description:
+              "Praxis's INTERNAL issue id (from praxis_list_issues). NOT the GitHub issue " +
+              "number - feeding a GitHub number here returns a misleading 404.",
+          }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         try {
-          return jsonResult(await praxisGet(`/api/v1/issues/${params.issue_id as number}/events`));
+          return jsonResult(
+            await praxisGet(
+              issuePath(
+                {
+                  repo: params.repo as string | undefined,
+                  number: params.number as number | undefined,
+                  issue_id: params.issue_id as number | undefined,
+                },
+                "/events",
+              ),
+            ),
+          );
         } catch (err) {
           return errorResult(err);
         }
@@ -116,14 +176,42 @@ const plugin = {
         "Diagnose WHY a Praxis issue is stuck: fuse counters vs their caps (at_cap = tripped to " +
         "blocked), open questions awaiting a human reply, the live resolver attempt, and any " +
         "unsettled outbox effects. This is the primary triage tool. The response is redacted by " +
-        "Praxis (no raw error text or tokens).",
+        "Praxis (no raw error text or tokens). Address by repo + GitHub issue number " +
+        "(preferred) or Praxis internal issue_id.",
       parameters: Type.Object({
-        issue_id: Type.Number({ description: "The Praxis issue id" }),
+        repo: Type.Optional(
+          Type.String({
+            description: "Repo full name, e.g. 'cloudwarriors-ai/scopely'. Use with `number`.",
+          }),
+        ),
+        number: Type.Optional(
+          Type.Number({
+            description:
+              "The GitHub issue number (the number in 'repo#123' references). Use with `repo`. " +
+              "PREFER this form - it is the reference humans give you.",
+          }),
+        ),
+        issue_id: Type.Optional(
+          Type.Number({
+            description:
+              "Praxis's INTERNAL issue id (from praxis_list_issues). NOT the GitHub issue " +
+              "number - feeding a GitHub number here returns a misleading 404.",
+          }),
+        ),
       }),
       async execute(_id: string, params: Record<string, unknown>) {
         try {
           return jsonResult(
-            await praxisGet(`/api/v1/issues/${params.issue_id as number}/diagnose`),
+            await praxisGet(
+              issuePath(
+                {
+                  repo: params.repo as string | undefined,
+                  number: params.number as number | undefined,
+                  issue_id: params.issue_id as number | undefined,
+                },
+                "/diagnose",
+              ),
+            ),
           );
         } catch (err) {
           return errorResult(err);

--- a/extensions/praxis/praxis-client.test.ts
+++ b/extensions/praxis/praxis-client.test.ts
@@ -126,3 +126,29 @@ describe("getPraxisBase", () => {
     expect(getPraxisBase()).toBe(BASE);
   });
 });
+
+describe("issuePath", () => {
+  it("prefers repo + number (the GitHub reference callers hold)", async () => {
+    const { issuePath } = await import("./praxis-client.js");
+    expect(issuePath({ repo: "cloudwarriors-ai/scopely", number: 837 })).toBe(
+      "/api/v1/repos/cloudwarriors-ai/scopely/issues/837",
+    );
+    expect(issuePath({ repo: "cw/app", number: 7 }, "/diagnose")).toBe(
+      "/api/v1/repos/cw/app/issues/7/diagnose",
+    );
+    // repo+number wins even when issue_id is also supplied.
+    expect(issuePath({ repo: "cw/app", number: 7, issue_id: 99 }, "/events")).toBe(
+      "/api/v1/repos/cw/app/issues/7/events",
+    );
+  });
+
+  it("falls back to the internal issue_id route", async () => {
+    const { issuePath } = await import("./praxis-client.js");
+    expect(issuePath({ issue_id: 37 }, "/diagnose")).toBe("/api/v1/issues/37/diagnose");
+  });
+
+  it("throws a naming-the-fix error when neither addressing form is given", async () => {
+    const { issuePath } = await import("./praxis-client.js");
+    expect(() => issuePath({})).toThrow(/repo \+ number.*issue_id/);
+  });
+});

--- a/extensions/praxis/praxis-client.ts
+++ b/extensions/praxis/praxis-client.ts
@@ -81,6 +81,27 @@ export function listIssuesPath(filters: { repo?: string; state?: string }): stri
   return qs ? `/api/v1/issues?${qs}` : "/api/v1/issues";
 }
 
+/** Build the per-issue path for either addressing mode. Callers hold `repo#number`
+ * (the GitHub reference in every conversation), so that form is preferred and maps to
+ * Praxis's by-number routes (praxis PR #168). `issue_id` is Praxis's INTERNAL pk —
+ * the 2026-07-08 incident was the support bot feeding GitHub numbers into the pk
+ * route and narrating the honest 404s as a repo-access problem. `suffix` is "" |
+ * "/events" | "/diagnose". */
+export function issuePath(
+  params: { repo?: string; number?: number; issue_id?: number },
+  suffix: "" | "/events" | "/diagnose" = "",
+): string {
+  if (params.repo && params.number !== undefined) {
+    return `/api/v1/repos/${params.repo}/issues/${params.number}${suffix}`;
+  }
+  if (params.issue_id !== undefined) {
+    return `/api/v1/issues/${params.issue_id}${suffix}`;
+  }
+  throw new Error(
+    "Provide either repo + number (GitHub reference) or issue_id (Praxis internal id)",
+  );
+}
+
 /** Connectivity + contract check: fetch the OpenAPI schema and confirm the
  * server's version matches the version this client targets. */
 export async function praxisHealth(): Promise<{ ok: boolean; version?: string; error?: string }> {


### PR DESCRIPTION
## Why

Live incident 2026-07-08 (dev_praxis Zoom channel): the Praxis Support agent fed GitHub issue numbers (837, 1006) into the praxis_* tools, whose only parameter was `issue_id` — **Praxis's internal pk** (scopely#837's pk is 37). The 404s were honest; the agent narrated them as *'Praxis can't access the repo.'* A controlled channel test after praxis's API fix ([praxis PR #168](https://github.com/cloudwarriors-ai/praxis/pull/168), deployed) still failed with `Praxis API 404 on both issue ids 837 and 1006` — because this tool schema offered no way to pass the reference humans actually give.

## What

`praxis_get_issue` / `praxis_list_events` / `praxis_diagnose_issue` now accept:
- **`repo` + `number`** (preferred — the GitHub reference) → praxis's new `/api/v1/repos/{repo}/issues/{number}[...]` routes
- **`issue_id`** (kept — internal ids from `praxis_list_issues`), description now warns explicitly against feeding GitHub numbers into it

`issuePath()` in praxis-client owns the addressing choice (repo+number wins when both given; clear error when neither).

## Evidence

```
pnpm exec vitest run extensions/praxis → 20 passed (5 new)
```

Verified server-side on noob-root before this PR: `GET /api/v1/repos/cloudwarriors-ai/scopely/issues/{837,1006,1008}` → correct states (user_uat / cancelled / cancelled).

https://claude.ai/code/session_015jmQkqMRNfbeCMwwNx29hM