### PR TITLE
fix(scopelybot): retry per-token when a full-name search misses

### DIFF
--- a/extensions/scopelybot/src/scopely-tools.test.ts
+++ b/extensions/scopelybot/src/scopely-tools.test.ts
@@ -1,0 +1,105 @@
+// Verifies scopely_list_users' multi-term name-search retry: the backend OR-matches
+// the *whole* search string per field (icontains), so a two-word "Josh Rickerd" never
+// hits separate first_name/last_name columns. This tool must retry per token and union
+// the results instead of reporting a false "no user found".
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMock = vi.fn();
+vi.mock("./scopely-api.js", () => ({
+  scopelyFetch: (...args: unknown[]) => fetchMock(...args),
+  jsonResult: (data: unknown) => ({ content: [{ type: "text", text: JSON.stringify(data) }] }),
+  errorResult: (err: unknown) => ({
+    content: [{ type: "text", text: JSON.stringify({ ok: false, error: String(err) }) }],
+  }),
+  buildQuery: (params: Record<string, unknown>, keys: string[]) => {
+    const qs = new URLSearchParams();
+    for (const k of keys) if (params[k] !== undefined) qs.set(k, String(params[k]));
+    const s = qs.toString();
+    return s ? `?${s}` : "";
+  },
+}));
+
+import { registerScopelyTools } from "./scopely-tools.js";
+
+type ToolDef = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+const noopLogger = () => {};
+function buildTools(): Record<string, ToolDef> {
+  const tools: Record<string, ToolDef> = {};
+  const api = {
+    registerTool: (factory: () => ToolDef) => {
+      const t = factory();
+      tools[t.name] = t;
+    },
+  } as never;
+  registerScopelyTools(api, noopLogger as never);
+  return tools;
+}
+const parse = (res: { content: { text: string }[] }) => JSON.parse(res.content[0].text);
+
+describe("scopely_list_users", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("returns the whole-phrase match as-is when the backend finds one", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: 1, email: "a@b.com" }] });
+    const tools = buildTools();
+    const res = parse(await tools.scopely_list_users.execute("id", { search: "unified-team" }));
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual([{ id: 1, email: "a@b.com" }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries per name token and unions results when the full phrase misses", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] }) // "Josh Rickerd" — no hit
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: [{ id: 47, email: "jrickert@unified-team.com", first_name: "" }],
+      }) // "Josh" token
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] }); // "Rickerd" token
+    const tools = buildTools();
+    const res = parse(await tools.scopely_list_users.execute("id", { search: "Josh Rickerd" }));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual([{ id: 47, email: "jrickert@unified-team.com", first_name: "" }]);
+    expect(res.note).toMatch(/individual name terms/);
+  });
+
+  it("dedupes when multiple tokens match the same user", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: 9, email: "j@x.com" }] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [{ id: 9, email: "j@x.com" }] });
+    const tools = buildTools();
+    const res = parse(await tools.scopely_list_users.execute("id", { search: "Jamie Jamison" }));
+    expect(res.data).toEqual([{ id: 9, email: "j@x.com" }]);
+  });
+
+  it("reports a genuine no-match when no token hits either", async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] })
+      .mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+    const tools = buildTools();
+    const res = parse(await tools.scopely_list_users.execute("id", { search: "Nobody Here" }));
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual([]);
+    expect(res.note).toBeUndefined();
+  });
+
+  it("does not retry a single-token search", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, data: [] });
+    const tools = buildTools();
+    const res = parse(await tools.scopely_list_users.execute("id", { search: "nomatch" }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res.data).toEqual([]);
+  });
+});

--- a/extensions/scopelybot/src/scopely-tools.ts
+++ b/extensions/scopelybot/src/scopely-tools.ts
@@ -67,7 +67,8 @@ export function registerScopelyTools(api: OpenClawPluginApi, logger: AuditLogger
         description:
           "List Scopely VIP users. Returns user profiles with roles, organizations, last_login, and session count. " +
           "Use this to answer 'who was the last person to login' or 'who are the active users'. " +
-          "Set ordering to '-last_login' to sort by most recent login.",
+          "Set ordering to '-last_login' to sort by most recent login. `search` handles a full " +
+          "person name (e.g. 'Josh Rickerd') automatically — no need to split it yourself.",
         parameters: Type.Object({
           role: Type.Optional(
             Type.String({
@@ -93,7 +94,39 @@ export function registerScopelyTools(api: OpenClawPluginApi, logger: AuditLogger
                 details: result.data,
               });
             }
-            return jsonResult({ ok: true, data: result.data });
+            const rows = Array.isArray(result.data) ? result.data : [];
+            const search = typeof params.search === "string" ? params.search.trim() : "";
+            // The backend OR-matches the *whole* search string against email, first_name,
+            // last_name, and username separately (icontains) — a two-word "Josh Rickerd"
+            // never matches, since no single field holds both tokens together. When the
+            // first attempt returns nothing and the query looks like a full name, retry
+            // per token and union the results client-side (deduped by id) instead of
+            // reporting a false "no user found".
+            const tokens = search.split(/\s+/).filter((t) => t.length > 1);
+            if (rows.length === 0 && tokens.length > 1) {
+              const byId = new Map<number, unknown>();
+              for (const token of tokens) {
+                const tokenQs = buildQuery({ ...params, search: token }, [
+                  "role",
+                  "search",
+                  "ordering",
+                ]);
+                const tokenResult = await scopelyFetch(`/api/auth/users/${tokenQs}`);
+                if (tokenResult.ok && Array.isArray(tokenResult.data)) {
+                  for (const row of tokenResult.data as Array<{ id: number }>) {
+                    byId.set(row.id, row);
+                  }
+                }
+              }
+              if (byId.size > 0) {
+                return jsonResult({
+                  ok: true,
+                  data: [...byId.values()],
+                  note: `No exact match for "${search}" as one phrase; matched individual name terms instead.`,
+                });
+              }
+            }
+            return jsonResult({ ok: true, data: rows });
           } catch (err) {
             return errorResult(err);
           }


### PR DESCRIPTION
## Summary
- `scopely_list_users` passed a human name straight through to the backend's `search`
  param. `UserListView.get` OR-matches the *whole* search string against
  `email`/`first_name`/`last_name`/`username` separately via `icontains`
  (`service/apps/users/views.py:1371-1381`) — a two-word query like "Josh Rickerd"
  can never match, since no single field holds both tokens together.
- Observed live in the vipbot_prod Zoom channel on 2026-07-20: the coordinator told
  a human "no user found" for "Josh Rickerd" when the record existed under
  `jrickert@unified-team.com` — the human had to already know the email to find it.
- Fix: when the whole-phrase search returns zero rows and the query has more than one
  token, retry per token and union the results (deduped by `id`), with a `note`
  explaining the fallback happened. A genuine no-match (no token hits either) still
  returns empty with no note — behavior unchanged for that case.

## Test plan
- [x] `npx vitest run extensions/scopelybot/src/scopely-tools.test.ts` — 5 new cases
      (whole-phrase hit passthrough, per-token retry + union, dedup across tokens,
      genuine no-match, no wasted retry on a single-token query)
- [x] `npx vitest run extensions/scopelybot/` — 16 files, 79 tests pass (no regressions)
- [ ] Activation on prod requires a dist/image rebuild (extension code, not config) —
      flagging as a separate deploy step pending sign-off, per this repo's guidance
      that new/changed tool contracts need a rebuild rather than just the bind-mount

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV