### PR TITLE
feat(scopelybot): runtime supervisor on before_agent_finalize (Slice S)

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -17,6 +17,7 @@ import { registerPassthroughTools } from "./src/passthrough-tools.js";
 import { registerPricingTools } from "./src/pricing-tools.js";
 import { registerScopelyTools } from "./src/scopely-tools.js";
 import { registerScopingCardTools } from "./src/scoping-card-tools.js";
+import { superviseFinalize } from "./src/supervisor.js";
 import { registerSupportTools } from "./src/support-tools.js";
 import { registerUserMaintenanceTools } from "./src/user-maintenance-tools.js";
 import { registerVendorConfigTools } from "./src/vendor-config-tools.js";
@@ -101,6 +102,17 @@ const plugin = {
     // Zoom card bodies do not render Markdown. Keep this rewrite at the Scopely
     // plugin boundary so other agents and channels retain their existing output.
     api.on("message_sending", (event, ctx) => rewriteScopelyBotZoomMessage(event.content, ctx));
+
+    // Runtime supervisor (Slice S): review the coordinator's draft final reply
+    // before it is accepted — deterministic rules/voice/grounding checks with a
+    // harness-budgeted single revision pass and a fuse that escalates to a named
+    // human instead of retrying forever. Opt-in via SCOPELYBOT_SUPERVISOR=1
+    // (checked inside superviseFinalize, at call time); scoped inside to
+    // agent:scopelybot: sessions so other bots' turns are untouched. NOTE: this
+    // is a conversation-typed hook — non-bundled deployments must also set
+    // plugins.entries.scopelybot.hooks.allowConversationAccess=true or the
+    // registry drops it with a warn diagnostic (src/plugins/registry.ts).
+    api.on("before_agent_finalize", (event) => superviseFinalize(event, { logger }));
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/extensions/scopelybot/src/supervisor.test.ts
+++ b/extensions/scopelybot/src/supervisor.test.ts
@@ -1,0 +1,201 @@
+// Supervisor tests (supervisor.ts — Slice S). Cover: opt-in gating, coordinator
+// session scoping, each deterministic check, the harness-budgeted revise shape,
+// the fuse (trip → accept + escalation post + cooldown pass-through), and the
+// confirm-gate boundary (the supervisor blocks code relays; it never executes).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendScopelyTextMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("./comfort.js", () => ({
+  sendScopelyText: (...args: unknown[]) => sendScopelyTextMock(...args),
+  getChannelThreadAnchor: () => undefined,
+  rememberChannelThreadAnchor: () => {},
+  sendComfortMessage: () => {},
+}));
+
+import {
+  resetSupervisorStateForTest,
+  reviewDraft,
+  superviseFinalize,
+  turnHadToolActivity,
+} from "./supervisor.js";
+
+const SESSION = "agent:scopelybot:zoom:channel:vipbot@conference.xmpp.zoom.us";
+const CHANNEL = "vipbot@conference.xmpp.zoom.us";
+const auditMock = vi.fn();
+
+// A turn with one grounded tool read (user → toolResult → assistant).
+const GROUNDED_TURN = [
+  { role: "user", content: "how many sessions?" },
+  { role: "assistant", content: [{ type: "toolCall" }] },
+  { role: "toolResult", content: "42" },
+];
+
+function event(draft: string, overrides?: Record<string, unknown>) {
+  return {
+    runId: "run-1",
+    turnId: "turn-1",
+    sessionKey: SESSION,
+    lastAssistantMessage: draft,
+    messages: GROUNDED_TURN,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  resetSupervisorStateForTest();
+  sendScopelyTextMock.mockClear();
+  auditMock.mockClear();
+  process.env.SCOPELYBOT_SUPERVISOR = "1";
+  process.env.SCOPELYBOT_ZOOM_CHANNEL = CHANNEL;
+});
+afterEach(() => {
+  delete process.env.SCOPELYBOT_SUPERVISOR;
+  delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
+  delete process.env.SCOPELYBOT_SUPERVISOR_FUSE_N;
+  delete process.env.SCOPELYBOT_ESCALATION_OWNER;
+});
+
+describe("gating", () => {
+  it("returns undefined when SCOPELYBOT_SUPERVISOR is not 1", async () => {
+    delete process.env.SCOPELYBOT_SUPERVISOR;
+    const res = await superviseFinalize(event("CONFIRM 1234"), { logger: auditMock });
+    expect(res).toBeUndefined();
+  });
+
+  it("ignores sessions that are not the scopelybot coordinator", async () => {
+    const res = await superviseFinalize(
+      event("CONFIRM 1234", { sessionKey: "agent:pulsebot:zoom:channel:x" }),
+      { logger: auditMock },
+    );
+    expect(res).toBeUndefined();
+  });
+
+  it("lets a clean grounded draft through with no opinion", async () => {
+    const res = await superviseFinalize(event("There are 42 active sessions."), {
+      logger: auditMock,
+    });
+    expect(res).toBeUndefined();
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("reviewDraft checks", () => {
+  it("blocks CONFIRM code relays (confirm-gate boundary)", () => {
+    const v = reviewDraft("Reply CONFIRM 4821 to proceed.", true);
+    expect(v).toMatchObject({ ok: false, checkId: "confirm_code_leak" });
+  });
+
+  it("blocks secret-shaped values", () => {
+    const jwt = `token: eyJ${"a".repeat(24)}.${"b".repeat(16)}`;
+    expect(reviewDraft(jwt, true)).toMatchObject({ ok: false, checkId: "secret_leak" });
+    expect(reviewDraft("The password is hunter22.", true)).toMatchObject({
+      ok: false,
+      checkId: "secret_leak",
+    });
+  });
+
+  it("does not flag reset-flow explanations that mention passwords", () => {
+    expect(
+      reviewDraft("A password reset email was sent to the user; they set their own.", true),
+    ).toEqual({ ok: true });
+  });
+
+  it("blocks raw JSON dumps", () => {
+    const dump = JSON.stringify({ results: Array.from({ length: 30 }, (_, i) => ({ id: i })) });
+    expect(reviewDraft(dump, true)).toMatchObject({ ok: false, checkId: "raw_json_dump" });
+  });
+
+  it("blocks state assertions made with zero tool reads this turn", () => {
+    const v = reviewDraft("Org 314 has 1250 sessions and owes $4,200.", false);
+    expect(v).toMatchObject({ ok: false, checkId: "unsupported_state_claim" });
+  });
+
+  it("allows the same state assertion when the turn had a tool read", () => {
+    expect(reviewDraft("Org 314 has 1250 sessions and owes $4,200.", true)).toEqual({ ok: true });
+  });
+
+  it("allows a short clarifying question even with no tool read", () => {
+    expect(reviewDraft("Do you mean session 314?", false)).toEqual({ ok: true });
+  });
+});
+
+describe("turnHadToolActivity", () => {
+  it("counts tool results after the last user message only", () => {
+    expect(turnHadToolActivity(GROUNDED_TURN)).toBe(true);
+    expect(
+      turnHadToolActivity([
+        { role: "toolResult", content: "stale — previous turn" },
+        { role: "user", content: "fresh question" },
+        { role: "assistant", content: "answer" },
+      ]),
+    ).toBe(false);
+    expect(turnHadToolActivity(undefined)).toBe(false);
+  });
+});
+
+describe("revise shape", () => {
+  it("returns a harness-budgeted single retry keyed per turn+check", async () => {
+    const res = await superviseFinalize(event("Reply CONFIRM 4821 to proceed."), {
+      logger: auditMock,
+    });
+    expect(res).toMatchObject({
+      action: "revise",
+      retry: {
+        idempotencyKey: "scopelybot-supervisor:turn-1:confirm_code_leak",
+        maxAttempts: 1,
+      },
+    });
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "scopely_supervisor",
+        resultSummary: "revise: confirm_code_leak",
+      }),
+    );
+  });
+});
+
+describe("fuse", () => {
+  it("trips after N revisions: accepts the draft, posts escalation, then cools down", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "2";
+    process.env.SCOPELYBOT_ESCALATION_OWNER = "John Rudolph";
+    const bad = () => event("Reply CONFIRM 4821 to proceed.");
+    let t = 1_000_000;
+    const deps = { logger: auditMock, now: () => t };
+
+    // Revision 1: normal revise.
+    expect(await superviseFinalize(bad(), deps)).toMatchObject({ action: "revise" });
+    // Revision 2: fuse trips — draft accepted, escalation posted naming the owner.
+    t += 1000;
+    expect(await superviseFinalize(bad(), deps)).toEqual({ action: "continue" });
+    expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
+    expect(String(sendScopelyTextMock.mock.calls[0][1])).toContain("John Rudolph");
+    expect(auditMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ resultSummary: "fuse_tripped after confirm_code_leak" }),
+    );
+    // Cooldown: pass-through, no further checks, no extra escalation.
+    t += 1000;
+    expect(await superviseFinalize(bad(), deps)).toEqual({ action: "continue" });
+    expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
+    // After cooldown expires the checks are live again.
+    t += 11 * 60_000;
+    expect(await superviseFinalize(bad(), deps)).toMatchObject({ action: "revise" });
+  });
+
+  it("fuse state is per session key", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "1";
+    const deps = { logger: auditMock, now: () => 5_000_000 };
+    // Session A trips immediately (threshold 1).
+    expect(await superviseFinalize(event("Reply CONFIRM 1111 now."), deps)).toEqual({
+      action: "continue",
+    });
+    // A different scopelybot session is unaffected by A's cooldown.
+    expect(
+      await superviseFinalize(
+        event("Reply CONFIRM 2222 now.", { sessionKey: "agent:scopelybot:zoom:thread:other" }),
+        deps,
+      ),
+    ).toEqual({ action: "continue" }); // trips its own fuse (threshold 1) — but independently
+    expect(sendScopelyTextMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/scopelybot/src/supervisor.ts
+++ b/extensions/scopelybot/src/supervisor.ts
@@ -1,0 +1,304 @@
+// Runtime supervisor for scopelybot (Slice S — Doug's direction, design in
+// docs/reference/scopely-support-service-design.md §4.2).
+//
+// Wired into `before_agent_finalize`: reviews the coordinator's DRAFT final
+// reply before it is accepted, and either lets it through (`continue`) or
+// requests ONE bounded revision pass (`revise` + retry.maxAttempts=1 — the
+// harness enforces the budget per run+idempotencyKey, so a broken check can
+// never create an unbounded loop). All checks are DETERMINISTIC string/shape
+// predicates — no model in the supervisor's own loop.
+//
+// The fuse (Doug's requirement): repeated revisions within a window mean the
+// model cannot satisfy the checks — stop retrying, accept the draft, post a
+// plain-language escalation naming a human owner to the bound channel, and
+// cool down (pass-through) so a degraded model can't spam revision churn.
+//
+// Out of reach BY CONSTRUCTION: the confirm gate. This module never touches
+// the pending-confirm store; its only contact with CONFIRM is BLOCKING drafts
+// that try to emit a code (the system posts confirm prompts deterministically
+// — the LLM must never relay one). Staged-write NO_REPLY turns never reach
+// this hook at all: the harness skips before_agent_finalize for silent
+// replies (src/agents/embedded-agent-runner/run/attempt.ts finalize guard).
+
+import type { AuditLogger } from "./audit.js";
+import { sendScopelyText } from "./comfort.js";
+
+// Shape of the before_agent_finalize event fields this module consumes.
+// Kept structural (not imported from core types) so the extension compiles
+// against the plugin SDK surface the other scopelybot modules use.
+export type FinalizeEvent = {
+  runId?: string;
+  sessionKey?: string;
+  turnId?: string;
+  lastAssistantMessage?: string;
+  messages?: unknown[];
+};
+
+export type FinalizeResult = {
+  action: "continue" | "revise";
+  reason?: string;
+  retry?: { instruction: string; idempotencyKey: string; maxAttempts: number };
+};
+
+// A failed check: checkId keys the harness retry budget; instruction is the
+// revision prompt the harness feeds back to the model for the second pass.
+export type SupervisorVerdict =
+  | { ok: true }
+  | { ok: false; checkId: string; reason: string; instruction: string };
+
+// Opt-in via env, same rollout pattern as SCOPELYBOT_CONFIRM_BUNDLE_MS:
+// unset/0 = supervisor disabled (byte-identical legacy behavior), so enabling
+// on prod is an explicit, reversible env line. Read at call time so tests and
+// late-loading env both resolve.
+export function supervisorEnabled(): boolean {
+  return process.env.SCOPELYBOT_SUPERVISOR === "1";
+}
+
+// Fuse tuning (env-overridable). Defaults: 3 revisions inside 10 minutes trip
+// the fuse; pass-through cooldown of 10 minutes after a trip.
+function fuseThreshold(): number {
+  const raw = Number(process.env.SCOPELYBOT_SUPERVISOR_FUSE_N ?? "3");
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : 3;
+}
+function fuseWindowMs(): number {
+  const raw = Number(process.env.SCOPELYBOT_SUPERVISOR_FUSE_WINDOW_MS ?? String(10 * 60_000));
+  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60_000;
+}
+function fuseCooldownMs(): number {
+  const raw = Number(process.env.SCOPELYBOT_SUPERVISOR_COOLDOWN_MS ?? String(10 * 60_000));
+  return Number.isFinite(raw) && raw > 0 ? raw : 10 * 60_000;
+}
+
+// ---------------------------------------------------------------------------
+// Checks — deterministic predicates over the draft text + turn tool activity.
+// Ordered by severity; the first failure wins (one revision instruction per
+// pass keeps the retry prompt unambiguous).
+// ---------------------------------------------------------------------------
+
+// A CONFIRM code in an outbound draft means the model is relaying/fabricating
+// a confirmation code — the one thing the confirm-gate design forbids (codes
+// are posted deterministically by stageWrite, never through the LLM).
+const CONFIRM_CODE_RE = /\bCONFIRM\s+\d{4}\b/i;
+
+// Conservative secret shapes: JWTs, PEM private keys, bearer/api-key tokens,
+// and explicit "the password is X" constructions. Deliberately narrow — a
+// false positive costs a wasted model pass, but chatty patterns (e.g. the
+// word "password" alone) would fire on legitimate reset-flow explanations.
+const SECRET_RES: RegExp[] = [
+  /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}/, // JWT
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\bBearer\s+[A-Za-z0-9._~+/-]{25,}/,
+  /\bsk-[A-Za-z0-9]{20,}/,
+  /\bpassword\s+(?:is|:)\s*[^\s.,;]{4,}/i,
+];
+
+// State-assertion cues: the draft claims concrete app state (ids, multi-digit
+// counts, currency, percentages, emails). Combined with ZERO tool activity in
+// the turn, this is the hallucinated-state signature T1/S9 was probing for.
+const STATE_CUE_RES: RegExp[] = [
+  /#\d+/,
+  /\bid\s*[:=]?\s*\d+/i,
+  /\b\d{3,}\b/,
+  /\$\s?\d/,
+  /\b\d+(?:\.\d+)?%/,
+  /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/,
+];
+
+// True when the draft parses wholesale as JSON, or embeds a large JSON blob —
+// the coordinator's contract is plain language, never raw tool output.
+function looksLikeJsonDump(draft: string): boolean {
+  const trimmed = draft.trim();
+  if ((trimmed.startsWith("{") || trimmed.startsWith("[")) && trimmed.length > 80) {
+    try {
+      JSON.parse(trimmed);
+      return true;
+    } catch {
+      // fall through to embedded-blob scan
+    }
+  }
+  const blob = trimmed.match(/[{[][\s\S]{300,}[}\]]/);
+  if (!blob) return false;
+  try {
+    JSON.parse(blob[0]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Review one draft. `hadToolActivity` = did the turn include any tool result
+// (spoke dispatches surface as tool results in the coordinator transcript,
+// so routed reads count as grounding).
+export function reviewDraft(draft: string, hadToolActivity: boolean): SupervisorVerdict {
+  if (CONFIRM_CODE_RE.test(draft)) {
+    return {
+      ok: false,
+      checkId: "confirm_code_leak",
+      reason: "draft contains a CONFIRM code",
+      instruction:
+        "Your reply contains a confirmation code. Never include, repeat, or invent CONFIRM codes — " +
+        "the system posts confirmation prompts itself. Remove the code and, if a write was staged, " +
+        "say only that a confirmation prompt was posted to the channel.",
+    };
+  }
+  for (const re of SECRET_RES) {
+    if (re.test(draft)) {
+      return {
+        ok: false,
+        checkId: "secret_leak",
+        reason: "draft contains a secret-shaped value",
+        instruction:
+          "Your reply contains what looks like a secret (token, key, or password value). Never put " +
+          "secret values in the channel. Remove it and explain the actual delivery mechanism instead " +
+          "(for example: a reset email is sent to the user).",
+      };
+    }
+  }
+  if (looksLikeJsonDump(draft)) {
+    return {
+      ok: false,
+      checkId: "raw_json_dump",
+      reason: "draft is raw JSON, not a human answer",
+      instruction:
+        "Your reply is raw JSON or contains a large JSON dump. Rewrite it as a plain-language answer: " +
+        "lead with the answer, keep only the fields the human asked about, no code blocks.",
+    };
+  }
+  // A clarifying question back to the human is not a state claim.
+  const isShortQuestion = draft.trim().length < 120 && draft.trim().endsWith("?");
+  if (!hadToolActivity && !isShortQuestion && STATE_CUE_RES.some((re) => re.test(draft))) {
+    return {
+      ok: false,
+      checkId: "unsupported_state_claim",
+      reason: "draft asserts app state with no tool read this turn",
+      instruction:
+        "Your reply states specific facts about the application (ids, counts, amounts, or addresses) " +
+        "but no tool was consulted this turn. Verify every stated fact with a fresh tool read before " +
+        "answering; if you cannot verify, say what you could not verify instead of guessing.",
+    };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Turn tool-activity detection over the (unknown-typed) transcript messages:
+// any toolResult-role message AFTER the last user message counts.
+// ---------------------------------------------------------------------------
+
+export function turnHadToolActivity(messages: unknown[] | undefined): boolean {
+  if (!Array.isArray(messages)) return false;
+  let sawToolResult = false;
+  for (const msg of messages) {
+    const role = (msg as { role?: unknown } | null)?.role;
+    if (role === "user") {
+      sawToolResult = false; // new turn boundary — reset
+    } else if (role === "toolResult") {
+      sawToolResult = true;
+    }
+  }
+  return sawToolResult;
+}
+
+// ---------------------------------------------------------------------------
+// Fuse — per-session sliding window of revision timestamps + cooldown.
+// ---------------------------------------------------------------------------
+
+type FuseState = { revisions: number[]; fusedUntil: number };
+const fuseBySession = new Map<string, FuseState>();
+
+function fuseFor(sessionKey: string): FuseState {
+  let s = fuseBySession.get(sessionKey);
+  if (!s) {
+    s = { revisions: [], fusedUntil: 0 };
+    fuseBySession.set(sessionKey, s);
+  }
+  return s;
+}
+
+// Record a revision; returns true when this one TRIPS the fuse.
+function recordRevisionAndCheckFuse(sessionKey: string, now: number): boolean {
+  const s = fuseFor(sessionKey);
+  const windowStart = now - fuseWindowMs();
+  s.revisions = s.revisions.filter((t) => t >= windowStart);
+  s.revisions.push(now);
+  if (s.revisions.length >= fuseThreshold()) {
+    s.revisions = [];
+    s.fusedUntil = now + fuseCooldownMs();
+    return true;
+  }
+  return false;
+}
+
+function isFused(sessionKey: string, now: number): boolean {
+  return fuseFor(sessionKey).fusedUntil > now;
+}
+
+// Test hook: clear all fuse state between test cases.
+export function resetSupervisorStateForTest(): void {
+  fuseBySession.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Hook entry point.
+// ---------------------------------------------------------------------------
+
+// Supervise one finalize event. Returns undefined (no opinion) for disabled /
+// out-of-scope / clean drafts, a revise result for a failed check, or continue
+// (+ deterministic escalation post) when the fuse trips.
+export async function superviseFinalize(
+  event: FinalizeEvent,
+  deps: { logger: AuditLogger; now?: () => number },
+): Promise<FinalizeResult | undefined> {
+  if (!supervisorEnabled()) return undefined;
+  // Coordinator scope only: spokes return internal packets (reviewed later);
+  // the user-facing surface is the scopelybot coordinator session.
+  const sessionKey = event.sessionKey ?? "";
+  if (!sessionKey.startsWith("agent:scopelybot:")) return undefined;
+  const draft = typeof event.lastAssistantMessage === "string" ? event.lastAssistantMessage : "";
+  if (!draft.trim()) return undefined;
+
+  const now = deps.now ? deps.now() : Date.now();
+  if (isFused(sessionKey, now)) return { action: "continue" };
+
+  const verdict = reviewDraft(draft, turnHadToolActivity(event.messages));
+  if (verdict.ok) return undefined;
+
+  const tripped = recordRevisionAndCheckFuse(sessionKey, now);
+  deps.logger({
+    ts: new Date(now).toISOString(),
+    tool: "scopely_supervisor",
+    actor: "system",
+    params: { checkId: verdict.checkId, sessionKey },
+    resultSummary: tripped ? `fuse_tripped after ${verdict.checkId}` : `revise: ${verdict.checkId}`,
+  });
+
+  if (tripped) {
+    // Stop retrying: accept the draft (it was already the model's best after
+    // prior passes) and post a plain-language escalation naming a human owner
+    // — the no-dead-end rule. Posted deterministically, never via the model.
+    const owner = process.env.SCOPELYBOT_ESCALATION_OWNER ?? "Chad Simon";
+    const channel = process.env.SCOPELYBOT_ZOOM_CHANNEL ?? "";
+    if (channel) {
+      await sendScopelyText(
+        channel,
+        `I couldn't fully verify parts of my last answer after several attempts — treat its details ` +
+          `as provisional. Flagging ${owner} to double-check; they'll follow up here.`,
+      ).catch(() => {
+        // Escalation post is best-effort; the audit entry above is the record.
+      });
+    }
+    return { action: "continue" };
+  }
+
+  return {
+    action: "revise",
+    reason: verdict.reason,
+    retry: {
+      instruction: verdict.instruction,
+      // Keyed per turn+check so the harness budget allows exactly ONE retry
+      // for this check in this turn, and a different check may still fire.
+      idempotencyKey: `scopelybot-supervisor:${event.turnId ?? event.runId ?? "turn"}:${verdict.checkId}`,
+      maxAttempts: 1,
+    },
+  };
+}


### PR DESCRIPTION
Implements the Slice S supervisor per the design in `docs/reference/scopely-support-service-design.md` §4.2 (Doug's direction: rules + voice + data-correctness + bounded retry + fuse).

**What it does** — on `before_agent_finalize`, reviews the coordinator's draft final reply with deterministic checks (no model in the supervisor's own loop):
- `confirm_code_leak` — draft relays/fabricates a `CONFIRM <code>` → revise (codes are posted deterministically by `stageWrite`, never through the LLM)
- `secret_leak` — JWT / PEM / bearer / api-key / "the password is X" shapes → revise with the delivery-mechanism policy
- `raw_json_dump` — draft is (or embeds large) raw JSON → revise to plain language
- `unsupported_state_claim` — draft asserts app state (ids/counts/amounts/emails) with ZERO tool reads this turn → revise forcing a fresh read (the T1 S9 probe, made mandatory)

**Bounded retry** — `retry.maxAttempts=1` keyed per turn+check; the harness enforces the budget (`lifecycle-hook-helpers.ts` finalize retry budget), so a broken check can never loop.

**The fuse** — N revisions (default 3) within a window (default 10 min) per session: stop retrying, accept the draft, post a plain-language escalation naming a human owner (`SCOPELYBOT_ESCALATION_OWNER`) to the bound channel — deterministically, never via the model — then cool down (pass-through).

**Confirm gate out of reach by construction** — the module never touches the pending store; staged-write NO_REPLY turns never reach the hook (the harness skips finalize for silent replies, `attempt.ts` finalize guard).

**Rollout** — opt-in via `SCOPELYBOT_SUPERVISOR=1` (unset = byte-identical legacy). No new tools → no plugin-contract/allowlist changes. Deploy note: `before_agent_finalize` is a conversation-typed hook — if the registry logs the `allowConversationAccess` warn diagnostic on prod, add `plugins.entries.scopelybot.hooks.allowConversationAccess: true` to openclaw.json.

**Verification** — 14 new tests; scopelybot suite 21 files / 116 tests green; zero new tsc errors in changed files (repo-wide AgentTool baseline unchanged).

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV