### PR TITLE
fix(gated-bots): scope zoom CONFIRM claims per agent session; thread-aware pending take

### DIFF
--- a/extensions/bigheadbot/index.test.ts
+++ b/extensions/bigheadbot/index.test.ts
@@ -21,3 +21,56 @@ describe("bigheadbot tool scoping", () => {
     expect(optionalFlags.every((flag) => flag === true)).toBe(true);
   });
 });
+
+// Six gated bots register the same first-claim-wins before_dispatch hook; each must
+// only claim CONFIRMs from its OWN agent sessions (2026-07-20 incident: pulsebot
+// claimed a scopelybot confirm and answered "expired" from its own empty store).
+describe("bigheadbot confirm claim scoping", () => {
+  type Handler = (
+    event: unknown,
+    ctx: unknown,
+  ) => Promise<{ handled: boolean; text?: string } | undefined>;
+
+  function registerAndGetBeforeDispatch(): Handler {
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const handlers = new Map<string, Handler>();
+    const api = {
+      registerTool: vi.fn(),
+      on: vi.fn((name: string, fn: Handler) => {
+        handlers.set(name, fn);
+      }),
+    } as never;
+    plugin.register(api, undefined);
+    const handler = handlers.get("before_dispatch");
+    if (!handler) throw new Error("before_dispatch handler not registered");
+    return handler;
+  }
+
+  it("declines a CONFIRM from another agent's zoom session (does not steal it)", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:scopelybot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("claims a CONFIRM from its own zoom session", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:bigheadbot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result?.handled).toBe(true);
+  });
+});

--- a/extensions/bigheadbot/index.ts
+++ b/extensions/bigheadbot/index.ts
@@ -80,6 +80,12 @@ const plugin = {
     // execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
       if (ctx.channelId !== "zoom") return undefined;
+      // Claim only CONFIRMs from this bot's own sessions (session key prefix set by
+      // the agent binding). Six gated bots register this same first-claim-wins hook;
+      // without this guard, whichever bot registered FIRST steals every zoom CONFIRM
+      // and answers "expired" from its own empty pending store (2026-07-20 incident:
+      // pulsebot consumed a scopelybot confirm code that was 13 seconds old).
+      if (ctx.sessionKey?.startsWith("agent:bigheadbot:") !== true) return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
       const result = await tryExecuteConfirm({

--- a/extensions/cloudflow-support/index.test.ts
+++ b/extensions/cloudflow-support/index.test.ts
@@ -21,3 +21,56 @@ describe("cloudflow-support tool scoping", () => {
     expect(optionalFlags.every((flag) => flag === true)).toBe(true);
   });
 });
+
+// Six gated bots register the same first-claim-wins before_dispatch hook; each must
+// only claim CONFIRMs from its OWN agent sessions (2026-07-20 incident: pulsebot
+// claimed a scopelybot confirm and answered "expired" from its own empty store).
+describe("cloudflow-support confirm claim scoping", () => {
+  type Handler = (
+    event: unknown,
+    ctx: unknown,
+  ) => Promise<{ handled: boolean; text?: string } | undefined>;
+
+  function registerAndGetBeforeDispatch(): Handler {
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const handlers = new Map<string, Handler>();
+    const api = {
+      registerTool: vi.fn(),
+      on: vi.fn((name: string, fn: Handler) => {
+        handlers.set(name, fn);
+      }),
+    } as never;
+    plugin.register(api, undefined);
+    const handler = handlers.get("before_dispatch");
+    if (!handler) throw new Error("before_dispatch handler not registered");
+    return handler;
+  }
+
+  it("declines a CONFIRM from another agent's zoom session (does not steal it)", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:scopelybot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("claims a CONFIRM from its own zoom session", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:cloudflow-support:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result?.handled).toBe(true);
+  });
+});

--- a/extensions/cloudflow-support/index.ts
+++ b/extensions/cloudflow-support/index.ts
@@ -74,6 +74,12 @@ const plugin = {
     // execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
       if (ctx.channelId !== "zoom") return undefined;
+      // Claim only CONFIRMs from this bot's own sessions (session key prefix set by
+      // the agent binding). Six gated bots register this same first-claim-wins hook;
+      // without this guard, whichever bot registered FIRST steals every zoom CONFIRM
+      // and answers "expired" from its own empty pending store (2026-07-20 incident:
+      // pulsebot consumed a scopelybot confirm code that was 13 seconds old).
+      if (ctx.sessionKey?.startsWith("agent:cloudflow-support:") !== true) return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
       const result = await tryExecuteConfirm({

--- a/extensions/external-org-autopilot/index.test.ts
+++ b/extensions/external-org-autopilot/index.test.ts
@@ -1,31 +1,15 @@
+/**
+ * Plugin-boundary test for external-org-autopilot's before_dispatch confirm claim scoping.
+ */
+
 import os from "node:os";
 import { describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 
-describe("pulsebot tool scoping", () => {
-  it("registers every tool as optional so per-agent allowlists can scope them", () => {
-    // Non-optional plugin tools bypass allowlists and leak into every agent's
-    // menu; optional ones are only visible to agents whose tools.allow opts in.
-    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
-    const optionalFlags: Array<boolean | undefined> = [];
-    const api = {
-      registerTool: vi.fn((_tool: unknown, opts?: { optional?: boolean }) => {
-        optionalFlags.push(opts?.optional);
-      }),
-      on: vi.fn(),
-    } as never;
-
-    plugin.register(api, undefined);
-
-    expect(optionalFlags.length).toBeGreaterThan(0);
-    expect(optionalFlags.every((flag) => flag === true)).toBe(true);
-  });
-});
-
 // Six gated bots register the same first-claim-wins before_dispatch hook; each must
 // only claim CONFIRMs from its OWN agent sessions (2026-07-20 incident: pulsebot
 // claimed a scopelybot confirm and answered "expired" from its own empty store).
-describe("pulsebot confirm claim scoping", () => {
+describe("external-org-autopilot confirm claim scoping", () => {
   type Handler = (
     event: unknown,
     ctx: unknown,
@@ -67,7 +51,7 @@ describe("pulsebot confirm claim scoping", () => {
       {
         channelId: "zoom",
         conversationId: "thread-1",
-        sessionKey: "agent:pulsebot:zoom:channel:thread-1",
+        sessionKey: "agent:external-org-autopilot:zoom:channel:thread-1",
         senderId: "someone",
       },
     );

--- a/extensions/external-org-autopilot/index.ts
+++ b/extensions/external-org-autopilot/index.ts
@@ -63,6 +63,12 @@ const plugin = {
     // execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
       if (ctx.channelId !== "zoom") return undefined;
+      // Claim only CONFIRMs from this bot's own sessions (session key prefix set by
+      // the agent binding). Six gated bots register this same first-claim-wins hook;
+      // without this guard, whichever bot registered FIRST steals every zoom CONFIRM
+      // and answers "expired" from its own empty pending store (2026-07-20 incident:
+      // pulsebot consumed a scopelybot confirm code that was 13 seconds old).
+      if (ctx.sessionKey?.startsWith("agent:external-org-autopilot:") !== true) return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
       const result = await tryExecuteConfirm({

--- a/extensions/pulsebot/index.ts
+++ b/extensions/pulsebot/index.ts
@@ -76,6 +76,12 @@ const plugin = {
     // execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
       if (ctx.channelId !== "zoom") return undefined;
+      // Claim only CONFIRMs from this bot's own sessions (session key prefix set by
+      // the agent binding). Six gated bots register this same first-claim-wins hook;
+      // without this guard, whichever bot registered FIRST steals every zoom CONFIRM
+      // and answers "expired" from its own empty pending store (2026-07-20 incident:
+      // pulsebot consumed a scopelybot confirm code that was 13 seconds old).
+      if (ctx.sessionKey?.startsWith("agent:pulsebot:") !== true) return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
       const result = await tryExecuteConfirm({

--- a/extensions/scopelybot/index.test.ts
+++ b/extensions/scopelybot/index.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Plugin-boundary tests for scopelybot's before_dispatch confirm claim: six gated
+ * bots register this same first-claim-wins hook, so each must only claim CONFIRMs
+ * arriving through its OWN agent sessions (2026-07-20 incident: pulsebot claimed a
+ * scopelybot confirm and answered "expired" from its own empty pending store).
+ */
+
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+type Handler = (
+  event: unknown,
+  ctx: unknown,
+) => Promise<{ handled: boolean; text?: string } | undefined>;
+
+function registerAndGetBeforeDispatch(): Handler {
+  process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+  const handlers = new Map<string, Handler>();
+  const api = {
+    registerTool: vi.fn(),
+    on: vi.fn((name: string, fn: Handler) => {
+      handlers.set(name, fn);
+    }),
+    registerHook: vi.fn(),
+  } as never;
+  plugin.register(api, { writeApproverIds: [] });
+  const handler = handlers.get("before_dispatch");
+  if (!handler) throw new Error("before_dispatch handler not registered");
+  return handler;
+}
+
+describe("scopelybot confirm claim scoping", () => {
+  it("declines a CONFIRM from another agent's zoom session (does not steal it)", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:pulsebot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("declines when no session key is present", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      { channelId: "zoom", conversationId: "thread-1", senderId: "someone" },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("claims a CONFIRM from its own zoom session (threaded)", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "554f6079-4d2e-4727-87db-1b1c482fff3d",
+        sessionKey: "agent:scopelybot:zoom:channel:554f6079-4d2e-4727-87db-1b1c482fff3d",
+        senderId: "someone",
+      },
+    );
+    // Claimed and suppressed — empty approver list yields the deterministic
+    // authorization refusal, never a coordinator dispatch.
+    expect(result?.handled).toBe(true);
+    expect(result?.text).toContain("not authorized");
+  });
+
+  it("ignores non-CONFIRM messages in its own session", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "what's the status of user 47?" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:scopelybot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -18,7 +18,7 @@ import { registerScopingCardTools } from "./src/scoping-card-tools.js";
 import { registerSupportTools } from "./src/support-tools.js";
 import { registerUserMaintenanceTools } from "./src/user-maintenance-tools.js";
 import { registerVendorConfigTools } from "./src/vendor-config-tools.js";
-import { rewriteScopelyBotZoomMessage } from "./src/zoom-format.js";
+import { isScopelyBotZoomMessage, rewriteScopelyBotZoomMessage } from "./src/zoom-format.js";
 
 // A human confirm reply. Mirrors the matcher in tryExecuteConfirm() so the
 // before_dispatch gate and the comfort-skip use one shape.
@@ -115,13 +115,25 @@ const plugin = {
     // re-stage), and `text` is delivered by core threaded into the conversation. The
     // LLM is never in the execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
-      if (ctx.channelId !== "zoom") return;
+      // Claim only CONFIRMs arriving through ScopelyBot's own Zoom surface (its
+      // bound channel or a thread inside it), proven by the agent-scoped session
+      // key. Six gated bots register this same first-claim-wins hook; an unscoped
+      // `channelId === "zoom"` claim lets whichever bot registered FIRST steal
+      // every zoom CONFIRM and answer "expired" from its own empty pending store
+      // (2026-07-20 incident: pulsebot consumed a scopelybot confirm).
+      if (
+        !isScopelyBotZoomMessage({ channelId: ctx.channelId ?? "", sessionKey: ctx.sessionKey })
+      ) {
+        return;
+      }
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return;
       const result = await tryExecuteConfirm({
         text,
         actor: ctx.senderId ?? "",
         conversationId: ctx.conversationId ?? "",
+        channelId: ctx.channelId,
+        sessionKey: ctx.sessionKey,
         approverIds: writeApproverIds,
         logger,
       });

--- a/extensions/scopelybot/src/confirm.test.ts
+++ b/extensions/scopelybot/src/confirm.test.ts
@@ -48,8 +48,54 @@ describe("ScopelyBot confirmation actor gate", () => {
       approverIds: [approver],
       logger,
     });
-    expect(takePendingMock).toHaveBeenCalledWith("1234", "vipbot_prod");
+    expect(takePendingMock).toHaveBeenCalledWith("1234", {
+      conversationId: "vipbot_prod",
+      fromOwnZoomSurface: false,
+    });
     expect(result).toContain("HTTP 502");
     expect(result).not.toContain("secret");
+  });
+
+  // Regression for the 2026-07-20 incident: a CONFIRM sent inside a Zoom thread
+  // dispatches with the THREAD id as conversationId (never matching the
+  // channel-JID-bound pending), but the scopelybot session key proves it arrived
+  // through the bot's own Zoom binding — takePending must receive that proof.
+  it("marks a threaded CONFIRM from scopelybot's own zoom session as own-surface", async () => {
+    takePendingMock.mockReturnValue({
+      summary: "reset password for user 47",
+      run: vi.fn().mockResolvedValue({ ok: true, status: 200, data: {} }),
+    });
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 8248",
+      actor: approver,
+      conversationId: "554f6079-4d2e-4727-87db-1b1c482fff3d",
+      channelId: "zoom",
+      sessionKey: "agent:scopelybot:zoom:channel:554f6079-4d2e-4727-87db-1b1c482fff3d",
+      approverIds: [approver],
+      logger,
+    });
+    expect(takePendingMock).toHaveBeenCalledWith("8248", {
+      conversationId: "554f6079-4d2e-4727-87db-1b1c482fff3d",
+      fromOwnZoomSurface: true,
+    });
+    expect(result).toContain("✅ Done");
+  });
+
+  it("does not treat another agent's zoom session as scopelybot's surface", async () => {
+    takePendingMock.mockReturnValue(undefined);
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 4321",
+      actor: approver,
+      conversationId: "some-thread-id",
+      channelId: "zoom",
+      sessionKey: "agent:pulsebot:zoom:channel:some-thread-id",
+      approverIds: [approver],
+      logger,
+    });
+    expect(takePendingMock).toHaveBeenCalledWith("4321", {
+      conversationId: "some-thread-id",
+      fromOwnZoomSurface: false,
+    });
+    expect(result).toContain("No pending action");
   });
 });

--- a/extensions/scopelybot/src/confirm.ts
+++ b/extensions/scopelybot/src/confirm.ts
@@ -8,6 +8,7 @@
 import type { AuditLogger } from "./audit.js";
 import { takePending } from "./pending-confirm.js";
 import { redactText } from "./redaction.js";
+import { isScopelyBotZoomMessage } from "./zoom-format.js";
 
 export function isApprovedWriteActor(actor: string, approverIds: string[]): boolean {
   const normalized = actor.trim().toLowerCase();
@@ -22,6 +23,8 @@ export async function tryExecuteConfirm(params: {
   text: string;
   actor: string;
   conversationId: string;
+  channelId?: string;
+  sessionKey?: string;
   approverIds: string[];
   logger: AuditLogger;
 }): Promise<string | null> {
@@ -32,8 +35,17 @@ export async function tryExecuteConfirm(params: {
   if (!isApprovedWriteActor(params.actor, params.approverIds)) {
     return "Write confirmation is not authorized for this Zoom identity.";
   }
-  // Channel-scoped: only consumes an action staged for THIS conversation.
-  const action = takePending(m[1], params.conversationId);
+  // Channel-scoped: only consumes an action staged for THIS conversation. Zoom
+  // thread replies dispatch with the thread id as conversationId, so the session
+  // key — which proves the message came through ScopelyBot's own Zoom binding —
+  // is the accepted channel-binding evidence for threaded CONFIRMs.
+  const action = takePending(m[1], {
+    conversationId: params.conversationId,
+    fromOwnZoomSurface: isScopelyBotZoomMessage({
+      channelId: params.channelId ?? "",
+      sessionKey: params.sessionKey,
+    }),
+  });
   if (!action) {
     return `No pending action for code ${m[1]} — it may have expired (5 min), already been used, or was requested in a different channel.`;
   }

--- a/extensions/scopelybot/src/pending-confirm.test.ts
+++ b/extensions/scopelybot/src/pending-confirm.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pending-store scope tests: a CONFIRM consumes an action only when it provably
+ * arrived where the action was staged — exact conversation match (channel root)
+ * or the caller's own-zoom-surface proof (thread replies dispatch with the
+ * thread id as conversationId; 2026-07-20 incident).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { putPending, takePending } from "./pending-confirm.js";
+
+const CHANNEL = "feaf3140540745b9b0f9e82fdc26ebee@conference.xmpp.zoom.us";
+
+function stage(code: string): void {
+  putPending({
+    code,
+    conversationId: CHANNEL,
+    summary: `test action ${code}`,
+    run: vi.fn().mockResolvedValue({ ok: true, status: 200, data: {} }),
+  });
+}
+
+describe("takePending scope acceptance", () => {
+  it("consumes on an exact conversation match (channel-root CONFIRM)", () => {
+    stage("1111");
+    const action = takePending("1111", { conversationId: CHANNEL });
+    expect(action?.summary).toBe("test action 1111");
+    // single-use: a second take must miss
+    expect(takePending("1111", { conversationId: CHANNEL })).toBeUndefined();
+  });
+
+  it("rejects a mismatched conversation without consuming the action", () => {
+    stage("2222");
+    // Simulates another bot's channel or a forged conversation: no own-surface proof.
+    expect(takePending("2222", { conversationId: "other-channel" })).toBeUndefined();
+    // Not consumed — the rightful channel can still confirm.
+    expect(takePending("2222", { conversationId: CHANNEL })?.summary).toBe("test action 2222");
+  });
+
+  it("consumes a thread-scoped CONFIRM carrying own-surface proof (2026-07-20 regression)", () => {
+    stage("8248");
+    // Thread replies dispatch with the thread id, never the channel JID.
+    const action = takePending("8248", {
+      conversationId: "554f6079-4d2e-4727-87db-1b1c482fff3d",
+      fromOwnZoomSurface: true,
+    });
+    expect(action?.summary).toBe("test action 8248");
+  });
+
+  it("misses on an unknown code even with own-surface proof", () => {
+    expect(
+      takePending("9999", { conversationId: CHANNEL, fromOwnZoomSurface: true }),
+    ).toBeUndefined();
+  });
+});

--- a/extensions/scopelybot/src/pending-confirm.ts
+++ b/extensions/scopelybot/src/pending-confirm.ts
@@ -40,14 +40,33 @@ export function putPending(a: Omit<PendingAction, "expiresAt">): void {
   store.set(a.code, { ...a, expiresAt: Date.now() + TTL_MS });
 }
 
+// Where the CONFIRM arrived from, as observed by the dispatch pipeline.
+export type ConfirmScope = {
+  conversationId: string; // dispatch conversation the CONFIRM arrived in
+  // True when the caller proved — via the agent-scoped session key — that the
+  // CONFIRM arrived through ScopelyBot's own Zoom binding. Zoom thread-scoped
+  // sessions dispatch with the THREAD id as conversationId, so an exact match
+  // against the channel-JID-bound pending can never succeed for a threaded reply
+  // (2026-07-20 incident: a 13-second-old code was reported "expired"). The
+  // session-key prefix is the channel-binding proof in that case: scopelybot has
+  // exactly one bound channel, so any `agent:scopelybot:zoom:*` session IS that
+  // channel or a thread inside it.
+  fromOwnZoomSurface?: boolean;
+};
+
 // Retrieve and consume a pending action (one-time use). Channel-scoped: a CONFIRM
-// only fires an action staged for the SAME conversation, so a code leaked/observed
-// in one channel cannot trigger a write staged for another. A channel mismatch does
-// NOT consume the action — the rightful channel can still confirm it.
-export function takePending(code: string, conversationId: string): PendingAction | undefined {
+// only fires an action staged for the SAME conversation (exact id match, or the
+// caller's proof that the message came through this bot's own Zoom surface), so a
+// code leaked/observed in another bot's channel cannot trigger a write staged here.
+// A scope mismatch does NOT consume the action — the rightful channel can still
+// confirm it.
+export function takePending(code: string, scope: ConfirmScope): PendingAction | undefined {
   prune();
   const a = store.get(code);
-  if (!a || a.conversationId !== conversationId) {
+  if (!a) {
+    return undefined;
+  }
+  if (a.conversationId !== scope.conversationId && scope.fromOwnZoomSurface !== true) {
     return undefined;
   }
   store.delete(code);

--- a/extensions/zoomwarriorssupportbot/index.test.ts
+++ b/extensions/zoomwarriorssupportbot/index.test.ts
@@ -21,3 +21,56 @@ describe("zoomwarriorssupportbot tool scoping", () => {
     expect(optionalFlags.every((flag) => flag === true)).toBe(true);
   });
 });
+
+// Six gated bots register the same first-claim-wins before_dispatch hook; each must
+// only claim CONFIRMs from its OWN agent sessions (2026-07-20 incident: pulsebot
+// claimed a scopelybot confirm and answered "expired" from its own empty store).
+describe("zoomwarriorssupportbot confirm claim scoping", () => {
+  type Handler = (
+    event: unknown,
+    ctx: unknown,
+  ) => Promise<{ handled: boolean; text?: string } | undefined>;
+
+  function registerAndGetBeforeDispatch(): Handler {
+    process.env.OPENCLAW_WORKSPACE = os.tmpdir();
+    const handlers = new Map<string, Handler>();
+    const api = {
+      registerTool: vi.fn(),
+      on: vi.fn((name: string, fn: Handler) => {
+        handlers.set(name, fn);
+      }),
+    } as never;
+    plugin.register(api, undefined);
+    const handler = handlers.get("before_dispatch");
+    if (!handler) throw new Error("before_dispatch handler not registered");
+    return handler;
+  }
+
+  it("declines a CONFIRM from another agent's zoom session (does not steal it)", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:scopelybot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("claims a CONFIRM from its own zoom session", async () => {
+    const handler = registerAndGetBeforeDispatch();
+    const result = await handler(
+      { content: "CONFIRM 8248" },
+      {
+        channelId: "zoom",
+        conversationId: "thread-1",
+        sessionKey: "agent:zoomwarriorssupportbot:zoom:channel:thread-1",
+        senderId: "someone",
+      },
+    );
+    expect(result?.handled).toBe(true);
+  });
+});

--- a/extensions/zoomwarriorssupportbot/index.ts
+++ b/extensions/zoomwarriorssupportbot/index.ts
@@ -78,6 +78,12 @@ const plugin = {
     // execution path: it cannot fabricate the inbound CONFIRM.
     api.on("before_dispatch", async (event, ctx) => {
       if (ctx.channelId !== "zoom") return undefined;
+      // Claim only CONFIRMs from this bot's own sessions (session key prefix set by
+      // the agent binding). Six gated bots register this same first-claim-wins hook;
+      // without this guard, whichever bot registered FIRST steals every zoom CONFIRM
+      // and answers "expired" from its own empty pending store (2026-07-20 incident:
+      // pulsebot consumed a scopelybot confirm code that was 13 seconds old).
+      if (ctx.sessionKey?.startsWith("agent:zoomwarriorssupportbot:") !== true) return undefined;
       const text = typeof event.content === "string" ? event.content : "";
       if (!CONFIRM_RE.test(text.trim())) return undefined;
       const result = await tryExecuteConfirm({


### PR DESCRIPTION
## Incident (2026-07-20, vipbot_prod)

John Rudolph confirmed a staged password reset with a **13-second-old** code and was told:

> No pending action for code 8248 — it may have expired (5 min), already been used, or was requested in a different channel.

## Root cause (proven from prod forensics)

**Six gated bots** (pulsebot, bigheadbot, cloudflow-support, zoomwarriorssupportbot, external-org-autopilot, scopelybot) each register a `before_dispatch` hook that claimed **every** zoom `CONFIRM <code>`. The hook runner (`runClaimingHooksList`, first-claim-wins in plugin registration order) let **pulsebot** (plugin #8) consume the confirm meant for **scopelybot** (plugin #20): pulsebot missed in its own pending store and replied "expired" from its identical message template. Evidence:

- Reply delivered ~300ms after webhook receipt — deterministic hook path, not an LLM turn.
- Zero `[scopelybot] before_dispatch claimed CONFIRM` logs on prod since container start — scopelybot's handler never ran for any CONFIRM.
- John's operator_id (`wc7WZVkGRMGcNWOYTksTvQ`) never touched scopelybot's approver gate — pulsebot's `tryExecuteConfirm` has no approver check, consistent with the observed message.

**Second latent bug** (would bite next): prod zoom `threading.sessionScope: "thread"` dispatches threaded CONFIRMs with the **thread id** as `conversationId`, which can never exact-match the channel-JID-bound pending — the whole incident exchange lived in one thread.

## Fix

1. **Claim scoping (all six bots):** `before_dispatch` only claims a CONFIRM whose `ctx.sessionKey` carries the bot's own `agent:<bot>:` prefix — the same proof `zoom-format.ts` already uses. Foreign confirms fall through to the owning bot.
2. **Thread-aware pending take (scopelybot):** `takePending(code, scope)` accepts an exact conversation match OR the caller's own-zoom-surface proof derived from the scopelybot session key (the bot has exactly one bound channel, so the session prefix is channel-binding evidence). TTL, single-use, CSPRNG code, approver-allowlist-before-store, and no-consume-on-mismatch are all unchanged.

## Verification

- `npx vitest run` over all six extensions: **22 files / 98 tests pass**, including the incident regression (threaded CONFIRM executes; foreign session declined without consuming) and claim-scoping tests per bot.
- Scoped `tsc --noEmit`: zero errors in changed files (remaining errors are the pre-existing repo-wide `registerTool`/`AgentTool` baseline in untouched `*-tools.ts` files).

## Deploy notes

- Extensions are bind-mounted and jiti-loaded on prod → **git pull + container restart**, no image rebuild.
- **Prod config change required with deploy:** add John Rudolph's operator id `wc7WZVkGRMGcNWOYTksTvQ` to scopelybot `writeApproverIds` — otherwise the fixed gate correctly answers him "not authorized".

## Known follow-up

The five non-scopely bots still bind pendings to their channel env and will miss **threaded** confirms in their own channels (pre-existing). This PR fixes the cross-bot steal for them and the full path for scopelybot.

Base is `codex/rescue-scopely-support-tools` (PR #70) because the fix builds on the rescued prod code; retarget to `development` after #70 merges.

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV