### PR TITLE
feat(scopelybot): voice-judge lane v2.1 — bounded tone/persona LLM check + revise-reason substrate fix

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -109,15 +109,25 @@ const plugin = {
     api.on("message_sending", (event, ctx) => rewriteScopelyBotZoomMessage(event.content, ctx));
 
     // Runtime supervisor (Slice S): review the coordinator's draft final reply
-    // before it is accepted — deterministic rules/voice/grounding checks with a
-    // harness-budgeted single revision pass and a fuse that escalates to a named
-    // human instead of retrying forever. Opt-in via SCOPELYBOT_SUPERVISOR=1
-    // (checked inside superviseFinalize, at call time); scoped inside to
-    // agent:scopelybot: sessions so other bots' turns are untouched. NOTE: this
-    // is a conversation-typed hook — non-bundled deployments must also set
+    // before it is accepted — deterministic rules/grounding checks plus the
+    // opt-in voice-judge lane, with bounded revision passes and a fuse that
+    // escalates to a named human instead of retrying forever. Opt-in via
+    // SCOPELYBOT_SUPERVISOR=1 (checked inside superviseFinalize, at call
+    // time); scoped inside to agent:scopelybot: sessions so other bots' turns
+    // are untouched. llmComplete powers only the voice lane
+    // (SCOPELYBOT_SUPERVISOR_VOICE=1): api.runtime.llm.complete is
+    // plugin-scoped by the host, and the judge's model override additionally
+    // requires plugins.entries.scopelybot.llm.allowModelOverride in the host
+    // config — absent that, the lane fails open. NOTE: this is a
+    // conversation-typed hook — non-bundled deployments must also set
     // plugins.entries.scopelybot.hooks.allowConversationAccess=true or the
     // registry drops it with a warn diagnostic (src/plugins/registry.ts).
-    api.on("before_agent_finalize", (event) => superviseFinalize(event, { logger }));
+    api.on("before_agent_finalize", (event) =>
+      superviseFinalize(event, {
+        logger,
+        llmComplete: async (params) => api.runtime.llm.complete(params),
+      }),
+    );
 
     // Comfort message + thread-anchor capture on inbound. CONFIRM execution is
     // NOT handled here: message_received is a fire-and-forget OBSERVE hook (it

--- a/extensions/scopelybot/src/supervisor.test.ts
+++ b/extensions/scopelybot/src/supervisor.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.SCOPELYBOT_SUPERVISOR;
   delete process.env.SCOPELYBOT_SUPERVISOR_V2;
+  delete process.env.SCOPELYBOT_SUPERVISOR_VOICE;
   delete process.env.SCOPELYBOT_ZOOM_CHANNEL;
   delete process.env.SCOPELYBOT_SUPERVISOR_FUSE_N;
   delete process.env.SCOPELYBOT_ESCALATION_OWNER;
@@ -297,12 +298,17 @@ describe("ungrounded_claim (v2)", () => {
 });
 
 describe("revise shape", () => {
-  it("returns a harness-budgeted single retry keyed per turn+check", async () => {
+  it("carries the actionable instruction in `reason` — the only field the harness feeds back", async () => {
     const res = await superviseFinalize(event("Reply CONFIRM 4821 to proceed."), {
       logger: auditMock,
     });
     expect(res).toMatchObject({
       action: "revise",
+      // SUBSTRATE PIN: run.ts builds the retry prompt from `reason` alone
+      // (buildBeforeAgentFinalizeRetryPrompt); retry.{instruction,
+      // idempotencyKey,maxAttempts} are typed but unconsumed by the harness.
+      // The crafted instruction must therefore BE the reason.
+      reason: expect.stringContaining("Never include, repeat, or invent CONFIRM codes"),
       retry: {
         idempotencyKey: "scopelybot-supervisor:turn-1:confirm_code_leak",
         maxAttempts: 1,
@@ -314,6 +320,106 @@ describe("revise shape", () => {
         resultSummary: "revise: confirm_code_leak",
       }),
     );
+  });
+});
+
+describe("voice lane (v2.1)", () => {
+  // Long enough to clear voice-judge skip predicates; grounded against
+  // GROUNDED_TURN's corpus ("42") so the deterministic plane stays clean.
+  const CLEAN_DRAFT =
+    "There are 42 active sessions right now. Everything else in the pipeline looks healthy " +
+    "and no approvals are waiting on you.";
+
+  beforeEach(() => {
+    process.env.SCOPELYBOT_SUPERVISOR_VOICE = "1";
+  });
+
+  it("is inert without llmComplete wired (flag alone cannot activate it)", async () => {
+    const res = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock });
+    expect(res).toBeUndefined();
+  });
+
+  it("judges only drafts the deterministic plane already passed", async () => {
+    const llmComplete = vi.fn().mockResolvedValue({ text: "PASS" });
+    const res = await superviseFinalize(event("Reply CONFIRM 4821 to proceed."), {
+      logger: auditMock,
+      llmComplete,
+    });
+    expect(res).toMatchObject({ action: "revise" }); // deterministic finding wins
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it("never judges spoke drafts — coordinator (human-facing) only", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_V2 = "1";
+    const llmComplete = vi.fn().mockResolvedValue({ text: "PASS" });
+    const res = await superviseFinalize(
+      event(CLEAN_DRAFT, { sessionKey: SPOKE_SESSION }),
+      { logger: auditMock, llmComplete },
+    );
+    expect(res).toBeUndefined();
+    expect(llmComplete).not.toHaveBeenCalled();
+  });
+
+  it("voice REVISE → framed instruction rides `reason`, charges the shared fuse, audits", async () => {
+    const llmComplete = vi
+      .fn()
+      .mockResolvedValue({ text: "REVISE: Lead with the answer and drop the filler." });
+    const res = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    expect(res).toMatchObject({ action: "revise" });
+    const reason = (res as { reason: string }).reason;
+    expect(reason).toContain("keeping every fact, number, name, and value exactly the same");
+    expect(reason).toContain("Lead with the answer");
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "scopely_supervisor", resultSummary: "revise: voice" }),
+    );
+  });
+
+  it("caps voice at ONE revision per run — the harness budget is global, the judge is non-deterministic", async () => {
+    const llmComplete = vi.fn().mockResolvedValue({ text: "REVISE: Tighten the phrasing." });
+    const first = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    expect(first).toMatchObject({ action: "revise" });
+    // Second finalize pass in the SAME run (the revised draft): judge not consulted.
+    const second = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    expect(second).toBeUndefined();
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+    // A different run judges again.
+    const third = await superviseFinalize(event(CLEAN_DRAFT, { runId: "run-2" }), {
+      logger: auditMock,
+      llmComplete,
+    });
+    expect(third).toMatchObject({ action: "revise" });
+  });
+
+  it("voice revisions count toward the SAME fuse as deterministic checks", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "2";
+    let t = 2_000_000;
+    const deps = {
+      logger: auditMock,
+      now: () => t,
+      llmComplete: vi.fn().mockResolvedValue({ text: "REVISE: Tighten the phrasing." }),
+    };
+    // Revision 1: voice (run-1).
+    expect(await superviseFinalize(event(CLEAN_DRAFT), deps)).toMatchObject({ action: "revise" });
+    // Revision 2: deterministic (run-2) — trips the shared fuse.
+    t += 1000;
+    expect(
+      await superviseFinalize(event("Reply CONFIRM 4821 to proceed.", { runId: "run-2" }), deps),
+    ).toEqual({ action: "continue" });
+    expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("judge fail-open (error/malformed) leaves the draft untouched", async () => {
+    const llmComplete = vi.fn().mockRejectedValue(new Error("boom"));
+    const res = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    expect(res).toBeUndefined();
+  });
+
+  it("stays fully inert when SCOPELYBOT_SUPERVISOR_VOICE is unset (rollout gate)", async () => {
+    delete process.env.SCOPELYBOT_SUPERVISOR_VOICE;
+    const llmComplete = vi.fn().mockResolvedValue({ text: "REVISE: anything" });
+    const res = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    expect(res).toBeUndefined();
+    expect(llmComplete).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/scopelybot/src/supervisor.ts
+++ b/extensions/scopelybot/src/supervisor.ts
@@ -3,10 +3,12 @@
 // v2 research in docs/reference/supervisor-v2-research.md).
 //
 // Wired into `before_agent_finalize`: reviews a DRAFT final reply before it is
-// accepted, and either lets it through (`continue`) or requests ONE bounded
-// revision pass (`revise` + retry.maxAttempts=1 — the harness enforces the
-// budget per run+idempotencyKey, so a broken check can never create an
-// unbounded loop). All checks are DETERMINISTIC string/shape predicates — no
+// accepted, and either lets it through (`continue`) or requests a bounded
+// revision pass. Bounds: the harness's global MAX_BEFORE_AGENT_FINALIZE_
+// REVISIONS=3 per run (run.ts:217) plus this module's fuse — the harness does
+// NOT enforce per-check retry budgets (retry.{idempotencyKey,maxAttempts} are
+// typed but unconsumed; only `reason` reaches the model, see the revise-return
+// comment below). All checks are DETERMINISTIC string/shape predicates — no
 // model in the supervisor's own loop (per the v2 research: deterministic
 // claim-vs-evidence is the highest-confidence egress pattern; LLM self-checks
 // are a documented failure mode).
@@ -53,6 +55,7 @@
 
 import type { AuditLogger } from "./audit.js";
 import { sendScopelyText } from "./comfort.js";
+import { judgeVoice, voiceJudgeEnabled, type VoiceLlmComplete } from "./voice-judge.js";
 
 // Shape of the before_agent_finalize event fields this module consumes.
 // Kept structural (not imported from core types) so the extension compiles
@@ -462,9 +465,29 @@ function isFused(fuseKey: string, now: number): boolean {
   return fuseFor(fuseKey).fusedUntil > now;
 }
 
+// ---------------------------------------------------------------------------
+// Voice-judge per-run once guard. The harness does not enforce per-check
+// retry budgets (see the revise-return comment), and an LLM judge is
+// non-deterministic across passes — without this cap a picky judge could
+// burn all 3 harness revisions on voice alone. Bounded FIFO so the set
+// cannot grow without limit across a long-lived process.
+// ---------------------------------------------------------------------------
+
+const VOICE_JUDGED_RUNS_MAX = 200;
+const voiceRevisedRuns = new Set<string>();
+
+function markVoiceRevised(runKey: string): void {
+  voiceRevisedRuns.add(runKey);
+  if (voiceRevisedRuns.size > VOICE_JUDGED_RUNS_MAX) {
+    const oldest = voiceRevisedRuns.values().next().value;
+    if (oldest !== undefined) voiceRevisedRuns.delete(oldest);
+  }
+}
+
 // Test hook: clear all fuse state between test cases.
 export function resetSupervisorStateForTest(): void {
   fuseBySession.clear();
+  voiceRevisedRuns.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -476,7 +499,7 @@ export function resetSupervisorStateForTest(): void {
 // (+ deterministic escalation post) when the fuse trips.
 export async function superviseFinalize(
   event: FinalizeEvent,
-  deps: { logger: AuditLogger; now?: () => number },
+  deps: { logger: AuditLogger; now?: () => number; llmComplete?: VoiceLlmComplete },
 ): Promise<FinalizeResult | undefined> {
   if (!supervisorEnabled()) return undefined;
   const sessionKey = event.sessionKey ?? "";
@@ -488,7 +511,33 @@ export async function superviseFinalize(
   const now = deps.now ? deps.now() : Date.now();
   if (isFused(scope.fuseKey, now)) return { action: "continue" };
 
-  const verdict = reviewDraft(draft, collectTurnEvidence(event.messages), scope.profile);
+  let verdict = reviewDraft(draft, collectTurnEvidence(event.messages), scope.profile);
+
+  // Voice lane (v2.1, SCOPELYBOT_SUPERVISOR_VOICE=1): only when the
+  // deterministic plane is satisfied, only for human-facing coordinator
+  // drafts, and at most once per run (the harness's revision budget is
+  // global, not per-check — a non-deterministic judge must self-cap).
+  // judgeVoice never throws: error/timeout/malformed output all fail open.
+  const runKey = event.runId ?? event.turnId ?? "";
+  if (
+    verdict.ok &&
+    voiceJudgeEnabled() &&
+    scope.profile === "coordinator" &&
+    deps.llmComplete &&
+    runKey &&
+    !voiceRevisedRuns.has(runKey)
+  ) {
+    const voice = await judgeVoice(draft, { complete: deps.llmComplete, logger: deps.logger, now: deps.now });
+    if (!voice.ok) {
+      markVoiceRevised(runKey);
+      verdict = {
+        ok: false,
+        checkId: "voice",
+        reason: "voice judge requested a tone/readability revision",
+        instruction: voice.instruction,
+      };
+    }
+  }
   if (verdict.ok) return undefined;
 
   const tripped = recordRevisionAndCheckFuse(scope.fuseKey, now);
@@ -520,11 +569,18 @@ export async function superviseFinalize(
 
   return {
     action: "revise",
-    reason: verdict.reason,
+    // SUBSTRATE FACT (verified 2026-07-21): the harness feeds ONLY `reason`
+    // back to the model — run.ts builds the retry prompt as
+    // BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX + "\n\n" + outcome.reason
+    // (src/agents/embedded-agent-runner/run.ts:276, attempt.ts:3193). The
+    // `retry.{instruction,idempotencyKey,maxAttempts}` fields exist in the
+    // typed contract (hook-types.ts:377) but nothing consumes them today, so
+    // the actionable instruction MUST ride in `reason` or it is silently
+    // dropped. The real revision bounds are the harness's global cap
+    // (MAX_BEFORE_AGENT_FINALIZE_REVISIONS=3 per run) plus this module's fuse.
+    reason: verdict.instruction,
     retry: {
       instruction: verdict.instruction,
-      // Keyed per turn+check so the harness budget allows exactly ONE retry
-      // for this check in this turn, and a different check may still fire.
       idempotencyKey: `scopelybot-supervisor:${event.turnId ?? event.runId ?? "turn"}:${verdict.checkId}`,
       maxAttempts: 1,
     },

--- a/extensions/scopelybot/src/voice-judge.test.ts
+++ b/extensions/scopelybot/src/voice-judge.test.ts
@@ -1,0 +1,156 @@
+// Voice-judge tests (voice-judge.ts — Slice S2 v2.1). Cover: the skip
+// predicates (short drafts, clarifying questions, system prompts), the
+// PASS/REVISE output contract, the deterministic post-guard (fact firewall:
+// hard tokens, digits, length, multiline; malformed shapes fail open), the
+// fact-preserving instruction frame, redaction of the outbound draft, the
+// hard timeout (fail-open, never throws), and completion-error fail-open.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { guardJudgeOutput, judgeVoice, voiceJudgeEnabled } from "./voice-judge.js";
+
+const auditMock = vi.fn();
+
+// A draft long enough to clear the skip predicates.
+const DRAFT =
+  "There are 713 sessions total and 391 in progress. The pricing spoke confirmed " +
+  "the Ring Central cards are intact. Contact jrickert@unified-team.com for access.";
+
+function completeReturning(text: string) {
+  return vi.fn().mockResolvedValue({ text });
+}
+
+beforeEach(() => {
+  auditMock.mockClear();
+  process.env.SCOPELYBOT_SUPERVISOR_VOICE = "1";
+});
+afterEach(() => {
+  delete process.env.SCOPELYBOT_SUPERVISOR_VOICE;
+  delete process.env.SCOPELYBOT_SUPERVISOR_VOICE_MODEL;
+  delete process.env.SCOPELYBOT_SUPERVISOR_VOICE_TIMEOUT_MS;
+});
+
+describe("gating + skip predicates", () => {
+  it("flag reads at call time", () => {
+    expect(voiceJudgeEnabled()).toBe(true);
+    delete process.env.SCOPELYBOT_SUPERVISOR_VOICE;
+    expect(voiceJudgeEnabled()).toBe(false);
+  });
+
+  it("skips short drafts, clarifying questions, and system-styled prompts without calling the LLM", async () => {
+    const complete = completeReturning("PASS");
+    for (const draft of [
+      "On it.",
+      "Do you mean session 314 or the archived one?",
+      "⚠️ Confirm archive of session 42 — reply CONFIRM 0000",
+    ]) {
+      expect(await judgeVoice(draft, { complete, logger: auditMock })).toEqual({ ok: true });
+    }
+    expect(complete).not.toHaveBeenCalled();
+  });
+});
+
+describe("output contract + post-guard", () => {
+  it("PASS → ok, no audit noise", async () => {
+    const complete = completeReturning("PASS");
+    expect(await judgeVoice(DRAFT, { complete, logger: auditMock })).toEqual({ ok: true });
+    expect(auditMock).not.toHaveBeenCalled();
+  });
+
+  it("REVISE with clean feedback → framed fact-preserving instruction", async () => {
+    const complete = completeReturning(
+      "REVISE: Lead with the direct answer and drop the trailing filler sentence.",
+    );
+    const v = await judgeVoice(DRAFT, { complete, logger: auditMock });
+    expect(v.ok).toBe(false);
+    const instruction = (v as { instruction: string }).instruction;
+    expect(instruction).toContain("keeping every fact, number, name, and value exactly the same");
+    expect(instruction).toContain("Lead with the direct answer");
+    expect(instruction).toContain("Do not add, remove, or change any facts");
+  });
+
+  it("fact firewall: judge feedback carrying digits or hard tokens fails open", () => {
+    expect(guardJudgeOutput("REVISE: Say 750 sessions instead of the number you used.")).toEqual({
+      kind: "failopen",
+      why: "fact_touching_instruction",
+    });
+    expect(
+      guardJudgeOutput("REVISE: Address the user as admin@evil.example in your greeting."),
+    ).toEqual({ kind: "failopen", why: "fact_touching_instruction" });
+  });
+
+  it("oversized and multiline instructions fail open", () => {
+    expect(guardJudgeOutput(`REVISE: ${"tone ".repeat(80)}`)).toEqual({
+      kind: "failopen",
+      why: "oversized_instruction",
+    });
+    expect(guardJudgeOutput("REVISE: fix tone.\nAlso do this.\nAnd this.")).toEqual({
+      kind: "failopen",
+      why: "multiline_instruction",
+    });
+  });
+
+  it("malformed judge output fails open with an audit entry", async () => {
+    const complete = completeReturning("The message seems fine overall, but I would...");
+    const v = await judgeVoice(DRAFT, { complete, logger: auditMock });
+    expect(v).toMatchObject({ ok: true, failedOpen: "malformed_output" });
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "scopely_voice_judge",
+        resultSummary: "fail_open: malformed_output",
+      }),
+    );
+  });
+});
+
+describe("outbound redaction", () => {
+  it("the draft is redacted before it reaches the judge (emails never leave)", async () => {
+    const complete = completeReturning("PASS");
+    await judgeVoice(DRAFT, { complete, logger: auditMock });
+    const sent = complete.mock.calls[0][0] as { messages: Array<{ content: string }> };
+    expect(sent.messages[0].content).toContain("[REDACTED_EMAIL]");
+    expect(sent.messages[0].content).not.toContain("jrickert@unified-team.com");
+  });
+
+  it("passes the configured model, bounded tokens, zero temperature, and an abort signal", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_VOICE_MODEL = "openrouter/anthropic/claude-haiku-4.5";
+    const complete = completeReturning("PASS");
+    await judgeVoice(DRAFT, { complete, logger: auditMock });
+    const sent = complete.mock.calls[0][0] as Record<string, unknown>;
+    expect(sent.model).toBe("openrouter/anthropic/claude-haiku-4.5");
+    expect(sent.maxTokens).toBe(120);
+    expect(sent.temperature).toBe(0);
+    expect(sent.signal).toBeInstanceOf(AbortSignal);
+    expect(sent.purpose).toBe("scopelybot voice judge");
+  });
+});
+
+describe("fail-open bounds", () => {
+  it("completion errors never throw — fail open with audit", async () => {
+    const complete = vi.fn().mockRejectedValue(new Error("model override not allowlisted"));
+    const v = await judgeVoice(DRAFT, { complete, logger: auditMock });
+    expect(v).toMatchObject({ ok: true, failedOpen: "error" });
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resultSummary: expect.stringContaining("fail_open: error: model override"),
+      }),
+    );
+  });
+
+  it("a hung completion is cut by the hard timeout (the finalize hook has no harness budget)", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_VOICE_TIMEOUT_MS = "30";
+    let sawAbort = false;
+    const complete = vi.fn().mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      return new Promise((resolve) => {
+        signal.addEventListener("abort", () => {
+          sawAbort = true;
+        });
+        setTimeout(() => resolve({ text: "PASS" }), 5_000);
+      });
+    });
+    const started = Date.now();
+    const v = await judgeVoice(DRAFT, { complete, logger: auditMock });
+    expect(Date.now() - started).toBeLessThan(2_000);
+    expect(v).toMatchObject({ ok: true, failedOpen: "error" });
+    expect(sawAbort).toBe(true);
+  });
+});

--- a/extensions/scopelybot/src/voice-judge.ts
+++ b/extensions/scopelybot/src/voice-judge.ts
@@ -1,0 +1,192 @@
+// Voice-judge lane for the scopelybot supervisor (Slice S2 v2.1 — the
+// "human-readable" pillar). A bounded LLM check scoped to tone / persona /
+// readability ONLY — never facts. Runs AFTER the deterministic checks pass on
+// a coordinator draft, so a draft never gets a voice opinion until it is
+// already correct + secure by the deterministic plane.
+//
+// Why an LLM here at all: readability has no deterministic predicate. The v2
+// research (docs/reference/supervisor-v2-research.md Q3) excludes LLM judges
+// as a CORRECTNESS backbone (position/verbosity/self-enhancement bias) but
+// allows a narrowly-scoped tone/persona lane — provided the judge is a
+// DIFFERENT model/vendor than the author (self-preference bias) and its
+// output is deterministically post-guarded so it can never touch facts.
+//
+// Containment stack (every layer independent):
+//   1. Flag-gated (SCOPELYBOT_SUPERVISOR_VOICE=1), coordinator profile only.
+//   2. Draft is REDACTED (redactText) before leaving for the judge — emails,
+//      phones, and secret-shaped values never reach the third-party model.
+//   3. Hard time bound: AbortController + Promise.race (before_agent_finalize
+//      has NO harness timeout — src/plugins/hooks.ts budget table — so a hung
+//      completion would otherwise block the turn). Race wins even if the
+//      completion path ignores the signal.
+//   4. Deterministic post-guard on the judge's output: must be exactly PASS
+//      or REVISE:<one short sentence>; the sentence is rejected if it carries
+//      ANY hard token (numbers / emails / ids — fact-touching), is too long,
+//      or spans multiple lines. Anything else fails open.
+//   5. The accepted instruction is wrapped in a fixed fact-preserving frame
+//      before it reaches the author model.
+//   6. Same fuse as the deterministic checks (caller wires it), plus a
+//      per-run once guard here — the harness does not enforce per-check
+//      retry budgets, and an LLM judge is non-deterministic across passes.
+//   7. Fail-open everywhere: judge error/timeout/malformed = no opinion.
+
+import type { AuditLogger } from "./audit.js";
+import { redactText } from "./redaction.js";
+import { extractHardTokens } from "./supervisor.js";
+
+// Structural copy of the api.runtime.llm.complete surface this module uses
+// (src/plugins/runtime/types-core.ts:111) — not imported from core, per this
+// extension's no-core-imports convention.
+export type VoiceLlmComplete = (params: {
+  messages: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+  model?: string;
+  maxTokens?: number;
+  temperature?: number;
+  systemPrompt?: string;
+  signal?: AbortSignal;
+  purpose?: string;
+}) => Promise<{ text: string }>;
+
+// Opt-in via env, same rollout pattern as the other supervisor flags.
+export function voiceJudgeEnabled(): boolean {
+  return process.env.SCOPELYBOT_SUPERVISOR_VOICE === "1";
+}
+
+// Judge model ref. Default is the prod-configured Anthropic fallback — a
+// different vendor family than the coordinator (gpt-5.6-luna), per the
+// self-preference-bias mitigation. The `model:` override additionally
+// requires `plugins.entries.scopelybot.llm.allowModelOverride` in the host
+// config; without it the completion throws and this lane fails open.
+function voiceJudgeModel(): string {
+  return process.env.SCOPELYBOT_SUPERVISOR_VOICE_MODEL ?? "openrouter/anthropic/claude-haiku-4.5";
+}
+
+function voiceJudgeTimeoutMs(): number {
+  const raw = Number(process.env.SCOPELYBOT_SUPERVISOR_VOICE_TIMEOUT_MS ?? "4000");
+  return Number.isFinite(raw) && raw > 0 ? raw : 4000;
+}
+
+// The judge's entire remit. Output contract is machine-checkable on purpose:
+// the post-guard rejects anything that isn't PASS or a single short
+// REVISE sentence free of hard tokens.
+const VOICE_SYSTEM_PROMPT =
+  "You review one outgoing Zoom chat message from an operations assistant. " +
+  "Judge ONLY tone, persona, and readability — never facts, numbers, names, or values.\n\n" +
+  "The voice standard: plain conversational language, lead with the answer, no markdown " +
+  "syntax, no bullet lists, no raw JSON, no hedging filler, concise, professional and direct. " +
+  "Redaction placeholders like [REDACTED_EMAIL] are expected — ignore them.\n\n" +
+  "Reply with exactly one line:\n" +
+  "PASS\n" +
+  "or\n" +
+  "REVISE: <one short sentence of voice or formatting feedback that mentions no specific " +
+  "numbers, names, or values>";
+
+const PASS_RE = /^\s*PASS\b/;
+const REVISE_RE = /^\s*REVISE:\s*(.+)$/s;
+const MAX_INSTRUCTION_CHARS = 300;
+
+// Fixed fact-preserving frame around the judge's feedback — even a subtly
+// off instruction cannot authorize a fact change in the revision pass.
+function frameInstruction(feedback: string): string {
+  return (
+    "Rewrite your reply keeping every fact, number, name, and value exactly the same. " +
+    `Voice feedback: ${feedback} ` +
+    "Do not add, remove, or change any facts."
+  );
+}
+
+export type VoiceVerdict =
+  | { ok: true }
+  | { ok: false; instruction: string }
+  // Judge unavailable/errored/malformed — caller treats as ok (fail-open) but
+  // the distinct shape lets tests pin the audit behavior.
+  | { ok: true; failedOpen: string };
+
+// Skip drafts with nothing to judge: trivially short texts, short clarifying
+// questions (same predicate as the supervisor's state-claim carve-out), and
+// system-styled ⚠️ prompts.
+function shouldSkip(draft: string): boolean {
+  const trimmed = draft.trim();
+  if (trimmed.length < 40) return true;
+  if (trimmed.length < 120 && trimmed.endsWith("?")) return true;
+  if (trimmed.startsWith("⚠️")) return true;
+  return false;
+}
+
+// Deterministic post-guard over the raw judge output. Returns the framed
+// revision instruction, "pass", or a fail-open reason string.
+export function guardJudgeOutput(
+  raw: string,
+): { kind: "pass" } | { kind: "revise"; instruction: string } | { kind: "failopen"; why: string } {
+  if (PASS_RE.test(raw)) return { kind: "pass" };
+  const m = REVISE_RE.exec(raw);
+  if (!m) return { kind: "failopen", why: "malformed_output" };
+  const feedback = m[1].trim();
+  if (!feedback || feedback.length > MAX_INSTRUCTION_CHARS) {
+    return { kind: "failopen", why: "oversized_instruction" };
+  }
+  if (feedback.split("\n").length > 2) {
+    return { kind: "failopen", why: "multiline_instruction" };
+  }
+  // Fact firewall: an instruction carrying hard tokens (numbers, emails,
+  // ids) is fact-touching by definition — outside the judge's remit.
+  if (extractHardTokens(feedback).length > 0 || /\d/.test(feedback)) {
+    return { kind: "failopen", why: "fact_touching_instruction" };
+  }
+  return { kind: "revise", instruction: frameInstruction(feedback) };
+}
+
+// Judge one coordinator draft. Never throws; every failure path is fail-open.
+export async function judgeVoice(
+  draft: string,
+  deps: { complete: VoiceLlmComplete; logger: AuditLogger; now?: () => number },
+): Promise<VoiceVerdict> {
+  if (shouldSkip(draft)) return { ok: true };
+
+  const now = deps.now ? deps.now() : Date.now();
+  const audit = (summary: string) =>
+    deps.logger({
+      ts: new Date(now).toISOString(),
+      tool: "scopely_voice_judge",
+      actor: "system",
+      resultSummary: summary,
+    });
+
+  const controller = new AbortController();
+  const timeoutMs = voiceJudgeTimeoutMs();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`voice judge timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    const result = await Promise.race([
+      deps.complete({
+        // Redacted draft: PII/secrets never leave for the third-party judge.
+        messages: [{ role: "user", content: redactText(draft, 4000) }],
+        model: voiceJudgeModel(),
+        maxTokens: 120,
+        temperature: 0,
+        systemPrompt: VOICE_SYSTEM_PROMPT,
+        signal: controller.signal,
+        purpose: "scopelybot voice judge",
+      }),
+      timeout,
+    ]);
+    const guarded = guardJudgeOutput(result.text ?? "");
+    if (guarded.kind === "pass") return { ok: true };
+    if (guarded.kind === "revise") return { ok: false, instruction: guarded.instruction };
+    audit(`fail_open: ${guarded.why}`);
+    return { ok: true, failedOpen: guarded.why };
+  } catch (err) {
+    const why = err instanceof Error ? err.message : String(err);
+    audit(`fail_open: error: ${why.slice(0, 200)}`);
+    return { ok: true, failedOpen: "error" };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/extensions/scopelybot/src/voice-judge.ts
+++ b/extensions/scopelybot/src/voice-judge.ts
@@ -164,19 +164,21 @@ export async function judgeVoice(
   });
 
   try {
-    const result = await Promise.race([
-      deps.complete({
-        // Redacted draft: PII/secrets never leave for the third-party judge.
-        messages: [{ role: "user", content: redactText(draft, 4000) }],
-        model: voiceJudgeModel(),
-        maxTokens: 120,
-        temperature: 0,
-        systemPrompt: VOICE_SYSTEM_PROMPT,
-        signal: controller.signal,
-        purpose: "scopelybot voice judge",
-      }),
-      timeout,
-    ]);
+    const completion = deps.complete({
+      // Redacted draft: PII/secrets never leave for the third-party judge.
+      messages: [{ role: "user", content: redactText(draft, 4000) }],
+      model: voiceJudgeModel(),
+      maxTokens: 120,
+      temperature: 0,
+      systemPrompt: VOICE_SYSTEM_PROMPT,
+      signal: controller.signal,
+      purpose: "scopelybot voice judge",
+    });
+    // The completion keeps running after losing the race (the abort above is
+    // advisory — the callee may ignore the signal); its eventual rejection
+    // must never surface as an unhandled rejection.
+    completion.catch(() => {});
+    const result = await Promise.race([completion, timeout]);
     const guarded = guardJudgeOutput(result.text ?? "");
     if (guarded.kind === "pass") return { ok: true };
     if (guarded.kind === "revise") return { ok: false, instruction: guarded.instruction };


### PR DESCRIPTION
## What

Item 2 of the authorized supervisor program: the **human-readable pillar**. After the deterministic correct+secure checks pass on a coordinator draft, an opt-in bounded `llm.complete` call judges tone/persona/readability ONLY — never facts.

### Voice-judge lane (`voice-judge.ts`, flag `SCOPELYBOT_SUPERVISOR_VOICE=1`)
- **Different vendor than the author** (default `openrouter/anthropic/claude-haiku-4.5` vs gpt-5.6-luna) per the supervisor-v2 research's self-preference-bias finding; override via `SCOPELYBOT_SUPERVISOR_VOICE_MODEL`. Model override requires `plugins.entries.scopelybot.llm.allowModelOverride` host config — absent that, the lane fails open.
- **Containment stack** (independent layers): draft redacted via `redactText` before leaving for the third-party judge; hard AbortController+race timeout (default 4s — `before_agent_finalize` has NO harness timeout); deterministic post-guard rejecting any judge output that isn't `PASS` / one short `REVISE:` sentence free of hard tokens (numbers/emails/ids = fact-touching = fail-open); accepted feedback wrapped in a fixed fact-preserving frame; **same fuse** as the deterministic checks plus a per-run once cap; fail-open on every error path.
- Coordinator profile only (spoke packets are internal); deterministic findings always win — the judge only sees drafts the deterministic plane already passed.

### Substrate fix (live-supervisor defect found while grounding)
The harness feeds ONLY `reason` back to the model (`buildBeforeAgentFinalizeRetryPrompt`, run.ts:276; attempt.ts:3193 consumes `outcome.reason` alone). `retry.{instruction,idempotencyKey,maxAttempts}` are typed (hook-types.ts:377) but unconsumed — the supervisor's crafted revision instructions were being silently dropped, and per-check budgets never existed (real bounds: global 3-revisions/run cap + our fuse). `reason` now carries the instruction; stale comments/tests corrected; substrate facts pinned in tests.

## Verification
- `vitest run extensions/scopelybot/`: **28 files / 193 tests pass** (19 new voice-judge + 8 new integration + revise-shape substrate pin).
- `tsc --noEmit`: zero errors in changed files (repo-wide AgentTool baseline unchanged; the one `supervisor`-named hit is pre-existing in untouched `extensions/slm-supervisor`).

## Deploy (separate step)
Prod compose env: `SCOPELYBOT_SUPERVISOR_VOICE=1`. Prod openclaw.json: `plugins.entries.scopelybot.llm = { \"allowModelOverride\": true, \"allowedModels\": [\"openrouter/anthropic/claude-haiku-4.5\"] }`. Then `compose restart openclaw` + live smoke.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J