### PR TITLE
fix(scopelybot): fail loud on unknown deployment filter values (#81)

### DIFF
--- a/extensions/scopelybot/src/support-tools.test.ts
+++ b/extensions/scopelybot/src/support-tools.test.ts
@@ -122,4 +122,71 @@ describe("Scopely support tools", () => {
     expect(stageWriteMock).toHaveBeenCalledTimes(5);
     expect(scopelyFetchMock).not.toHaveBeenCalled();
   });
+
+  // Issue #81: the backend silently filters to zero rows on an unknown
+  // deployment_type value ("prod" is an environment name, not a deployment
+  // key) — the tool must reject unknown keys with the valid list instead of
+  // relaying a confidently-wrong all-zero count.
+  describe("status_counts deployment filter fail-loud (issue #81)", () => {
+    const TEMPLATES = {
+      ok: true,
+      status: 200,
+      data: [{ key: "autopilot" }, { key: "copilot" }, { key: "bespoke" }, { key: "tnm" }],
+    };
+
+    it("rejects an unknown deployment key without querying counts", async () => {
+      const tools = buildTools();
+      scopelyFetchMock.mockResolvedValueOnce(TEMPLATES);
+      const result = parse(
+        await tools.scopely_session_status_counts.execute("x", { deployment: "prod" }),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain('Unknown deployment type "prod"');
+      expect(result.error).toContain("autopilot, copilot, bespoke, tnm");
+      // Only the template lookup fired — never the counts query.
+      expect(scopelyFetchMock).toHaveBeenCalledTimes(1);
+      expect(String(scopelyFetchMock.mock.calls[0][0])).toContain("deployment-type-templates");
+    });
+
+    it("passes a valid deployment key through to the counts query", async () => {
+      const tools = buildTools();
+      scopelyFetchMock
+        .mockResolvedValueOnce(TEMPLATES)
+        .mockResolvedValueOnce({ ok: true, status: 200, data: { total: 5, counts: {}, other: 0 } });
+      const result = parse(
+        await tools.scopely_session_status_counts.execute("x", { deployment: "copilot" }),
+      );
+      expect(result.ok).toBe(true);
+      expect(result.data.total).toBe(5);
+      expect(String(scopelyFetchMock.mock.calls[1][0])).toContain("deployment=copilot");
+    });
+
+    it("skips validation entirely when no deployment filter is given", async () => {
+      const tools = buildTools();
+      scopelyFetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        data: { total: 713, counts: { in_progress: 391 }, other: 0 },
+      });
+      const result = parse(await tools.scopely_session_status_counts.execute("x", {}));
+      expect(result.ok).toBe(true);
+      expect(result.data.total).toBe(713);
+      expect(scopelyFetchMock).toHaveBeenCalledTimes(1);
+      expect(String(scopelyFetchMock.mock.calls[0][0])).toContain("status-counts");
+    });
+
+    it("fails open when the template lookup itself fails (no false blocks)", async () => {
+      const tools = buildTools();
+      scopelyFetchMock
+        .mockResolvedValueOnce({ ok: false, status: 500, data: undefined })
+        .mockResolvedValueOnce({ ok: true, status: 200, data: { total: 0, counts: {}, other: 0 } });
+      const result = parse(
+        await tools.scopely_session_status_counts.execute("x", { deployment: "prod" }),
+      );
+      // Template list unavailable → cannot validate → the query proceeds
+      // (backend behavior unchanged) rather than hard-failing reads.
+      expect(result.ok).toBe(true);
+      expect(scopelyFetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/extensions/scopelybot/src/support-tools.ts
+++ b/extensions/scopelybot/src/support-tools.ts
@@ -191,10 +191,18 @@ export function registerSupportTools(
       {
         name: "scopely_session_status_counts",
         description:
-          "Get live Scopely session counts by lifecycle status with optional admin-list facets. Read-only.",
+          "Get live Scopely session counts by lifecycle status with optional admin-list facets. Read-only. " +
+          "For a plain 'how many sessions' question, call with NO filters.",
         parameters: Type.Object({
           vendor: Type.Optional(Type.String()),
-          deployment: Type.Optional(Type.String()),
+          deployment: Type.Optional(
+            Type.String({
+              description:
+                "Deployment-type KEY from the scoping wizard (e.g. autopilot, copilot, bespoke) — " +
+                "NOT an environment name like prod/dev. Unknown keys are rejected with the valid list. " +
+                "Omit to count sessions across all deployment types.",
+            }),
+          ),
           search: Type.Optional(Type.String()),
           date_from: Type.Optional(Type.String()),
           date_to: Type.Optional(Type.String()),
@@ -203,6 +211,31 @@ export function registerSupportTools(
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
+            // Fail-loud filter validation (issue #81): the backend silently
+            // returns all-zero counts for an unknown deployment_type value —
+            // observed live 2026-07-21 when the model guessed deployment="prod"
+            // and confidently reported "0 sessions" against 713 real ones.
+            // Valid keys are data-defined (deployment-type templates), so we
+            // check against the live list instead of hardcoding an enum. Same
+            // self-correction pattern that fixed the S7 container guessing.
+            const deployment =
+              typeof params.deployment === "string" ? params.deployment.trim() : "";
+            if (deployment) {
+              const templates = await scopelyFetch(`/api/admin/deployment-type-templates/`);
+              const rows = Array.isArray(templates.data)
+                ? templates.data
+                : ((asRecord(templates.data).results as unknown[]) ?? []);
+              const validKeys = rows.map((row) => String(asRecord(row).key ?? "")).filter(Boolean);
+              if (templates.ok && validKeys.length > 0 && !validKeys.includes(deployment)) {
+                return jsonResult({
+                  ok: false,
+                  error:
+                    `Unknown deployment type "${deployment}" — the backend would silently return zero ` +
+                    `counts for it. Valid deployment-type keys: ${validKeys.join(", ")}. ` +
+                    `Omit the deployment filter to count sessions across all deployment types.`,
+                });
+              }
+            }
             const query = buildQuery(params, [
               "vendor",
               "deployment",


### PR DESCRIPTION
Fixes #81 — live incident 2026-07-21: spoke guessed `deployment: "prod"` (an environment name, not a deployment-type key), the backend silently exact-matched to zero rows, and the bot confidently answered "0 sessions" against 713 real ones (391 in_progress, ORM-verified).

**Fix (tool layer, S7 self-correction pattern):** when a `deployment` filter is provided, `scopely_session_status_counts` validates it against the live `/api/admin/deployment-type-templates/` list (values are data-defined — no hardcoded enum) and rejects unknowns with an error naming the valid keys, so the spoke self-corrects in one round-trip instead of relaying a confidently-wrong zero. Fails open if the template lookup itself errors (reads never hard-block). Param description now names the key space (`autopilot/copilot/bespoke/…`) and warns it is NOT prod/dev.

No new tool names → no plugin-contract or allowlist changes; prod deploy = pull + recreate.

**Tests:** 4 new (reject-unknown without counts query, valid-key passthrough, no-filter skip, fail-open on template 500) — support-tools file 7/7 green.

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV