### PR TITLE
feat(scopelybot): deal workflow verbs — lifecycle, approvals, discounts, SOW pipeline (Slice 3)

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -17,6 +17,8 @@ import { registerPassthroughTools } from "./src/passthrough-tools.js";
 import { registerPricingTools } from "./src/pricing-tools.js";
 import { registerScopelyTools } from "./src/scopely-tools.js";
 import { registerScopingCardTools } from "./src/scoping-card-tools.js";
+import { registerSessionLifecycleTools } from "./src/session-lifecycle-tools.js";
+import { registerSowTools } from "./src/sow-tools.js";
 import { superviseFinalize } from "./src/supervisor.js";
 import { registerSupportTools } from "./src/support-tools.js";
 import { registerUserMaintenanceTools } from "./src/user-maintenance-tools.js";
@@ -97,6 +99,8 @@ const plugin = {
     registerDeploymentConfigTools(optionalApi, logger);
     registerScopingCardTools(optionalApi, logger);
     registerSupportTools(optionalApi, logger, pluginConfig);
+    registerSessionLifecycleTools(optionalApi, logger);
+    registerSowTools(optionalApi, logger);
     registerApproverTools(optionalApi, logger, approverStore);
 
     // Zoom card bodies do not render Markdown. Keep this rewrite at the Scopely
@@ -211,7 +215,7 @@ const plugin = {
     }
 
     console.log(
-      "[scopelybot] Registered 99 tools (11 observability + 6 admin + 4 monitoring + 6 GH + 1 correlation + 2 passthrough + 9 user-maintenance + 8 org + 15 pricing + 13 vendor-config + 8 deployment-config + 5 scoping-card + 11 support)",
+      "[scopelybot] Registered 115 tools (11 observability + 6 admin + 4 monitoring + 6 GH + 1 correlation + 2 passthrough + 9 user-maintenance + 8 org + 15 pricing + 13 vendor-config + 8 deployment-config + 5 scoping-card + 11 support + 11 session-lifecycle + 5 sow)",
     );
   },
 };

--- a/extensions/scopelybot/openclaw.plugin.json
+++ b/extensions/scopelybot/openclaw.plugin.json
@@ -135,7 +135,23 @@
       "scopely_update_vendor_term",
       "scopely_user_activity",
       "scopely_vendor_config",
-      "scopely_wizard_funnel"
+      "scopely_wizard_funnel",
+      "scopely_cancel_session",
+      "scopely_archive_session",
+      "scopely_reopen_session",
+      "scopely_revise_session",
+      "scopely_clone_session",
+      "scopely_request_session_approval",
+      "scopely_approve_session",
+      "scopely_reject_session",
+      "scopely_list_session_discounts",
+      "scopely_add_session_discount",
+      "scopely_remove_session_discount",
+      "scopely_sow_preview",
+      "scopely_generate_sow",
+      "scopely_execute_sow",
+      "scopely_send_sow",
+      "scopely_change_sow_signer"
     ]
   }
 }

--- a/extensions/scopelybot/src/session-lifecycle-tools.test.ts
+++ b/extensions/scopelybot/src/session-lifecycle-tools.test.ts
@@ -1,0 +1,196 @@
+// Contract tests for the Slice 3 lifecycle/approval/discount verbs: every
+// mutation stages (never executes at call time), staged runs hit the verified
+// backend paths with the right method/body, summaries carry the facts an
+// approver needs, and the discount id-resolution read runs immediately.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scopelyFetchMock = vi.fn();
+const stageWriteMock = vi.fn();
+vi.mock("./scopely-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./scopely-api.js")>("./scopely-api.js");
+  return { ...actual, scopelyFetch: (...args: unknown[]) => scopelyFetchMock(...args) };
+});
+vi.mock("./gated.js", () => ({
+  stageWrite: (...args: unknown[]) => {
+    stageWriteMock(...args);
+    return Promise.resolve({
+      content: [
+        { type: "text", text: JSON.stringify({ staged: true, awaiting_confirmation: true }) },
+      ],
+    });
+  },
+}));
+
+import { registerSessionLifecycleTools } from "./session-lifecycle-tools.js";
+
+type Tool = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+function buildTools() {
+  const tools: Record<string, Tool> = {};
+  const api = {
+    registerTool: (factory: () => Tool) => {
+      const tool = factory();
+      tools[tool.name] = tool;
+    },
+  } as never;
+  registerSessionLifecycleTools(api, (() => {}) as never);
+  return tools;
+}
+
+function parse(result: { content: { text: string }[] }) {
+  return JSON.parse(result.content[0].text);
+}
+
+// Runs the staged closure captured by the last stageWrite call.
+async function runStaged() {
+  const run = stageWriteMock.mock.calls.at(-1)?.[1] as () => Promise<unknown>;
+  return run();
+}
+
+describe("session lifecycle tools", () => {
+  beforeEach(() => {
+    scopelyFetchMock.mockReset();
+    scopelyFetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    stageWriteMock.mockReset();
+  });
+
+  it("registers the exact eleven tools", () => {
+    expect(Object.keys(buildTools()).sort()).toEqual(
+      [
+        "scopely_add_session_discount",
+        "scopely_approve_session",
+        "scopely_archive_session",
+        "scopely_cancel_session",
+        "scopely_clone_session",
+        "scopely_list_session_discounts",
+        "scopely_reject_session",
+        "scopely_remove_session_discount",
+        "scopely_reopen_session",
+        "scopely_request_session_approval",
+        "scopely_revise_session",
+      ].sort(),
+    );
+  });
+
+  it("every mutation stages without touching the backend at call time", async () => {
+    const tools = buildTools();
+    await tools.scopely_cancel_session.execute("x", { session_id: 7 });
+    await tools.scopely_archive_session.execute("x", { session_id: 7 });
+    await tools.scopely_reopen_session.execute("x", { session_id: 7 });
+    await tools.scopely_revise_session.execute("x", { session_id: 7 });
+    await tools.scopely_clone_session.execute("x", { session_id: 7 });
+    await tools.scopely_request_session_approval.execute("x", { session_id: 7 });
+    await tools.scopely_approve_session.execute("x", { session_id: 7 });
+    await tools.scopely_reject_session.execute("x", { session_id: 7 });
+    await tools.scopely_add_session_discount.execute("x", {
+      session_id: 7,
+      discount_type: "percent",
+      value: 10,
+    });
+    await tools.scopely_remove_session_discount.execute("x", { session_id: 7, discount_id: 3 });
+    expect(stageWriteMock).toHaveBeenCalledTimes(10);
+    expect(scopelyFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("staged lifecycle runs POST the verified paths with reason bodies", async () => {
+    const tools = buildTools();
+    await tools.scopely_cancel_session.execute("x", { session_id: 42, reason: "dup deal" });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe("CANCEL session 42 (reason: dup deal)");
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/42/cancel/", {
+      method: "POST",
+      body: JSON.stringify({ reason: "dup deal" }),
+    });
+
+    await tools.scopely_reopen_session.execute("x", { session_id: 42 });
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenLastCalledWith("/api/sessions/42/reopen/", {
+      method: "POST",
+      body: "{}",
+    });
+  });
+
+  it("approve/reject carry comments in summary and body", async () => {
+    const tools = buildTools();
+    await tools.scopely_reject_session.execute("x", { session_id: 9, comments: "price too low" });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe(
+      "REJECT approval request on session 9 (comments: price too low)",
+    );
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/9/reject/", {
+      method: "POST",
+      body: JSON.stringify({ comments: "price too low" }),
+    });
+  });
+
+  it("add discount validates value and stages a fully-described summary", async () => {
+    const tools = buildTools();
+    const bad = parse(
+      await tools.scopely_add_session_discount.execute("x", {
+        session_id: 7,
+        discount_type: "fixed",
+        value: -5,
+      }),
+    );
+    expect(bad.ok).toBe(false);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+
+    await tools.scopely_add_session_discount.execute("x", {
+      session_id: 7,
+      discount_type: "percent",
+      value: 15,
+      label: "Partner rate",
+      category: "ucaas",
+    });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe(
+      'add discount "Partner rate" (15%, category ucaas) to session 7',
+    );
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/discounts/", {
+      method: "POST",
+      body: JSON.stringify({
+        discount_type: "percent",
+        value: "15",
+        label: "Partner rate",
+        category: "ucaas",
+      }),
+    });
+  });
+
+  it("remove discount DELETEs the verified path", async () => {
+    const tools = buildTools();
+    await tools.scopely_remove_session_discount.execute("x", { session_id: 7, discount_id: 3 });
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/discounts/3/", {
+      method: "DELETE",
+    });
+  });
+
+  it("discount list is a direct read (id-resolution dependency)", async () => {
+    scopelyFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: [{ id: 3, discount_type: "percent", value: "10.00" }],
+    });
+    const result = parse(
+      await buildTools().scopely_list_session_discounts.execute("x", { session_id: 7 }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.data[0].id).toBe(3);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/discounts/");
+  });
+
+  it("rejects a non-positive session id before staging", async () => {
+    const result = parse(await buildTools().scopely_cancel_session.execute("x", { session_id: 0 }));
+    expect(result.ok).toBe(false);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/scopelybot/src/session-lifecycle-tools.ts
+++ b/extensions/scopelybot/src/session-lifecycle-tools.ts
@@ -1,0 +1,325 @@
+// Deal-workflow verbs for Scopely sessions (plan Slice 3): lifecycle
+// transitions, the approval workflow, and session discounts. Every mutation
+// only STAGES via stageWrite() — the confirm-gate invariant — and executes
+// only on a human `CONFIRM <code>` (before_dispatch, index.ts). The discount
+// LIST read is co-located here because it is the id-resolution dependency for
+// discount removal (scopelybot-spoke-partitioning-problem.md: keep dependency
+// reads next to the verbs that need them).
+//
+// Backend contracts verified against scopely service/apps/scoping/urls.py and
+// views/{sessions,approvals,sow,pricing}.py on 2026-07-21: all lifecycle and
+// approval actions are POST with optional {reason}/{comments} bodies;
+// discounts are POST {discount_type, value, label?, category?} and DELETE.
+
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
+import { scopelyFetch, jsonResult, errorResult } from "./scopely-api.js";
+
+// Validate and narrow a session id once; every tool below needs it.
+function sessionId(params: Record<string, unknown>): number {
+  const parsed = Number(params.session_id);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("session_id must be a positive integer");
+  }
+  return parsed;
+}
+
+const SESSION_ID_PARAM = Type.Number({ description: "Numeric session id" });
+
+// Shared description tail for staged writes — the phrasing the coordinator
+// already responds to correctly (matches user-maintenance-tools.ts).
+const STAGED =
+  "You ARE authorized — CALL this tool; do NOT refuse or defer to the UI. It is safe: it only " +
+  "STAGES the action; nothing happens until the requester replies `CONFIRM <code>`.";
+
+export function registerSessionLifecycleTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // --- lifecycle transitions -----------------------------------------------
+
+  // One registration helper for the four body-free/reason-only POST verbs —
+  // they differ only in path, summary verb, and description.
+  const lifecycleVerbs: Array<{
+    tool: string;
+    path: string;
+    verb: string;
+    description: string;
+    withReason: boolean;
+  }> = [
+    {
+      tool: "scopely_cancel_session",
+      path: "cancel",
+      verb: "CANCEL",
+      description:
+        "Cancel a Scopely scoping session (awaiting-signature sessions are voided first). " +
+        STAGED,
+      withReason: true,
+    },
+    {
+      tool: "scopely_archive_session",
+      path: "archive",
+      verb: "ARCHIVE",
+      description:
+        "Archive a Scopely session — hidden from active work but SOW/pricing/DocuSign history " +
+        "remain recoverable. " +
+        STAGED,
+      withReason: true,
+    },
+    {
+      tool: "scopely_reopen_session",
+      path: "reopen",
+      verb: "REOPEN",
+      description:
+        "Reopen a cancelled or archived Scopely session back into active work. " + STAGED,
+      withReason: false,
+    },
+    {
+      tool: "scopely_revise_session",
+      path: "revise",
+      verb: "REVISE",
+      description:
+        "Start a revision of a Scopely session (new editable version of a generated deal). " +
+        STAGED,
+      withReason: false,
+    },
+    {
+      tool: "scopely_clone_session",
+      path: "clone",
+      verb: "CLONE",
+      description:
+        "Clone a Scopely session into a new draft with the same configuration. " + STAGED,
+      withReason: false,
+    },
+  ];
+
+  for (const spec of lifecycleVerbs) {
+    api.registerTool(() =>
+      wrapToolWithAudit(
+        {
+          name: spec.tool,
+          description: spec.description,
+          parameters: spec.withReason
+            ? Type.Object({
+                session_id: SESSION_ID_PARAM,
+                reason: Type.Optional(
+                  Type.String({ description: "Reason, recorded in the audit trail" }),
+                ),
+              })
+            : Type.Object({ session_id: SESSION_ID_PARAM }),
+          async execute(_id: string, params: Record<string, unknown>) {
+            try {
+              const id = sessionId(params);
+              const reason =
+                spec.withReason && typeof params.reason === "string" ? params.reason : "";
+              const summary = `${spec.verb} session ${id}${reason ? ` (reason: ${reason})` : ""}`;
+              return await stageWrite(summary, () =>
+                scopelyFetch(`/api/sessions/${id}/${spec.path}/`, {
+                  method: "POST",
+                  body: JSON.stringify(reason ? { reason } : {}),
+                }),
+              );
+            } catch (err) {
+              return errorResult(err);
+            }
+          },
+        },
+        logger,
+      ),
+    );
+  }
+
+  // --- approval workflow ---------------------------------------------------
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_request_session_approval",
+        description:
+          "Submit a priced Scopely session for manager approval (required above the approval " +
+          "threshold before SOW generation). " +
+          STAGED,
+        parameters: Type.Object({ session_id: SESSION_ID_PARAM }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            return await stageWrite(`request approval for session ${id}`, () =>
+              scopelyFetch(`/api/sessions/${id}/request-approval/`, { method: "POST", body: "{}" }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  for (const spec of [
+    {
+      tool: "scopely_approve_session",
+      path: "approve",
+      verb: "APPROVE",
+      description:
+        "Approve a Scopely session's pending approval request so the deal can proceed to SOW. " +
+        STAGED +
+        " Pending requests: scopely_pending_approvals.",
+    },
+    {
+      tool: "scopely_reject_session",
+      path: "reject",
+      verb: "REJECT",
+      description:
+        "Reject a Scopely session's pending approval request, sending it back to the rep. " +
+        STAGED +
+        " Pending requests: scopely_pending_approvals.",
+    },
+  ]) {
+    api.registerTool(() =>
+      wrapToolWithAudit(
+        {
+          name: spec.tool,
+          description: spec.description,
+          parameters: Type.Object({
+            session_id: SESSION_ID_PARAM,
+            comments: Type.Optional(
+              Type.String({ description: "Reviewer comments, shown to the requester" }),
+            ),
+          }),
+          async execute(_id: string, params: Record<string, unknown>) {
+            try {
+              const id = sessionId(params);
+              const comments = typeof params.comments === "string" ? params.comments : "";
+              const summary = `${spec.verb} approval request on session ${id}${
+                comments ? ` (comments: ${comments})` : ""
+              }`;
+              return await stageWrite(summary, () =>
+                scopelyFetch(`/api/sessions/${id}/${spec.path}/`, {
+                  method: "POST",
+                  body: JSON.stringify(comments ? { comments } : {}),
+                }),
+              );
+            } catch (err) {
+              return errorResult(err);
+            }
+          },
+        },
+        logger,
+      ),
+    );
+  }
+
+  // --- discounts -----------------------------------------------------------
+
+  // Dependency read: resolves discount ids for removal and shows what is
+  // already applied. Runs immediately (read-only).
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_list_session_discounts",
+        description:
+          "List the discounts applied to a Scopely session (id, type, label, value, category). " +
+          "Read-only — runs immediately. Use before removing a discount to find its discount_id.",
+        parameters: Type.Object({ session_id: SESSION_ID_PARAM }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const result = await scopelyFetch(`/api/sessions/${id}/discounts/`);
+            return jsonResult({ ok: result.ok, status: result.status, data: result.data });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_add_session_discount",
+        description:
+          "Add a discount line to a Scopely session's pricing. " +
+          STAGED +
+          " value must be non-negative; percent values are 0-100.",
+        parameters: Type.Object({
+          session_id: SESSION_ID_PARAM,
+          discount_type: Type.Union([Type.Literal("percent"), Type.Literal("fixed")], {
+            description: "percent = percentage off; fixed = fixed amount off",
+          }),
+          value: Type.Number({ description: "Non-negative discount value" }),
+          label: Type.Optional(Type.String({ description: "Display label (default 'Discount')" })),
+          category: Type.Optional(
+            Type.String({
+              description: "Pricing category to scope to; omit to apply to the total",
+            }),
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const discountType = params.discount_type as "percent" | "fixed";
+            const value = Number(params.value);
+            if (!Number.isFinite(value) || value < 0) {
+              throw new Error("value must be a non-negative number");
+            }
+            const label =
+              typeof params.label === "string" && params.label ? params.label : "Discount";
+            const category = typeof params.category === "string" ? params.category : "";
+            const body: Record<string, unknown> = {
+              discount_type: discountType,
+              value: String(value),
+              label,
+            };
+            if (category) body.category = category;
+            const rendered = discountType === "percent" ? `${value}%` : `${value} fixed`;
+            const summary = `add discount "${label}" (${rendered}${
+              category ? `, category ${category}` : ", on total"
+            }) to session ${id}`;
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/sessions/${id}/discounts/`, {
+                method: "POST",
+                body: JSON.stringify(body),
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_remove_session_discount",
+        description:
+          "Remove a discount line from a Scopely session. " +
+          STAGED +
+          " Find the discount_id first with scopely_list_session_discounts.",
+        parameters: Type.Object({
+          session_id: SESSION_ID_PARAM,
+          discount_id: Type.Number({ description: "Numeric discount id to remove" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const discountId = Number(params.discount_id);
+            if (!Number.isInteger(discountId) || discountId <= 0) {
+              throw new Error("discount_id must be a positive integer");
+            }
+            return await stageWrite(`remove discount ${discountId} from session ${id}`, () =>
+              scopelyFetch(`/api/sessions/${id}/discounts/${discountId}/`, { method: "DELETE" }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}

--- a/extensions/scopelybot/src/sow-tools.test.ts
+++ b/extensions/scopelybot/src/sow-tools.test.ts
@@ -1,0 +1,194 @@
+// Contract tests for the Slice 3 SOW pipeline: preview reads immediately and
+// bounds its payload; generate stages and DISCARDS the document bytes; the
+// external send plane (execute/send/change-signer) stages with summaries that
+// name the customer recipient explicitly and enforces required recipients.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scopelyFetchMock = vi.fn();
+const stageWriteMock = vi.fn();
+vi.mock("./scopely-api.js", async () => {
+  const actual = await vi.importActual<typeof import("./scopely-api.js")>("./scopely-api.js");
+  return { ...actual, scopelyFetch: (...args: unknown[]) => scopelyFetchMock(...args) };
+});
+vi.mock("./gated.js", () => ({
+  stageWrite: (...args: unknown[]) => {
+    stageWriteMock(...args);
+    return Promise.resolve({
+      content: [
+        { type: "text", text: JSON.stringify({ staged: true, awaiting_confirmation: true }) },
+      ],
+    });
+  },
+}));
+
+import { registerSowTools } from "./sow-tools.js";
+
+type Tool = {
+  name: string;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: { text: string }[] }>;
+};
+
+function buildTools() {
+  const tools: Record<string, Tool> = {};
+  const api = {
+    registerTool: (factory: () => Tool) => {
+      const tool = factory();
+      tools[tool.name] = tool;
+    },
+  } as never;
+  registerSowTools(api, (() => {}) as never);
+  return tools;
+}
+
+function parse(result: { content: { text: string }[] }) {
+  return JSON.parse(result.content[0].text);
+}
+
+async function runStaged() {
+  const run = stageWriteMock.mock.calls.at(-1)?.[1] as () => Promise<{
+    ok: boolean;
+    status: number;
+    data: unknown;
+  }>;
+  return run();
+}
+
+describe("SOW tools", () => {
+  beforeEach(() => {
+    scopelyFetchMock.mockReset();
+    scopelyFetchMock.mockResolvedValue({ ok: true, status: 200, data: {} });
+    stageWriteMock.mockReset();
+  });
+
+  it("registers the exact five tools", () => {
+    expect(Object.keys(buildTools()).sort()).toEqual(
+      [
+        "scopely_change_sow_signer",
+        "scopely_execute_sow",
+        "scopely_generate_sow",
+        "scopely_send_sow",
+        "scopely_sow_preview",
+      ].sort(),
+    );
+  });
+
+  it("preview reads immediately and bounds line items", async () => {
+    scopelyFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        company_info: { name: "Example Co" },
+        totals: { grand_total: "1000" },
+        line_items: Array.from({ length: 80 }, (_, i) => ({ key: `item-${i}` })),
+      },
+    });
+    const result = parse(await buildTools().scopely_sow_preview.execute("x", { session_id: 7 }));
+    expect(result.ok).toBe(true);
+    expect(result.data.line_item_count).toBe(80);
+    expect(result.data.line_items).toHaveLength(50);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/sow-preview/");
+  });
+
+  it("generate stages, and its run discards the document bytes", async () => {
+    const tools = buildTools();
+    await tools.scopely_generate_sow.execute("x", { session_id: 7 });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe("generate SOW for session 7");
+    expect(scopelyFetchMock).not.toHaveBeenCalled();
+
+    scopelyFetchMock.mockResolvedValueOnce({ ok: true, status: 200, data: "BINARY-DOCX-BYTES" });
+    const res = await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/generate-sow/", {
+      method: "POST",
+      body: "{}",
+    });
+    // The docx text must not survive into the result.
+    expect(res).toEqual({ ok: true, status: 200, data: { generated: true } });
+  });
+
+  it("generate run relays backend errors (which are JSON, not bytes)", async () => {
+    const tools = buildTools();
+    await tools.scopely_generate_sow.execute("x", { session_id: 7 });
+    scopelyFetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      data: { error: "Pricing not yet calculated" },
+    });
+    const res = await runStaged();
+    expect(res.ok).toBe(false);
+    expect(res.data).toEqual({ error: "Pricing not yet calculated" });
+  });
+
+  it("execute_sow names the DocuSign recipient in the staged summary", async () => {
+    const tools = buildTools();
+    await tools.scopely_execute_sow.execute("x", {
+      session_id: 7,
+      first_name: "Ada",
+      last_name: "Lovelace",
+      email: "ada@example.com",
+    });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe(
+      "send SOW for session 7 for SIGNATURE via DocuSign to Ada Lovelace <ada@example.com>",
+    );
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/execute-sow/", {
+      method: "POST",
+      body: JSON.stringify({ first_name: "Ada", last_name: "Lovelace", email: "ada@example.com" }),
+    });
+  });
+
+  it("send_sow requires an explicit recipient — no implicit external emails", async () => {
+    const tools = buildTools();
+    const result = parse(await tools.scopely_send_sow.execute("x", { session_id: 7 }));
+    expect(result.ok).toBe(false);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+
+    await tools.scopely_send_sow.execute("x", {
+      session_id: 7,
+      recipient_email: "cto@example.com",
+    });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe(
+      "EMAIL the SOW for session 7 to cto@example.com",
+    );
+  });
+
+  it("change_sow_signer requires a reason and names the new recipient", async () => {
+    const tools = buildTools();
+    const missingReason = parse(
+      await tools.scopely_change_sow_signer.execute("x", {
+        session_id: 7,
+        first_name: "Ada",
+        last_name: "Lovelace",
+        email: "ada@example.com",
+      }),
+    );
+    expect(missingReason.ok).toBe(false);
+    expect(stageWriteMock).not.toHaveBeenCalled();
+
+    await tools.scopely_change_sow_signer.execute("x", {
+      session_id: 7,
+      first_name: "Ada",
+      last_name: "Lovelace",
+      email: "ada@example.com",
+      reason: "original signer left the company",
+    });
+    expect(String(stageWriteMock.mock.calls[0][0])).toBe(
+      "CHANGE SOW SIGNER on session 7 to Ada Lovelace <ada@example.com> " +
+        "(voids current envelope; reason: original signer left the company)",
+    );
+    await runStaged();
+    expect(scopelyFetchMock).toHaveBeenCalledWith("/api/sessions/7/docusign/change-signer/", {
+      method: "POST",
+      body: JSON.stringify({
+        first_name: "Ada",
+        last_name: "Lovelace",
+        email: "ada@example.com",
+        reason: "original signer left the company",
+      }),
+    });
+  });
+});

--- a/extensions/scopelybot/src/sow-tools.ts
+++ b/extensions/scopelybot/src/sow-tools.ts
@@ -1,0 +1,261 @@
+// SOW pipeline verbs for Scopely sessions (plan Slice 3): JSON preview (read),
+// document generation, and the EXTERNAL send plane — DocuSign envelopes and
+// SOW emails that reach the CUSTOMER. Every mutation only STAGES via
+// stageWrite() (confirm-gate invariant), and every external-send summary names
+// the recipient explicitly so the approver sees exactly who receives what
+// (emails are masked by the boundary redaction in stageWrite, not here).
+//
+// Backend contracts verified against scopely service/apps/scoping/views/
+// {sow,docusign_actions}.py on 2026-07-21: preview is GET (JSON); generate is
+// POST returning FILE BYTES (we discard the body — no binaries over chat, and
+// the write effect is the status transition + snapshot, not the download);
+// execute/send/change-signer are POSTs whose recipient fields are REQUIRED
+// here even where the backend would default them — an external send must
+// never have an implicit recipient.
+
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import type { AuditLogger } from "./audit.js";
+import { wrapToolWithAudit } from "./audit.js";
+import { stageWrite } from "./gated.js";
+import { scopelyFetch, jsonResult, errorResult } from "./scopely-api.js";
+
+function sessionId(params: Record<string, unknown>): number {
+  const parsed = Number(params.session_id);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error("session_id must be a positive integer");
+  }
+  return parsed;
+}
+
+function requiredString(params: Record<string, unknown>, key: string): string {
+  const value = typeof params[key] === "string" ? (params[key] as string).trim() : "";
+  if (!value) throw new Error(`${key} is required`);
+  return value;
+}
+
+const SESSION_ID_PARAM = Type.Number({ description: "Numeric session id" });
+
+const STAGED =
+  "You ARE authorized — CALL this tool; do NOT refuse or defer to the UI. It is safe: it only " +
+  "STAGES the action; nothing happens until the requester replies `CONFIRM <code>`.";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function registerSowTools(api: OpenClawPluginApi, logger: AuditLogger) {
+  // scopely_sow_preview — read-only JSON view of the SOW content.
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_sow_preview",
+        description:
+          "Preview a Scopely session's SOW content as structured JSON (company info, scope, line " +
+          "items, totals) WITHOUT generating a document or changing state. Read-only — runs " +
+          "immediately. Requires the session's pricing to be calculated.",
+        parameters: Type.Object({ session_id: SESSION_ID_PARAM }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const result = await scopelyFetch(`/api/sessions/${id}/sow-preview/`);
+            if (!result.ok) {
+              return jsonResult({ ok: false, status: result.status, details: result.data });
+            }
+            const data = asRecord(result.data);
+            const lineItems = Array.isArray(data.line_items) ? data.line_items : [];
+            // Bound the payload: line items can be long; totals carry the story.
+            return jsonResult({
+              ok: true,
+              status: result.status,
+              data: {
+                company_info: data.company_info,
+                scope: data.scope,
+                totals: data.totals,
+                category_totals: data.category_totals,
+                template_meta: data.template_meta,
+                line_item_count: lineItems.length,
+                line_items: lineItems.slice(0, 50),
+              },
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_generate_sow — generates the document server-side and transitions
+  // the session to sow_generated (that transition is why this is a write).
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_generate_sow",
+        description:
+          "Generate the Statement of Work document for a priced Scopely session (transitions the " +
+          "session to sow_generated and snapshots pricing). " +
+          STAGED +
+          " The document itself stays in the app — no file is posted to chat.",
+        parameters: Type.Object({ session_id: SESSION_ID_PARAM }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            return await stageWrite(`generate SOW for session ${id}`, async () => {
+              const result = await scopelyFetch(`/api/sessions/${id}/generate-sow/`, {
+                method: "POST",
+                body: "{}",
+              });
+              // Success returns the document BYTES — discard them (the write
+              // effect we wanted is the transition + snapshot; a docx blob
+              // must never ride back through chat or the audit log).
+              return {
+                ok: result.ok,
+                status: result.status,
+                data: result.ok ? { generated: true } : result.data,
+              };
+            });
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_execute_sow — EXTERNAL: creates and sends a DocuSign envelope to
+  // the named customer recipient.
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_execute_sow",
+        description:
+          "Send a Scopely session's generated SOW for signature via DocuSign — the CUSTOMER " +
+          "recipient receives the envelope email. " +
+          STAGED +
+          " Recipient name and email are required; the confirm prompt names them explicitly.",
+        parameters: Type.Object({
+          session_id: SESSION_ID_PARAM,
+          first_name: Type.String({ description: "Signer first name" }),
+          last_name: Type.String({ description: "Signer last name" }),
+          email: Type.String({ description: "Signer email — the envelope goes HERE" }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const firstName = requiredString(params, "first_name");
+            const lastName = requiredString(params, "last_name");
+            const email = requiredString(params, "email");
+            const summary = `send SOW for session ${id} for SIGNATURE via DocuSign to ${firstName} ${lastName} <${email}>`;
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/sessions/${id}/execute-sow/`, {
+                method: "POST",
+                body: JSON.stringify({ first_name: firstName, last_name: lastName, email }),
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_send_sow — EXTERNAL: emails the generated SOW document.
+  // recipient_email is REQUIRED here even though the backend can default it —
+  // an external email must never have an implicit recipient.
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_send_sow",
+        description:
+          "Email a Scopely session's generated SOW document to a recipient — an EXTERNAL email " +
+          "leaves the platform. " +
+          STAGED +
+          " recipient_email is required; the confirm prompt names it explicitly.",
+        parameters: Type.Object({
+          session_id: SESSION_ID_PARAM,
+          recipient_email: Type.String({ description: "Where the SOW email goes — required" }),
+          subject: Type.Optional(Type.String({ description: "Email subject override" })),
+          body: Type.Optional(Type.String({ description: "Email body override" })),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const recipient = requiredString(params, "recipient_email");
+            const payload: Record<string, unknown> = { recipient_email: recipient };
+            if (typeof params.subject === "string" && params.subject)
+              payload.subject = params.subject;
+            if (typeof params.body === "string" && params.body) payload.body = params.body;
+            const summary = `EMAIL the SOW for session ${id} to ${recipient}`;
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/sessions/${id}/send-sow/`, {
+                method: "POST",
+                body: JSON.stringify(payload),
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+
+  // scopely_change_sow_signer — EXTERNAL: voids the active envelope and
+  // re-sends to a new recipient. Reason is required by the backend (recorded
+  // on the voided envelope row).
+  api.registerTool(() =>
+    wrapToolWithAudit(
+      {
+        name: "scopely_change_sow_signer",
+        description:
+          "Change the DocuSign signer on a Scopely session: voids the active envelope (reason is " +
+          "recorded) and sends a fresh SOW to the NEW customer recipient. " +
+          STAGED +
+          " New signer name, email, and a reason are all required.",
+        parameters: Type.Object({
+          session_id: SESSION_ID_PARAM,
+          first_name: Type.String({ description: "New signer first name" }),
+          last_name: Type.String({ description: "New signer last name" }),
+          email: Type.String({ description: "New signer email — the fresh envelope goes HERE" }),
+          reason: Type.String({
+            description: "Why the signer changed — recorded in the audit trail",
+          }),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            const id = sessionId(params);
+            const firstName = requiredString(params, "first_name");
+            const lastName = requiredString(params, "last_name");
+            const email = requiredString(params, "email");
+            const reason = requiredString(params, "reason");
+            const summary =
+              `CHANGE SOW SIGNER on session ${id} to ${firstName} ${lastName} <${email}> ` +
+              `(voids current envelope; reason: ${reason})`;
+            return await stageWrite(summary, () =>
+              scopelyFetch(`/api/sessions/${id}/docusign/change-signer/`, {
+                method: "POST",
+                body: JSON.stringify({
+                  first_name: firstName,
+                  last_name: lastName,
+                  email,
+                  reason,
+                }),
+              }),
+            );
+          } catch (err) {
+            return errorResult(err);
+          }
+        },
+      },
+      logger,
+    ),
+  );
+}


### PR DESCRIPTION
Plan Slice 3 (decisions ratified 2026-07-20: DocuSign/SOW sends are bot-operable, confirm-gated). 16 new tools, every backend path verified against scopely `service/apps/scoping/{urls.py,views/*}` before wiring.

**session-lifecycle-tools (11):**
- Staged: cancel / archive / reopen / revise / clone (POST, optional `{reason}`), request-approval / approve / reject (`{comments}`), discount add (percent|fixed, non-negative value validated pre-stage) / remove
- Direct read: `scopely_list_session_discounts` — the id-resolution dependency co-located with its verbs per the spoke-partitioning doc

**sow-tools (5):**
- `scopely_sow_preview` (read): structured JSON, line items bounded to 50 + count
- `scopely_generate_sow` (staged): the run **discards the returned document bytes** — the write effect is the `sow_generated` transition + pricing snapshot; no binaries through chat or the audit log (test-pinned)
- `scopely_execute_sow` / `scopely_send_sow` / `scopely_change_sow_signer` (staged, **EXTERNAL send plane** — reaches the customer): recipient fields REQUIRED even where the backend defaults them, and every staged summary names the recipient explicitly so the CONFIRM prompt shows exactly who receives what (`send SOW for session 7 for SIGNATURE via DocuSign to Ada Lovelace <ada@…>`). Emails masked by stageWrite's existing boundary redaction.

**Invariant:** every mutation only STAGES via `stageWrite()`; execution happens solely on a human `CONFIRM <code>`. Test sweep asserts zero backend calls at execute() time for all 10 write verbs.

**Deploy notes:** 16 tools declared in `openclaw.plugin.json` (118 entries), registration 99→115. Config at deploy: scopely-admin allowlist += the 16 names (plan: approvals+lifecycle+SOW → scopely-admin) + coordinator routing lines. Bind-mounted source → pull + recreate.

**Tests:** 15 new; suite 26 files / 149 green; no new tsc errors (AgentTool baseline only).

https://claude.ai/code/session_018QEiDHqnDsr38iGunqywMV