### PR TITLE
rescue(scopelybot): recover unpushed prod support-tools + zoom formatting

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -2,6 +2,8 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { registerAdminTools } from "./src/admin-tools.js";
 import { createAuditLogger } from "./src/audit.js";
 import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import type { ScopelyBotConfig } from "./src/config.js";
+import { configuredWriteApprovers, resolveScopelyBotConfig } from "./src/config.js";
 import { tryExecuteConfirm } from "./src/confirm.js";
 import { registerCorrelationTools } from "./src/correlation-tools.js";
 import { registerDeploymentConfigTools } from "./src/deployment-config-tools.js";
@@ -13,10 +15,10 @@ import { registerPassthroughTools } from "./src/passthrough-tools.js";
 import { registerPricingTools } from "./src/pricing-tools.js";
 import { registerScopelyTools } from "./src/scopely-tools.js";
 import { registerScopingCardTools } from "./src/scoping-card-tools.js";
+import { registerSupportTools } from "./src/support-tools.js";
 import { registerUserMaintenanceTools } from "./src/user-maintenance-tools.js";
 import { registerVendorConfigTools } from "./src/vendor-config-tools.js";
-
-type PluginConfig = { scopelyRepos?: string[] };
+import { rewriteScopelyBotZoomMessage } from "./src/zoom-format.js";
 
 // A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
 // before_dispatch gate and the comfort-skip use one shape.
@@ -43,13 +45,24 @@ const plugin = {
         default: ["cloudwarriors-ai/scopely"],
         description: "GitHub repos scoped for Scopely issue management",
       },
+      serviceContainers: {
+        type: "array",
+        items: { type: "string" },
+        description: "Exact Docker container names Scopely support tools may inspect",
+      },
+      writeApproverIds: {
+        type: "array",
+        items: { type: "string" },
+        description: "Exact Zoom sender ids allowed to execute staged Scopely writes",
+      },
     },
   },
 
-  register(api: OpenClawPluginApi, config?: PluginConfig) {
+  register(api: OpenClawPluginApi, config?: ScopelyBotConfig) {
     const workspaceDir = process.env.OPENCLAW_WORKSPACE ?? "/root/.openclaw/workspace";
     const logger = createAuditLogger(workspaceDir);
-    const pluginConfig: PluginConfig = config ?? { scopelyRepos: ["cloudwarriors-ai/scopely"] };
+    const pluginConfig = resolveScopelyBotConfig(api.config, config);
+    const writeApproverIds = configuredWriteApprovers(pluginConfig);
 
     // Register every scopelybot tool as `optional: true` so per-agent allowlists
     // actually scope them: non-optional plugin tools bypass allowlists entirely and
@@ -74,6 +87,11 @@ const plugin = {
     registerVendorConfigTools(optionalApi, logger);
     registerDeploymentConfigTools(optionalApi, logger);
     registerScopingCardTools(optionalApi, logger);
+    registerSupportTools(optionalApi, logger, pluginConfig);
+
+    // Zoom card bodies do not render Markdown. Keep this rewrite at the Scopely
+    // plugin boundary so other agents and channels retain their existing output.
+    api.on("message_sending", (event, ctx) => rewriteScopelyBotZoomMessage(event.content, ctx));
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it
@@ -104,6 +122,7 @@ const plugin = {
         text,
         actor: ctx.senderId ?? "",
         conversationId: ctx.conversationId ?? "",
+        approverIds: writeApproverIds,
         logger,
       });
       // `handled: true` suppresses the coordinator so the CONFIRM cannot re-stage; the
@@ -148,7 +167,7 @@ const plugin = {
     }
 
     console.log(
-      "[scopelybot] Registered 86 tools (10 observability + 5 admin + 4 monitoring + 6 GH + 1 correlation + 2 passthrough + 9 user-maintenance + 8 org + 15 pricing + 13 vendor-config + 8 deployment-config + 5 scoping-card)",
+      "[scopelybot] Registered 97 tools (10 observability + 5 admin + 4 monitoring + 6 GH + 1 correlation + 2 passthrough + 9 user-maintenance + 8 org + 15 pricing + 13 vendor-config + 8 deployment-config + 5 scoping-card + 11 support)",
     );
   },
 };

--- a/extensions/scopelybot/openclaw.plugin.json
+++ b/extensions/scopelybot/openclaw.plugin.json
@@ -15,6 +15,20 @@
           "cloudwarriors-ai/scopely"
         ],
         "description": "GitHub repos scoped for Scopely issue management"
+      },
+      "serviceContainers": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Exact Docker container names Scopely support tools may inspect"
+      },
+      "writeApproverIds": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Exact Zoom sender ids allowed to execute staged Scopely writes"
       }
     }
   },
@@ -25,6 +39,7 @@
       "scopely_approve_access_request",
       "scopely_audit_logs",
       "scopely_auth_status",
+      "scopely_compare_session_versions",
       "scopely_correlate_errors",
       "scopely_create_currency",
       "scopely_create_deployment_type",
@@ -76,6 +91,8 @@
       "scopely_list_pricing_items",
       "scopely_list_project_types",
       "scopely_list_scoping_cards",
+      "scopely_list_services",
+      "scopely_list_session_versions",
       "scopely_list_sessions",
       "scopely_list_users",
       "scopely_list_vendor_terms",
@@ -88,7 +105,12 @@
       "scopely_reject_access_request",
       "scopely_remove_org_domain",
       "scopely_reset_user_password",
+      "scopely_reassign_session",
+      "scopely_refresh_docusign_status",
+      "scopely_resend_docusign",
+      "scopely_resend_user_verification",
       "scopely_search",
+      "scopely_session_status_counts",
       "scopely_session_pricing",
       "scopely_set_user_active",
       "scopely_update_currency",
@@ -105,7 +127,10 @@
       "scopely_update_vendor_term",
       "scopely_user_activity",
       "scopely_vendor_config",
-      "scopely_wizard_funnel"
+      "scopely_wizard_funnel",
+      "scopely_support_session",
+      "scopely_trace_logs",
+      "scopely_unlock_user"
     ]
   }
 }

--- a/extensions/scopelybot/src/audit.test.ts
+++ b/extensions/scopelybot/src/audit.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapToolWithAudit } from "./audit.js";
+
+describe("write audit summaries", () => {
+  it("does not describe a staged write as executed", async () => {
+    const logger = vi.fn();
+    const tool = wrapToolWithAudit(
+      {
+        name: "scopely_test_write",
+        description: "test",
+        parameters: {},
+        async execute() {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({ staged: true, awaiting_confirmation: true }),
+              },
+            ],
+          };
+        },
+      },
+      logger,
+    );
+
+    await tool.execute("call", {});
+
+    expect(logger).toHaveBeenCalledWith(
+      expect.objectContaining({ resultSummary: "staged: awaiting confirmation" }),
+    );
+  });
+});

--- a/extensions/scopelybot/src/audit.ts
+++ b/extensions/scopelybot/src/audit.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { redactValue } from "./redaction.js";
 
 export interface AuditEntry {
   ts: string;
@@ -57,6 +58,8 @@ export function wrapToolWithAudit(
         const parsed = JSON.parse(result.content[0]?.text ?? "{}");
         if (parsed.ok === false) {
           resultSummary = `error: ${parsed.error ?? "unknown"}`;
+        } else if (parsed.staged === true && parsed.awaiting_confirmation === true) {
+          resultSummary = "staged: awaiting confirmation";
         } else if (Array.isArray(parsed.data)) {
           resultSummary = `${parsed.data.length} items`;
         } else {
@@ -91,13 +94,5 @@ export function wrapToolWithAudit(
 }
 
 function sanitizeParams(params: Record<string, unknown>): Record<string, unknown> {
-  const clean: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(params)) {
-    if (typeof v === "string" && v.length > 200) {
-      clean[k] = v.slice(0, 200) + "...[truncated]";
-    } else {
-      clean[k] = v;
-    }
-  }
-  return clean;
+  return redactValue(params, { maxStringLength: 200 }) as Record<string, unknown>;
 }

--- a/extensions/scopelybot/src/config.test.ts
+++ b/extensions/scopelybot/src/config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveScopelyBotConfig } from "./config.js";
+
+describe("resolveScopelyBotConfig", () => {
+  it("reads the enabled plugin entry from the OpenClaw root config", () => {
+    const pluginConfig = {
+      scopelyRepos: ["cloudwarriors-ai/scopely"],
+      serviceContainers: ["scopely-scopely-backend-1"],
+      writeApproverIds: ["approved-sender"],
+    };
+    expect(
+      resolveScopelyBotConfig({ plugins: { entries: { scopelybot: { config: pluginConfig } } } }),
+    ).toEqual(pluginConfig);
+  });
+
+  it("lets an explicit test override win", () => {
+    const override = { serviceContainers: ["override"] };
+    expect(resolveScopelyBotConfig({}, override)).toBe(override);
+  });
+});

--- a/extensions/scopelybot/src/config.ts
+++ b/extensions/scopelybot/src/config.ts
@@ -1,0 +1,38 @@
+/** Shared, fail-closed configuration contract for ScopelyBot tools and writes. */
+
+export interface ScopelyBotConfig {
+  scopelyRepos?: string[];
+  serviceContainers?: string[];
+  writeApproverIds?: string[];
+}
+
+export function resolveScopelyBotConfig(
+  rootConfig: unknown,
+  override?: ScopelyBotConfig,
+): ScopelyBotConfig {
+  if (override) return override;
+  const root = rootConfig as {
+    plugins?: { entries?: { scopelybot?: { config?: ScopelyBotConfig } } };
+  };
+  return (
+    root.plugins?.entries?.scopelybot?.config ?? {
+      scopelyRepos: ["cloudwarriors-ai/scopely"],
+    }
+  );
+}
+
+export function configuredServiceContainers(config: ScopelyBotConfig): string[] {
+  const values = config.serviceContainers?.map((value) => value.trim()).filter(Boolean) ?? [];
+  if (values.length === 0 || new Set(values).size !== values.length) {
+    throw new Error(
+      "Scopely serviceContainers must be a non-empty, duplicate-free exact allowlist",
+    );
+  }
+  return values;
+}
+
+export function configuredWriteApprovers(config: ScopelyBotConfig): string[] {
+  return [
+    ...new Set((config.writeApproverIds ?? []).map((value) => value.trim().toLowerCase())),
+  ].filter(Boolean);
+}

--- a/extensions/scopelybot/src/confirm.test.ts
+++ b/extensions/scopelybot/src/confirm.test.ts
@@ -1,0 +1,55 @@
+/** Confirm authorization tests ensure shared-channel codes remain actor-bound. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const takePendingMock = vi.fn();
+vi.mock("./pending-confirm.js", () => ({
+  takePending: (...args: unknown[]) => takePendingMock(...args),
+}));
+
+import { isApprovedWriteActor, tryExecuteConfirm } from "./confirm.js";
+
+const logger = vi.fn();
+const approver = "Mb4vcQ4YQUaQKJjoY4vntQ";
+
+describe("ScopelyBot confirmation actor gate", () => {
+  beforeEach(() => {
+    takePendingMock.mockReset();
+    logger.mockReset();
+  });
+
+  it("normalizes exact opaque sender ids", () => {
+    expect(isApprovedWriteActor(approver, [approver.toLowerCase()])).toBe(true);
+    expect(isApprovedWriteActor("other", [approver])).toBe(false);
+    expect(isApprovedWriteActor(approver, [])).toBe(false);
+  });
+
+  it("does not consume a valid code when the same-channel actor is unauthorized", async () => {
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 1234",
+      actor: "unauthorized-member-id",
+      conversationId: "vipbot_prod",
+      approverIds: [approver],
+      logger,
+    });
+    expect(result).toContain("not authorized");
+    expect(takePendingMock).not.toHaveBeenCalled();
+  });
+
+  it("executes once for an approved actor and hides backend failure bodies", async () => {
+    takePendingMock.mockReturnValue({
+      summary: "unlock user 7",
+      run: vi.fn().mockResolvedValue({ ok: false, status: 502, data: { token: "secret" } }),
+    });
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 1234",
+      actor: approver,
+      conversationId: "vipbot_prod",
+      approverIds: [approver],
+      logger,
+    });
+    expect(takePendingMock).toHaveBeenCalledWith("1234", "vipbot_prod");
+    expect(result).toContain("HTTP 502");
+    expect(result).not.toContain("secret");
+  });
+});

--- a/extensions/scopelybot/src/confirm.ts
+++ b/extensions/scopelybot/src/confirm.ts
@@ -7,6 +7,13 @@
 
 import type { AuditLogger } from "./audit.js";
 import { takePending } from "./pending-confirm.js";
+import { redactText } from "./redaction.js";
+
+export function isApprovedWriteActor(actor: string, approverIds: string[]): boolean {
+  const normalized = actor.trim().toLowerCase();
+  const allowed = new Set(approverIds.map((value) => value.trim().toLowerCase()).filter(Boolean));
+  return Boolean(normalized) && allowed.size > 0 && allowed.has(normalized);
+}
 
 // Called from the before_dispatch handler. If the inbound text is `CONFIRM <code>`
 // for a live pending action, execute it and return a human-readable result string.
@@ -15,10 +22,16 @@ export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
   conversationId: string;
+  approverIds: string[];
   logger: AuditLogger;
 }): Promise<string | null> {
   const m = params.text.trim().match(/^CONFIRM\s+(\d{4})\b/i);
   if (!m) return null;
+  // Check identity before touching the pending store. An unauthorized user in
+  // the correct channel cannot execute OR consume a valid pending action.
+  if (!isApprovedWriteActor(params.actor, params.approverIds)) {
+    return "Write confirmation is not authorized for this Zoom identity.";
+  }
   // Channel-scoped: only consumes an action staged for THIS conversation.
   const action = takePending(m[1], params.conversationId);
   if (!action) {
@@ -37,9 +50,9 @@ export async function tryExecuteConfirm(params: {
     });
     return res.ok
       ? `✅ Done: ${action.summary}.`
-      : `❌ Failed (HTTP ${res.status}): ${action.summary}. ${JSON.stringify(res.data).slice(0, 200)}`;
+      : `❌ Failed (HTTP ${res.status}): ${action.summary}.`;
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = redactText(err instanceof Error ? err.message : String(err), 500);
     params.logger({
       ts: new Date().toISOString(),
       tool: "scopely_confirm_execute",
@@ -49,6 +62,6 @@ export async function tryExecuteConfirm(params: {
       error: msg,
       durationMs: Date.now() - start,
     });
-    return `❌ Error executing ${action.summary}: ${msg}`;
+    return `❌ Error executing ${action.summary}.`;
   }
 }

--- a/extensions/scopelybot/src/correlation-tools.ts
+++ b/extensions/scopelybot/src/correlation-tools.ts
@@ -3,20 +3,14 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import type { ScopelyBotConfig } from "./config.js";
+import { traceScopelyLogs } from "./devtools-client.js";
 import { jsonResult, errorResult } from "./scopely-api.js";
-
-const DEVTOOLS_BASE = () =>
-  process.env.SCOPELY_DEVTOOLS_API_URL ??
-  process.env.DEVTOOLS_API_URL ??
-  "https://devtools-api.cloudwarriors.ai";
-const DEVTOOLS_TOKEN = () => process.env.SCOPELY_DEV_TOOLS_API ?? process.env.DEV_TOOLS_API ?? "";
-
-type PluginConfig = { scopelyRepos?: string[] };
 
 export function registerCorrelationTools(
   api: OpenClawPluginApi,
   logger: AuditLogger,
-  config: PluginConfig,
+  config: ScopelyBotConfig,
 ) {
   api.registerTool(() =>
     wrapToolWithAudit(
@@ -49,37 +43,16 @@ export function registerCorrelationTools(
               (params.container as string) ||
               process.env.SCOPELY_CONTAINER ||
               "scopely-scopely-backend-1";
-            const tail = (params.tail as number) || 500;
-            const since = params.since as string | undefined;
-
-            // 1. Search container logs via devtools API
-            let logMatches: string[] = [];
-            const token = DEVTOOLS_TOKEN();
-            if (token) {
-              const qs = new URLSearchParams({ tail: String(tail) });
-              if (since) {
-                qs.set("since", since);
-              }
-              try {
-                const resp = await fetch(
-                  `${DEVTOOLS_BASE()}/api/v1/containers/${encodeURIComponent(container)}/logs?${qs}`,
-                  { headers: { Authorization: `Bearer ${token}` } },
-                );
-                if (resp.ok) {
-                  const data = (await resp.json()) as { logs?: string };
-                  const logText =
-                    typeof data === "string" ? data : (data.logs ?? JSON.stringify(data));
-                  const lines = logText.split("\n");
-                  const lowerPattern = pattern.toLowerCase();
-                  logMatches = lines.filter((l: string) => l.toLowerCase().includes(lowerPattern));
-                }
-              } catch {
-                // devtools unavailable, continue with GH search
-              }
-            }
+            const logResult = await traceScopelyLogs(config, {
+              pattern,
+              containers: [container],
+              tail: params.tail,
+              since: params.since,
+            });
 
             // 2. Search GitHub issues for similar patterns
             let ghMatches: unknown = [];
+            let ghSource: Record<string, unknown> = { ok: false };
             try {
               const repo = (config.scopelyRepos ?? ["cloudwarriors-ai/scopely"])[0];
               const query = pattern.slice(0, 100);
@@ -104,18 +77,20 @@ export function registerCorrelationTools(
                 },
               );
               ghMatches = JSON.parse(result);
-            } catch {
-              // gh search failed, continue
+              ghSource = { ok: true };
+            } catch (err) {
+              ghSource = { ok: false, error: err instanceof Error ? err.message : String(err) };
             }
 
             return jsonResult({
-              ok: true,
+              ok: logResult.ok || ghSource.ok === true,
               pattern,
               container,
-              logMatches: {
-                count: logMatches.length,
-                lines: logMatches.slice(0, 50),
+              sources: {
+                logs: logResult.results[0]?.source ?? { ok: false, error: "no log result" },
+                github: ghSource,
               },
+              logMatches: logResult.results[0]?.matches ?? [],
               ghIssues: ghMatches,
             });
           } catch (err) {

--- a/extensions/scopelybot/src/deployment-config-tools.test.ts
+++ b/extensions/scopelybot/src/deployment-config-tools.test.ts
@@ -113,6 +113,7 @@ describe("deployment-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -131,6 +132,7 @@ describe("deployment-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/devtools-client.test.ts
+++ b/extensions/scopelybot/src/devtools-client.test.ts
@@ -1,0 +1,23 @@
+/** Time-normalization tests prevent ambiguous DevTools query behavior. */
+
+import { describe, expect, it } from "vitest";
+import { normalizeEpoch } from "./devtools-client.js";
+
+describe("normalizeEpoch", () => {
+  const now = Date.parse("2026-07-18T12:00:00Z");
+
+  it("normalizes relative, ISO, and epoch inputs", () => {
+    expect(normalizeEpoch("1h", now)).toBe(Math.floor(now / 1000) - 3600);
+    expect(normalizeEpoch("30m", now)).toBe(Math.floor(now / 1000) - 1800);
+    expect(normalizeEpoch("2026-07-18T11:00:00Z", now)).toBe(
+      Math.floor(Date.parse("2026-07-18T11:00:00Z") / 1000),
+    );
+    expect(normalizeEpoch("1234", now)).toBe(1234);
+  });
+
+  it("rejects ambiguous values", () => {
+    for (const value of ["1hour", "yesterday", -1, 1.5, {}]) {
+      expect(() => normalizeEpoch(value, now)).toThrow();
+    }
+  });
+});

--- a/extensions/scopelybot/src/devtools-client.ts
+++ b/extensions/scopelybot/src/devtools-client.ts
@@ -1,0 +1,185 @@
+/** Bounded, fail-explicit client for Scopely application container logs. */
+
+import type { ScopelyBotConfig } from "./config.js";
+import { configuredServiceContainers } from "./config.js";
+import { redactText } from "./redaction.js";
+
+type ContainerInfo = {
+  id?: string;
+  name?: string;
+  image?: string;
+  state?: string;
+  status?: string;
+  created?: number;
+};
+
+export type SourceState = {
+  ok: boolean;
+  base?: string;
+  status?: number;
+  error?: string;
+};
+
+const DEVTOOLS_TOKEN = () => process.env.SCOPELY_DEV_TOOLS_API ?? process.env.DEV_TOOLS_API ?? "";
+const MAX_LOG_LINES = 50;
+const MAX_LOG_BYTES = 24_000;
+
+function bases(): string[] {
+  return [
+    process.env.DEVTOOLS_API_URL,
+    process.env.SCOPELY_DEVTOOLS_API_URL,
+    "https://devtools-api.cloudwarriors.ai",
+  ]
+    .map((value) => value?.trim().replace(/\/$/, ""))
+    .filter((value): value is string => Boolean(value))
+    .filter((value, index, values) => values.indexOf(value) === index);
+}
+
+async function devtoolsRequest(path: string): Promise<{
+  state: SourceState;
+  response?: Response;
+}> {
+  const token = DEVTOOLS_TOKEN();
+  if (!token) return { state: { ok: false, error: "DevTools token is not configured" } };
+  const failures: string[] = [];
+  for (const base of bases()) {
+    try {
+      const response = await fetch(`${base}${path}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (response.ok) return { state: { ok: true, base, status: response.status }, response };
+      failures.push(`${base}: HTTP ${response.status}`);
+    } catch (err) {
+      failures.push(`${base}: ${err instanceof Error ? err.name : "request failed"}`);
+    }
+  }
+  return { state: { ok: false, error: failures.join("; ").slice(0, 500) } };
+}
+
+export function normalizeEpoch(value: unknown, nowMs = Date.now()): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) throw new Error("time must be epoch seconds");
+    return value;
+  }
+  if (typeof value !== "string") throw new Error("time must be relative, ISO, or epoch seconds");
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed)) throw new Error("time is outside the safe integer range");
+    return parsed;
+  }
+  const relative = trimmed.match(/^(\d+)([mhd])$/i);
+  if (relative) {
+    const amount = Number(relative[1]);
+    const seconds = amount * ({ m: 60, h: 3600, d: 86400 }[relative[2].toLowerCase()] ?? 0);
+    return Math.max(0, Math.floor(nowMs / 1000) - seconds);
+  }
+  const iso = Date.parse(trimmed);
+  if (!Number.isFinite(iso))
+    throw new Error("time must be like 30m, 1h, ISO-8601, or epoch seconds");
+  return Math.floor(iso / 1000);
+}
+
+function normalizeTail(value: unknown): number {
+  const parsed = value === undefined ? 500 : Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) throw new Error("tail must be a positive integer");
+  return Math.min(parsed, 1000);
+}
+
+export async function listScopelyServices(config: ScopelyBotConfig) {
+  const allowed = configuredServiceContainers(config);
+  const request = await devtoolsRequest("/api/v1/containers");
+  if (!request.response) {
+    return {
+      ok: false,
+      source: request.state,
+      services: allowed.map((name) => ({ name, discovered: false })),
+    };
+  }
+  let containers: ContainerInfo[];
+  try {
+    const data = await request.response.json();
+    if (!Array.isArray(data)) throw new Error("unexpected container-list response");
+    containers = data as ContainerInfo[];
+  } catch (err) {
+    return {
+      ok: false,
+      source: {
+        ...request.state,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      },
+      services: allowed.map((name) => ({ name, discovered: false })),
+    };
+  }
+  const byName = new Map(containers.map((container) => [container.name, container]));
+  return {
+    ok: true,
+    source: request.state,
+    services: allowed.map((name) => {
+      const container = byName.get(name);
+      return container
+        ? {
+            name,
+            discovered: true,
+            image: container.image,
+            state: container.state,
+            status: container.status,
+          }
+        : { name, discovered: false };
+    }),
+  };
+}
+
+export async function traceScopelyLogs(config: ScopelyBotConfig, params: Record<string, unknown>) {
+  const allowed = configuredServiceContainers(config);
+  const requested = Array.isArray(params.containers)
+    ? params.containers.map((value) => String(value))
+    : allowed;
+  if (requested.length === 0 || requested.some((name) => !allowed.includes(name))) {
+    throw new Error("containers must be a non-empty subset of the exact Scopely service allowlist");
+  }
+  const pattern = typeof params.pattern === "string" ? params.pattern.trim() : "";
+  if (!pattern || pattern.length > 200) throw new Error("pattern must be 1-200 characters");
+  const tail = normalizeTail(params.tail);
+  const since = normalizeEpoch(params.since);
+  const until = normalizeEpoch(params.until);
+  if (since !== undefined && until !== undefined && until < since) {
+    throw new Error("until must be greater than or equal to since");
+  }
+
+  const results = await Promise.all(
+    requested.map(async (container) => {
+      const query = new URLSearchParams({ tail: String(tail) });
+      if (since !== undefined) query.set("since", String(since));
+      if (until !== undefined) query.set("until", String(until));
+      const request = await devtoolsRequest(
+        `/api/v1/containers/${encodeURIComponent(container)}/logs?${query.toString()}`,
+      );
+      if (!request.response) {
+        return { container, source: request.state, matches: [] as string[] };
+      }
+      const text = await request.response.text();
+      const needle = pattern.toLowerCase();
+      let bytes = 0;
+      const matches: string[] = [];
+      for (const line of text.split("\n")) {
+        if (!line.toLowerCase().includes(needle)) continue;
+        const safe = redactText(line, 2_000);
+        const size = Buffer.byteLength(safe, "utf8");
+        if (matches.length >= MAX_LOG_LINES || bytes + size > MAX_LOG_BYTES) break;
+        matches.push(safe);
+        bytes += size;
+      }
+      return { container, source: request.state, matches };
+    }),
+  );
+  return {
+    ok: results.some((result) => result.source.ok),
+    pattern,
+    window: { since, until, tail },
+    results,
+  };
+}

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -9,6 +9,7 @@
 
 import { getChannelThreadAnchor, sendScopelyText } from "./comfort.js";
 import { makeCode, putPending } from "./pending-confirm.js";
+import { redactText } from "./redaction.js";
 import { jsonResult } from "./scopely-api.js";
 
 type FetchResult = Promise<{ ok: boolean; status: number; data: unknown }>;
@@ -42,9 +43,10 @@ export async function stageWrite(summary: string, run: () => FetchResult) {
   // Bind the staged action to that channel: only a CONFIRM from it can fire the
   // action (takePending enforces the match). Code is unpredictable (crypto).
   const code = makeCode();
-  putPending({ code, conversationId: channel, summary, run });
+  const safeSummary = redactText(summary, 500);
+  putPending({ code, conversationId: channel, summary: safeSummary, run });
   const prompt =
-    `⚠️ Confirm: ${summary} on PROD.\n` +
+    `⚠️ Confirm: ${safeSummary} on PROD.\n` +
     `Reply \`CONFIRM ${code}\` within 5 minutes to proceed, or ignore to cancel.`;
 
   await sendScopelyText(channel, prompt, getChannelThreadAnchor(channel));

--- a/extensions/scopelybot/src/gh-tools.test.ts
+++ b/extensions/scopelybot/src/gh-tools.test.ts
@@ -2,11 +2,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the process boundary so no real `gh` command ever runs and we can assert that
 // LLM-controlled values reach gh as literal argv elements (execFileSync = no shell),
-// never a shell string. scopelybot's gh writes are NOT confirm-gated — they execute
-// immediately — so injection safety here rests entirely on argv (no shell).
+// never a shell string. Writes are staged and the captured closure is exercised
+// separately so no command can run before confirmation.
 const execFileSyncMock = vi.fn();
+const stagedRuns: Array<() => Promise<unknown>> = [];
 vi.mock("node:child_process", () => ({
   execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+}));
+
+vi.mock("./gated.js", () => ({
+  stageWrite: (_summary: string, run: () => Promise<unknown>) => {
+    stagedRuns.push(run);
+    return Promise.resolve({
+      content: [
+        { type: "text", text: JSON.stringify({ staged: true, awaiting_confirmation: true }) },
+      ],
+    });
+  },
 }));
 
 vi.mock("./scopely-api.js", () => ({
@@ -57,6 +69,7 @@ function ghArgvContaining(token: string): string[] | undefined {
 describe("scopelybot gh tools are injection-safe (execFileSync, no shell)", () => {
   beforeEach(() => {
     execFileSyncMock.mockReset();
+    stagedRuns.length = 0;
   });
 
   it("every gh call passes argv to execFileSync, not a shell string", async () => {
@@ -80,14 +93,29 @@ describe("scopelybot gh tools are injection-safe (execFileSync, no shell)", () =
     expect(argv).toContain(malicious);
   });
 
-  it("create passes a metachar title as ONE verbatim argv element (executes immediately)", async () => {
+  it("create stages first, then passes a metachar title as ONE verbatim argv element", async () => {
     const tools = buildTools();
     execFileSyncMock.mockReturnValue("https://github.com/cloudwarriors-ai/scopely/issues/9");
     const title = 'Crash "$(rm -rf /)" `id`';
     await tools.scopely_gh_create_issue.execute("t", { title, body: "x" });
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(stagedRuns).toHaveLength(1);
+    await stagedRuns[0]();
     const argv = ghArgvContaining("create");
     expect(argv).toBeDefined();
     expect(argv).toContain(title);
+  });
+
+  it("comment and close are separate staged writes", async () => {
+    const tools = buildTools();
+    execFileSyncMock.mockReturnValue("ok");
+    await tools.scopely_gh_add_comment.execute("t", { number: 9, body: "QA" });
+    await tools.scopely_gh_close_issue.execute("t", { number: 9, reason: "completed" });
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(stagedRuns).toHaveLength(2);
+    await stagedRuns[0]();
+    await stagedRuns[1]();
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
   });
 
   it("get_issue rejects a non-integer issue number and never shells out", async () => {

--- a/extensions/scopelybot/src/gh-tools.ts
+++ b/extensions/scopelybot/src/gh-tools.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
 import { jsonResult, errorResult } from "./scopely-api.js";
 
 type PluginConfig = { scopelyRepos?: string[] };
@@ -171,27 +172,29 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             const labels = params.labels as string[] | undefined;
             const title = typeof params.title === "string" ? params.title : "";
             const body = typeof params.body === "string" ? params.body : "";
-            const result = execFileSync(
-              "gh",
-              [
-                "issue",
-                "create",
-                "--repo",
-                repo,
-                "--title",
-                title,
-                ...(labels?.length ? ["--label", labels.join(",")] : []),
-                "--body-file",
-                "-",
-              ],
-              {
-                encoding: "utf-8",
-                input: body,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            return jsonResult({ ok: true, url: result.trim() });
+            return await stageWrite(`create GitHub issue in ${repo}: ${title}`, async () => {
+              const result = execFileSync(
+                "gh",
+                [
+                  "issue",
+                  "create",
+                  "--repo",
+                  repo,
+                  "--title",
+                  title,
+                  ...(labels?.length ? ["--label", labels.join(",")] : []),
+                  "--body-file",
+                  "-",
+                ],
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return { ok: true, status: 201, data: { url: result.trim() } };
+            });
           } catch (err) {
             return errorResult(err);
           }
@@ -220,17 +223,19 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             assertAllowedRepo(repo, config);
             const issueNumber = assertIssueNumber(params.number);
             const body = typeof params.body === "string" ? params.body : "";
-            const result = execFileSync(
-              "gh",
-              ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
-              {
-                encoding: "utf-8",
-                input: body,
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-              },
-            );
-            return jsonResult({ ok: true, url: result.trim() });
+            return await stageWrite(`comment on GitHub issue ${repo}#${issueNumber}`, async () => {
+              const result = execFileSync(
+                "gh",
+                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
+                {
+                  encoding: "utf-8",
+                  input: body,
+                  timeout: 30000,
+                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                },
+              );
+              return { ok: true, status: 200, data: { url: result.trim() } };
+            });
           } catch (err) {
             return errorResult(err);
           }
@@ -291,9 +296,6 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
             Type.String({ description: "Repo (owner/name). Defaults to primary Scopely repo." }),
           ),
           number: Type.Number({ description: "Issue number" }),
-          comment: Type.Optional(
-            Type.String({ description: "Closing comment to post before closing." }),
-          ),
           reason: Type.Optional(
             Type.String({ description: "Close reason: completed or not_planned." }),
           ),
@@ -308,38 +310,25 @@ export function registerGhTools(api: OpenClawPluginApi, logger: AuditLogger, con
               params.reason.trim().toLowerCase() === "not_planned"
                 ? "not planned"
                 : "completed";
-            const closingComment = typeof params.comment === "string" ? params.comment.trim() : "";
-
-            if (closingComment) {
-              execFileSync(
-                "gh",
-                ["issue", "comment", String(issueNumber), "--repo", repo, "--body-file", "-"],
-                {
-                  encoding: "utf-8",
-                  input: closingComment,
-                  timeout: 30000,
-                  env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
-                },
-              );
-            }
-
-            const closeOutput = execFileSync(
-              "gh",
-              ["issue", "close", String(issueNumber), "--repo", repo, "--reason", reason],
-              {
-                encoding: "utf-8",
-                timeout: 30000,
-                env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+            return await stageWrite(
+              `close GitHub issue ${repo}#${issueNumber} as ${reason}`,
+              async () => {
+                const closeOutput = execFileSync(
+                  "gh",
+                  ["issue", "close", String(issueNumber), "--repo", repo, "--reason", reason],
+                  {
+                    encoding: "utf-8",
+                    timeout: 30000,
+                    env: { ...process.env, GH_NO_UPDATE_NOTIFIER: "1" },
+                  },
+                ).trim();
+                return {
+                  ok: true,
+                  status: 200,
+                  data: { number: issueNumber, repo, closeOutput, closeReason: reason },
+                };
               },
-            ).trim();
-
-            return jsonResult({
-              ok: true,
-              number: issueNumber,
-              repo,
-              closeOutput,
-              closeReason: reason,
-            });
+            );
           } catch (err) {
             return errorResult(err);
           }

--- a/extensions/scopelybot/src/org-tools.test.ts
+++ b/extensions/scopelybot/src/org-tools.test.ts
@@ -114,6 +114,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -135,6 +136,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -151,6 +153,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -169,6 +172,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -186,6 +190,7 @@ describe("org-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/pricing-tools.test.ts
+++ b/extensions/scopelybot/src/pricing-tools.test.ts
@@ -138,6 +138,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -170,6 +171,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -195,6 +197,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -211,6 +214,7 @@ describe("pricing-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/redaction.test.ts
+++ b/extensions/scopelybot/src/redaction.test.ts
@@ -1,0 +1,34 @@
+/** Regression tests for nested secret and PII redaction at tool boundaries. */
+
+import { describe, expect, it } from "vitest";
+import { redactText, redactValue } from "./redaction.js";
+
+describe("ScopelyBot redaction", () => {
+  it("redacts nested secret keys without mutating safe fields", () => {
+    expect(
+      redactValue({
+        safe: "keep",
+        nested: { password: "hunter2", authorization: "Bearer abc.def" },
+        rows: [{ refresh_token: "xyz", id: 7 }],
+      }),
+    ).toEqual({
+      safe: "keep",
+      nested: { password: "[REDACTED]", authorization: "[REDACTED]" },
+      rows: [{ refresh_token: "[REDACTED]", id: 7 }],
+    });
+  });
+
+  it("redacts credentials, email addresses, and phone numbers embedded in text", () => {
+    const result = redactText(
+      "Authorization: Bearer abc.def user=casey@example.com phone=(212) 555-0199 access_token=xyz",
+    );
+    expect(result).not.toContain("abc.def");
+    expect(result).not.toContain("casey@example.com");
+    expect(result).not.toContain("212");
+    expect(result).not.toContain("xyz");
+  });
+
+  it("bounds long strings", () => {
+    expect(redactText("x".repeat(100), 10)).toBe("xxxxxxxxxx...[truncated]");
+  });
+});

--- a/extensions/scopelybot/src/redaction.ts
+++ b/extensions/scopelybot/src/redaction.ts
@@ -1,0 +1,43 @@
+/** Recursively remove credentials and direct PII before tool data crosses a boundary. */
+
+const SENSITIVE_KEY_RE =
+  /(?:^|_)(?:password|passwd|secret|token|api[_-]?key|authorization|cookie|set-cookie|access_token|refresh_token|client_secret)(?:$|_)/i;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const PHONE_RE = /(?<![\w-])(?:\+\d{1,3}[ .-]?)?(?:\(?\d{3}\)?[ .-])\d{3}[ .-]\d{4}(?![\w-])/g;
+const BEARER_RE = /\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+\/-]+=*/gi;
+const COOKIE_RE = /\b(?:access_token|refresh_token|sessionid|csrftoken)=[^;\s]+/gi;
+const NAMED_SECRET_RE =
+  /\b(password|passwd|secret|token|api[_-]?key|authorization|cookie)\b\s*[:=]\s*([^\s,;]+)/gi;
+
+export function redactText(value: string, maxLength = 20_000): string {
+  const redacted = value
+    .replace(BEARER_RE, "[REDACTED_AUTH]")
+    .replace(COOKIE_RE, "[REDACTED_COOKIE]")
+    .replace(NAMED_SECRET_RE, (_match, name: string) => `${name}=[REDACTED]`)
+    .replace(EMAIL_RE, "[REDACTED_EMAIL]")
+    .replace(PHONE_RE, "[REDACTED_PHONE]");
+  return redacted.length > maxLength ? `${redacted.slice(0, maxLength)}...[truncated]` : redacted;
+}
+
+export function redactValue(
+  value: unknown,
+  options: { maxStringLength?: number; depth?: number } = {},
+): unknown {
+  const maxStringLength = options.maxStringLength ?? 20_000;
+  const depth = options.depth ?? 0;
+  if (depth > 12) return "[REDACTED_DEPTH]";
+  if (typeof value === "string") return redactText(value, maxStringLength);
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item, { maxStringLength, depth: depth + 1 }));
+  }
+  if (value && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      result[key] = SENSITIVE_KEY_RE.test(key)
+        ? "[REDACTED]"
+        : redactValue(item, { maxStringLength, depth: depth + 1 });
+    }
+    return result;
+  }
+  return value;
+}

--- a/extensions/scopelybot/src/scopely-api.ts
+++ b/extensions/scopelybot/src/scopely-api.ts
@@ -1,3 +1,4 @@
+import { redactText, redactValue } from "./redaction.js";
 import { scopelyCookieHeader, scopelyEnsureAuth, scopelyClearSession } from "./scopely-auth.js";
 
 const SCOPELY_URL = () =>
@@ -43,11 +44,11 @@ export async function scopelyFetch(
 }
 
 export function jsonResult(data: unknown) {
-  return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+  return { content: [{ type: "text" as const, text: JSON.stringify(redactValue(data)) }] };
 }
 
 export function errorResult(err: unknown) {
-  const message = err instanceof Error ? err.message : String(err);
+  const message = redactText(err instanceof Error ? err.message : String(err), 1000);
   return {
     content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }) }],
   };

--- a/extensions/scopelybot/src/scoping-card-tools.test.ts
+++ b/extensions/scopelybot/src/scoping-card-tools.test.ts
@@ -119,6 +119,7 @@ describe("scoping-card-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -151,6 +152,7 @@ describe("scoping-card-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/support-tools.test.ts
+++ b/extensions/scopelybot/src/support-tools.test.ts
@@ -1,0 +1,125 @@
+/** Contract tests for the eleven bounded support tools and staged writes. */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scopelyFetchMock = vi.fn();
+const stageWriteMock = vi.fn();
+vi.mock("./scopely-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./scopely-api.js")>("./scopely-api.js");
+  return { ...actual, scopelyFetch: (...args: unknown[]) => scopelyFetchMock(...args) };
+});
+vi.mock("./gated.js", () => ({
+  stageWrite: (...args: unknown[]) => {
+    stageWriteMock(...args);
+    return Promise.resolve({
+      content: [
+        { type: "text", text: JSON.stringify({ staged: true, awaiting_confirmation: true }) },
+      ],
+    });
+  },
+}));
+vi.mock("./devtools-client.js", () => ({
+  listScopelyServices: vi.fn().mockResolvedValue({ ok: true, services: [] }),
+  traceScopelyLogs: vi.fn().mockResolvedValue({ ok: true, results: [] }),
+}));
+
+import { registerSupportTools } from "./support-tools.js";
+
+type Tool = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+function buildTools() {
+  const tools: Record<string, Tool> = {};
+  const api = {
+    registerTool: (factory: () => Tool) => {
+      const tool = factory();
+      tools[tool.name] = tool;
+    },
+  } as never;
+  registerSupportTools(api, (() => {}) as never, {
+    serviceContainers: ["scopely-scopely-backend-1"],
+    writeApproverIds: ["approver"],
+  });
+  return tools;
+}
+
+function parse(result: { content: { text: string }[] }) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe("Scopely support tools", () => {
+  beforeEach(() => {
+    scopelyFetchMock.mockReset();
+    stageWriteMock.mockReset();
+  });
+
+  it("registers the exact eleven support tools", () => {
+    expect(Object.keys(buildTools()).sort()).toEqual(
+      [
+        "scopely_compare_session_versions",
+        "scopely_list_services",
+        "scopely_list_session_versions",
+        "scopely_reassign_session",
+        "scopely_refresh_docusign_status",
+        "scopely_resend_docusign",
+        "scopely_resend_user_verification",
+        "scopely_session_status_counts",
+        "scopely_support_session",
+        "scopely_trace_logs",
+        "scopely_unlock_user",
+      ].sort(),
+    );
+  });
+
+  it("shapes a session support bundle and omits direct PII/answers", async () => {
+    const tools = buildTools();
+    scopelyFetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          id: 7,
+          company_name: "Example",
+          status: "in_progress",
+          contact_email: "person@example.com",
+          answers: { password: "secret" },
+          pricing_snapshot: { grand_total: "100", currency_code: "USD", internal: "omit" },
+        },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: {
+          session_id: "7",
+          timeline: [
+            {
+              wizard_step: "company",
+              "@timestamp": "2026-07-18T00:00:00Z",
+              duration_to_next_ms: 1,
+            },
+          ],
+        },
+      });
+    const result = parse(await tools.scopely_support_session.execute("x", { session_id: 7 }));
+    expect(result.detail).not.toHaveProperty("contact_email");
+    expect(result.detail).not.toHaveProperty("answers");
+    expect(result.detail.pricing_snapshot).toEqual({ grand_total: "100", currency_code: "USD" });
+    expect(result.timeline.timeline[0]).toHaveProperty("@timestamp");
+  });
+
+  it("stages every new mutation without calling the backend", async () => {
+    const tools = buildTools();
+    await tools.scopely_unlock_user.execute("x", { user_id: 1 });
+    await tools.scopely_resend_user_verification.execute("x", { user_id: 1 });
+    await tools.scopely_reassign_session.execute("x", { session_id: 1, organization_id: 2 });
+    await tools.scopely_refresh_docusign_status.execute("x", { session_id: 1 });
+    await tools.scopely_resend_docusign.execute("x", { session_id: 1 });
+    expect(stageWriteMock).toHaveBeenCalledTimes(5);
+    expect(scopelyFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/scopelybot/src/support-tools.ts
+++ b/extensions/scopelybot/src/support-tools.ts
@@ -1,0 +1,425 @@
+/** High-value, bounded support workflows for Scopely PE/PM incident handling. */
+
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import type { ScopelyBotConfig } from "./config.js";
+import { traceScopelyLogs, listScopelyServices } from "./devtools-client.js";
+import { stageWrite } from "./gated.js";
+import { buildQuery, errorResult, jsonResult, scopelyFetch } from "./scopely-api.js";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function positiveId(value: unknown, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0)
+    throw new Error(`${name} must be a positive integer`);
+  return parsed;
+}
+
+function shapeSession(value: unknown) {
+  const data = asRecord(value);
+  const pricing = asRecord(data.pricing_snapshot);
+  return {
+    id: data.id,
+    company_name: data.company_name,
+    status: data.status,
+    organization_name: data.organization_name,
+    source_vendor_key: data.source_vendor_key,
+    destination_vendor_key: data.destination_vendor_key,
+    project_type: data.project_type,
+    deployment_type: data.deployment_type,
+    created_at: data.created_at,
+    updated_at: data.updated_at,
+    pricing_snapshot: {
+      grand_total: pricing.grand_total,
+      currency_code: pricing.currency_code,
+    },
+  };
+}
+
+function shapeTimeline(value: unknown) {
+  const data = asRecord(value);
+  const timeline = Array.isArray(data.timeline) ? data.timeline : [];
+  return {
+    session_id: data.session_id,
+    timeline: timeline.slice(0, 200).map((entry) => {
+      const row = asRecord(entry);
+      return {
+        wizard_step: row.wizard_step,
+        "@timestamp": row["@timestamp"],
+        duration_to_next_ms: row.duration_to_next_ms,
+      };
+    }),
+  };
+}
+
+function shapeVersions(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.slice(0, 100).map((entry) => {
+    const row = asRecord(entry);
+    return {
+      id: row.id,
+      version_number: row.version_number,
+      grand_total: row.grand_total,
+      created_at: row.created_at,
+    };
+  });
+}
+
+function shapeComparison(value: unknown) {
+  const data = asRecord(value);
+  const shapeVersion = (entry: unknown) => {
+    const row = asRecord(entry);
+    return { version_number: row.version_number, grand_total: row.grand_total };
+  };
+  const diffs = Array.isArray(data.line_item_diff) ? data.line_item_diff : [];
+  return {
+    v1: shapeVersion(data.v1),
+    v2: shapeVersion(data.v2),
+    line_item_diff: diffs.slice(0, 200).map((entry) => {
+      const row = asRecord(entry);
+      const v1 = asRecord(row.v1);
+      const v2 = asRecord(row.v2);
+      return {
+        pricing_key: row.pricing_key,
+        changed: row.changed,
+        v1: { quantity: v1.quantity, total: v1.total },
+        v2: { quantity: v2.quantity, total: v2.total },
+      };
+    }),
+  };
+}
+
+export function registerSupportTools(
+  api: OpenClawPluginApi,
+  logger: AuditLogger,
+  config: ScopelyBotConfig,
+) {
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_list_services",
+        description:
+          "List the exact allowlisted Scopely application/extraction containers and their live Docker health. Read-only; unrelated, database, Elasticsearch, OpenClaw, and DevTools containers are never returned.",
+        parameters: Type.Object({}),
+        async execute() {
+          try {
+            return jsonResult(await listScopelyServices(config));
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_trace_logs",
+        description:
+          "Search bounded, redacted logs across exact allowlisted Scopely services. Reports each source success/failure explicitly. Read-only. Accepts relative (30m/1h), ISO, or epoch times.",
+        parameters: Type.Object({
+          pattern: Type.String({
+            description: "Literal case-insensitive text to find (1-200 chars)",
+          }),
+          containers: Type.Optional(
+            Type.Array(Type.String(), {
+              description: "Exact allowlisted service names; defaults to all",
+            }),
+          ),
+          since: Type.Optional(
+            Type.String({ description: "Start: 30m, 1h, ISO-8601, or epoch seconds" }),
+          ),
+          until: Type.Optional(Type.String({ description: "End: ISO-8601 or epoch seconds" })),
+          tail: Type.Optional(Type.Number({ description: "Lines per service, clamped to 1000" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            return jsonResult(await traceScopelyLogs(config, params));
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_support_session",
+        description:
+          "Assemble a read-only support case for one Scopely session from admin detail and wizard timeline. Returns a PII-safe shaped response and explicit source status.",
+        parameters: Type.Object({ session_id: Type.Number({ description: "Numeric session id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            const [detail, timeline] = await Promise.all([
+              scopelyFetch(`/api/admin/sessions/${sessionId}/`),
+              scopelyFetch(`/api/admin/sessions/${sessionId}/timeline/`),
+            ]);
+            return jsonResult({
+              ok: detail.ok || timeline.ok,
+              session_id: sessionId,
+              sources: {
+                detail: { ok: detail.ok, status: detail.status },
+                timeline: { ok: timeline.ok, status: timeline.status },
+              },
+              detail: detail.ok ? shapeSession(detail.data) : undefined,
+              timeline: timeline.ok ? shapeTimeline(timeline.data) : undefined,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_session_status_counts",
+        description:
+          "Get live Scopely session counts by lifecycle status with optional admin-list facets. Read-only.",
+        parameters: Type.Object({
+          vendor: Type.Optional(Type.String()),
+          deployment: Type.Optional(Type.String()),
+          search: Type.Optional(Type.String()),
+          date_from: Type.Optional(Type.String()),
+          date_to: Type.Optional(Type.String()),
+          created_by: Type.Optional(Type.String()),
+          organization: Type.Optional(Type.String()),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const query = buildQuery(params, [
+              "vendor",
+              "deployment",
+              "search",
+              "date_from",
+              "date_to",
+              "created_by",
+              "organization",
+            ]);
+            const result = await scopelyFetch(`/api/admin/sessions/status-counts/${query}`);
+            const data = asRecord(result.data);
+            return jsonResult({
+              ok: result.ok,
+              status: result.status,
+              data: result.ok
+                ? { total: data.total, counts: data.counts, other: data.other }
+                : undefined,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_list_session_versions",
+        description: "List PII-safe pricing revision metadata for a Scopely session. Read-only.",
+        parameters: Type.Object({ session_id: Type.Number({ description: "Numeric session id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            const result = await scopelyFetch(`/api/sessions/${sessionId}/versions/`);
+            return jsonResult({
+              ok: result.ok,
+              status: result.status,
+              data: result.ok ? shapeVersions(result.data) : undefined,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_compare_session_versions",
+        description:
+          "Compare two pricing versions for one Scopely session using a bounded PII-safe diff. Read-only.",
+        parameters: Type.Object({
+          session_id: Type.Number({ description: "Numeric session id" }),
+          v1: Type.Number({ description: "First pricing version id" }),
+          v2: Type.Number({ description: "Second pricing version id" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            const v1 = positiveId(params.v1, "v1");
+            const v2 = positiveId(params.v2, "v2");
+            const result = await scopelyFetch(
+              `/api/sessions/${sessionId}/versions/compare/?v1=${v1}&v2=${v2}`,
+            );
+            return jsonResult({
+              ok: result.ok,
+              status: result.status,
+              data: result.ok ? shapeComparison(result.data) : undefined,
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_unlock_user",
+        description:
+          "Stage clearing a Scopely user's login lockout. PROD write; nothing executes until a separately authorized Zoom sender confirms the system-posted code.",
+        parameters: Type.Object({ user_id: Type.Number({ description: "Numeric user id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const userId = positiveId(params.user_id, "user_id");
+            return stageWrite(`unlock user id ${userId}`, () =>
+              scopelyFetch(`/api/auth/users/${userId}/unlock/`, { method: "POST", body: "{}" }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_resend_user_verification",
+        description:
+          "Stage issuing and emailing a fresh onboarding verification code. PROD write; invalidates the prior code and requires separately authorized Zoom confirmation.",
+        parameters: Type.Object({ user_id: Type.Number({ description: "Numeric user id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const userId = positiveId(params.user_id, "user_id");
+            return stageWrite(`resend onboarding verification for user id ${userId}`, () =>
+              scopelyFetch(`/api/auth/users/${userId}/resend-verification/`, {
+                method: "POST",
+                body: "{}",
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_reassign_session",
+        description:
+          "Stage moving a session to another organization and optionally owner. HIGH IMPACT: can recompute pricing and require DocuSign pricing acknowledgement. Requires separately authorized Zoom confirmation.",
+        parameters: Type.Object({
+          session_id: Type.Number({ description: "Numeric session id" }),
+          organization_id: Type.Number({ description: "Destination organization id" }),
+          owner_user_id: Type.Optional(
+            Type.Number({ description: "Optional owner in destination org" }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            const organizationId = positiveId(params.organization_id, "organization_id");
+            const body: Record<string, unknown> = { organization_id: organizationId };
+            if (params.owner_user_id !== undefined) {
+              body.owner_user_id = positiveId(params.owner_user_id, "owner_user_id");
+            }
+            const owner = body.owner_user_id ? ` and owner ${body.owner_user_id}` : "";
+            return stageWrite(
+              `reassign session ${sessionId} to organization ${organizationId}${owner}; pricing may be recomputed and DocuSign acknowledgement may be required`,
+              () =>
+                scopelyFetch(`/api/admin/sessions/${sessionId}/reassign/`, {
+                  method: "POST",
+                  body: JSON.stringify(body),
+                }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_refresh_docusign_status",
+        description:
+          "Stage polling DocuSign and reconciling session status. This may transition the session to signed, declined, or voided; requires separately authorized Zoom confirmation.",
+        parameters: Type.Object({ session_id: Type.Number({ description: "Numeric session id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            return stageWrite(`refresh DocuSign status for session ${sessionId}`, () =>
+              scopelyFetch(`/api/sessions/${sessionId}/docusign/refresh-status/`, {
+                method: "POST",
+                body: "{}",
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_resend_docusign",
+        description:
+          "Stage re-emailing the active DocuSign envelope to its current recipient. No document change, but sends external email and requires separately authorized Zoom confirmation.",
+        parameters: Type.Object({ session_id: Type.Number({ description: "Numeric session id" }) }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const sessionId = positiveId(params.session_id, "session_id");
+            return stageWrite(`resend active DocuSign envelope for session ${sessionId}`, () =>
+              scopelyFetch(`/api/sessions/${sessionId}/docusign/resend/`, {
+                method: "POST",
+                body: "{}",
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/user-maintenance-tools.test.ts
+++ b/extensions/scopelybot/src/user-maintenance-tools.test.ts
@@ -130,6 +130,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "tester",
+      approverIds: ["tester"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -161,6 +162,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "tester",
+      approverIds: ["tester"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -180,6 +182,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${approveCode}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -197,6 +200,7 @@ describe("user-maintenance-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${rejectCode}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -216,6 +220,7 @@ describe("user-maintenance-tools", () => {
     const wrong = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "attacker",
+      approverIds: ["attacker"],
       conversationId: "someone-elses-channel@conference.xmpp.zoom.us",
       logger: noopLogger as never,
     });
@@ -226,6 +231,7 @@ describe("user-maintenance-tools", () => {
     const right = await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -252,6 +258,7 @@ describe("user-maintenance-tools", () => {
     const reply = await tryExecuteConfirm({
       text: "CONFIRM 0000",
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/vendor-config-tools.test.ts
+++ b/extensions/scopelybot/src/vendor-config-tools.test.ts
@@ -112,6 +112,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -134,6 +135,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -158,6 +160,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -172,6 +175,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${delCode}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
@@ -195,6 +199,7 @@ describe("vendor-config-tools", () => {
     await tryExecuteConfirm({
       text: `CONFIRM ${code}`,
       actor: "t",
+      approverIds: ["t"],
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });

--- a/extensions/scopelybot/src/zoom-format.test.ts
+++ b/extensions/scopelybot/src/zoom-format.test.ts
@@ -1,0 +1,79 @@
+// Verifies Scopely-only, loss-aware plain-text formatting for Zoom delivery.
+import { describe, expect, it } from "vitest";
+import {
+  formatScopelyZoomText,
+  isScopelyBotZoomMessage,
+  rewriteScopelyBotZoomMessage,
+} from "./zoom-format.js";
+
+describe("formatScopelyZoomText", () => {
+  it("cleans the screenshot-shaped support response", () => {
+    const content = `- **Operational active vendors:** **20** (23 active records total; 3 are non-operational).
+*Source: current vendor catalog.*
+
+- **Open customer-facing access issue:** **Yes — 1 issue.**
+**#1108:** External customers see “Application not found” after Zoom sign-in because the Marketplace app is unpublished. Internal users are unaffected.
+*Source: GitHub issue \`cloudwarriors-ai/scopely#1108\`, updated 2026-07-18 14:30 UTC.*
+
+**What to do:** Route affected external customers through the manual **capture** path instead of **Connect Zoom**, and track the fix through issue #1108.`;
+
+    expect(formatScopelyZoomText(content)).toBe(
+      `• Operational active vendors: 20 (23 active records total; 3 are non-operational).
+Source: current vendor catalog.
+
+• Open customer-facing access issue: Yes — 1 issue.
+#1108: External customers see “Application not found” after Zoom sign-in because the Marketplace app is unpublished. Internal users are unaffected.
+Source: GitHub issue cloudwarriors-ai/scopely#1108, updated 2026-07-18 14:30 UTC.
+
+What to do: Route affected external customers through the manual capture path instead of Connect Zoom, and track the fix through issue #1108.`,
+    );
+  });
+
+  it("preserves readable plain text exactly", () => {
+    const content = "There are 20 operational vendors.\n\nIssue #1108 is the one to watch.";
+    expect(formatScopelyZoomText(content)).toBe(content);
+  });
+
+  it("keeps links and technical identifiers useful", () => {
+    const content =
+      "See [issue 1108](https://github.com/cloudwarriors-ai/scopely/issues/1108) for `vendor_id`. Call `__init__` next; the `_id_` field is required. Source: GitHub issue #1108. 2 * 3 * 4 is still 24.";
+    expect(formatScopelyZoomText(content)).toBe(
+      "See issue 1108 (https://github.com/cloudwarriors-ai/scopely/issues/1108) for vendor_id. Call __init__ next; the _id_ field is required. Source: GitHub issue #1108. 2 * 3 * 4 is still 24.",
+    );
+  });
+
+  it("removes headings, quote markers, fences, and excessive blank lines", () => {
+    const content = "## Result\n\n> Clear answer\n\n\n```text\nstatus=healthy\n```";
+    expect(formatScopelyZoomText(content)).toBe("Result\n\nClear answer\n\nstatus=healthy");
+  });
+});
+
+describe("ScopelyBot Zoom formatting scope", () => {
+  it("matches only canonical ScopelyBot Zoom sessions", () => {
+    expect(
+      isScopelyBotZoomMessage({ channelId: "zoom", sessionKey: "agent:scopelybot:zoom:vip" }),
+    ).toBe(true);
+    expect(isScopelyBotZoomMessage({ channelId: "zoom", sessionKey: "agent:other:zoom:vip" })).toBe(
+      false,
+    );
+    expect(
+      isScopelyBotZoomMessage({ channelId: "slack", sessionKey: "agent:scopelybot:slack:vip" }),
+    ).toBe(false);
+    expect(isScopelyBotZoomMessage({ channelId: "zoom" })).toBe(false);
+  });
+
+  it("returns no rewrite for already-readable or out-of-scope messages", () => {
+    expect(
+      rewriteScopelyBotZoomMessage("Already readable.", {
+        channelId: "zoom",
+        sessionKey: "agent:scopelybot:zoom:vip",
+      }),
+    ).toBeUndefined();
+    expect(
+      rewriteScopelyBotZoomMessage("**Do not change**", {
+        channelId: "zoom",
+        sessionKey: "agent:other:zoom:vip",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/scopelybot/src/zoom-format.ts
+++ b/extensions/scopelybot/src/zoom-format.ts
@@ -1,0 +1,40 @@
+// Formats ScopelyBot's model-authored replies for Zoom's plain-text card body.
+
+export type ScopelyZoomMessageContext = {
+  channelId: string;
+  sessionKey?: string;
+};
+
+const SCOPELYBOT_SESSION_PREFIX = "agent:scopelybot:";
+
+/** Restricts readable-output rewriting to ScopelyBot's own Zoom session. */
+export function isScopelyBotZoomMessage(ctx: ScopelyZoomMessageContext): boolean {
+  return ctx.channelId === "zoom" && ctx.sessionKey?.startsWith(SCOPELYBOT_SESSION_PREFIX) === true;
+}
+
+/** Removes unsupported Markdown presentation while preserving the reply's useful text. */
+export function formatScopelyZoomText(content: string): string {
+  return content
+    .replace(/\r\n?/g, "\n")
+    .replace(/^[ \t]*```[^\n]*$/gm, "")
+    .replace(/\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g, "$1 ($2)")
+    .replace(/`([^`\n]+)`/g, "$1")
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, "")
+    .replace(/^[ \t]{0,3}>[ \t]?/gm, "")
+    .replace(/^[ \t]*[-*+][ \t]+/gm, "• ")
+    .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+    .replace(/(^|[\s(])\*([^\s*\n](?:[^*\n]*?[^\s*\n])?)\*(?=$|[\s).,!?;:])/g, "$1$2")
+    .replace(/[ \t]+$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Returns a hook rewrite only when a ScopelyBot Zoom reply actually changes. */
+export function rewriteScopelyBotZoomMessage(
+  content: string,
+  ctx: ScopelyZoomMessageContext,
+): { content: string } | undefined {
+  if (!isScopelyBotZoomMessage(ctx)) return undefined;
+  const formatted = formatScopelyZoomText(content);
+  return formatted === content ? undefined : { content: formatted };
+}


### PR DESCRIPTION
## Summary
- Prod's live checkout (`/root/web/moltbot`, container `openclaw`, the ScopelyBot Zoom
  agent) had diverged from this repo: an unpushed commit (`0bd57a5bcf`, "Add gated
  Scopely support tooling") plus uncommitted work (Zoom Markdown-stripping) that only
  existed on the box, never in git.
- Reconstructed both pieces via read-only prod inspection (`git format-patch` for the
  committed piece, direct file capture for the uncommitted piece — **prod itself was
  not modified, committed to, or pushed from** during this recovery) and reapplied
  cleanly onto current `development`.
- Adds 11 new ScopelyBot tools (session trace logs, support-session bundles, service
  inventory, session status counts, session-version list/compare, unlock user, resend
  verification, reassign session, DocuSign refresh/resend), a fail-closed
  service-container + write-approver config layer, a container-log client, shared
  secret/PII redaction, and Zoom-plain-text formatting for ScopelyBot replies (Zoom
  card bodies don't render Markdown).

## Test plan
- [x] `npx vitest run extensions/scopelybot/` — 15 files, 74 tests pass
- [x] `npx tsc --noEmit -p tsconfig.extensions.json` — 355 errors on this branch vs
      344 on `development` before this change; the +11 are `support-tools.ts` hitting
      the same pre-existing repo-wide `AgentTool`/`registerTool` type-contract mismatch
      every other tool file already has — not introduced here, out of scope for this PR
- [ ] After merge: reconcile prod's checkout onto `development` at this commit (prod is
      currently sitting on an unmerged feature branch directly — separate follow-up)

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV