### PR TITLE
fix(tests): default vitest to non-watch mode to stop bare-invocation process leaks

### DIFF
--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -267,7 +267,10 @@ async function main() {
             "node",
             ...resolveVitestNodeArgs(process.env),
             resolveVitestCliEntry(),
-            ...(plan.watchMode ? [] : ["run"]),
+            // watch:false is now the shared-config default (see vitest.shared.config.ts);
+            // pass --watch explicitly here so watch mode still activates instead of
+            // silently relying on Vitest's implicit non-CI watch default.
+            ...(plan.watchMode ? ["--watch"] : ["run"]),
             "--config",
             plan.config,
             ...plan.forwardedArgs,

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2117,7 +2117,10 @@ function createVitestArgs(params) {
     "node",
     ...resolveVitestNodeArgs(params.env),
     resolveVitestCliEntry(),
-    ...(params.watchMode ? [] : ["run"]),
+    // watch:false is now the shared-config default (see vitest.shared.config.ts);
+    // pass --watch explicitly here so watch mode still activates instead of
+    // silently relying on Vitest's implicit non-CI watch default.
+    ...(params.watchMode ? ["--watch"] : ["run"]),
     "--config",
     params.config,
     ...(params.config === UI_E2E_VITEST_CONFIG ? ["--configLoader", "runner"] : []),

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -435,6 +435,13 @@ export const sharedVitestConfig = {
     hookTimeout: isWindows ? 180_000 : 120_000,
     unstubEnvs: true,
     unstubGlobals: true,
+    // Default to one-shot runs. A bare `vitest` invocation (no `run`, no `--watch`)
+    // otherwise falls back to Vitest's interactive watch default, which never exits
+    // and — across this workspace's 80 project configs — piles up dozens of orphaned
+    // worker processes over time (see incident 2026-07-20). `--watch` on the CLI still
+    // overrides this, so the sanctioned `pnpm test:watch` path (test-projects.mjs) is
+    // unaffected; it passes `--watch` explicitly instead of relying on the implicit default.
+    watch: false,
     isolate: false,
     pool: defaultPool,
     runner: nonIsolatedRunnerPath,


### PR DESCRIPTION
## Summary
- A bare `vitest` invocation (no `run`, no `--watch`) falls back to Vitest's interactive watch default, which never exits. Across this workspace's 80 project configs, that piled up 50+ orphaned worker processes over ~25 minutes today and exhausted system memory (a Force Quit dialog showed the editor's process tree at 164GB — actually these leaked vitest children rolled up under it).
- `AGENTS.md`/`scripts/CLAUDE.md` already documents this exact failure mode ("bare `vitest ...` starts local watch mode and will not exit on its own" / "Never use bare `vitest ...` in automation") but nothing enforced it structurally — it relied on everyone remembering.
- This makes the safe behavior the default instead of a documentation-only convention:
  - `test/vitest/vitest.shared.config.ts`: `watch: false` in the shared test config, inherited by all 80 project configs via spread.
  - `scripts/test-projects.mjs` / `scripts/test-projects.test-support.mjs`: the one sanctioned watch entrypoint (`pnpm test:watch`) previously relied on *omitting* `run` to fall into Vitest's implicit watch default. It now passes `--watch` explicitly, which overrides the config default, so that path is unaffected.

## Verification
- `node scripts/run-vitest.mjs run test/scripts/test-projects.test.ts test/scripts/run-vitest.test.ts` on this branch (built off current `origin/main`): 191 passed, 1 pre-existing unrelated failure (`covers each normal full-suite test file exactly once` — missing `apps/slm-dashboard` test files in the full-suite shard list; confirmed present on `origin/main` without this change too, not introduced here).
- Bare `node node_modules/vitest/vitest.mjs --config test/vitest/vitest.unit-fast.config.ts <file>` (no `run`/`--watch`): now exits with code 0 on its own instead of hanging in watch mode.
- Confirmed zero leftover vitest processes after the run.

## Test plan
- [x] Ran affected test files via the sanctioned wrapper, no regressions vs. `origin/main`
- [x] Confirmed bare vitest now exits instead of entering watch mode
- [x] Confirmed `pnpm test:watch` path still passes `--watch` explicitly (unaffected)