### PR TITLE
fix(scopelybot): start digest/passthrough intervals in register(), not gateway:startup

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -222,6 +222,19 @@ const plugin = {
       );
     });
 
+    // Interval scheduling pattern (2026-07-21 prod incident + follow-up):
+    //   1. NEVER wire timers to `gateway:startup` — it is emitted exactly once
+    //      ~250ms after boot to listeners that exist AT BOOT
+    //      (src/gateway/server-startup-post-attach.ts), and scopelybot
+    //      registers LAZILY on first inbound, so such a hook never fires here.
+    //   2. `api.registerHook` also THROWS on missing opts.name (registry.ts
+    //      "hook registration missing name"), and a throw in register() fails
+    //      the ENTIRE plugin — the incident that killed every scopelybot tool.
+    //   Instead: start the unref'd interval directly in register() and hand
+    //   cleanup to api.lifecycle.registerRuntimeLifecycle (diagnostic-based
+    //   surface — registration problems log, never throw; cleanup runs on
+    //   plugin disable/reset/delete/restart via runPluginHostCleanup).
+
     // Schedule recurring passthrough test runs.
     // Disabled if PASSTHROUGH_RUNNER_ENABLED is not "1" or SCOPELY_REPO_PATH is unset.
     const runnerEnabled = process.env.PASSTHROUGH_RUNNER_ENABLED === "1";
@@ -231,26 +244,29 @@ const plugin = {
         MIN_INTERVAL_MS,
         Number(process.env.PASSTHROUGH_INTERVAL_MS ?? DEFAULT_INTERVAL_MS),
       );
-      api.registerHook("gateway:startup", () => {
-        // Run once at startup, then on the configured interval
+      // Run once at registration, then on the configured interval.
+      void runPassthroughCycle(workspaceDir, { source: "scheduled" }).catch((err) => {
+        console.error("[scopelybot-passthrough] startup cycle failed:", err);
+      });
+      if (intervalHandle) clearInterval(intervalHandle); // re-register safety
+      intervalHandle = setInterval(() => {
         void runPassthroughCycle(workspaceDir, { source: "scheduled" }).catch((err) => {
-          console.error("[scopelybot-passthrough] startup cycle failed:", err);
+          console.error("[scopelybot-passthrough] scheduled cycle failed:", err);
         });
-        intervalHandle = setInterval(() => {
-          void runPassthroughCycle(workspaceDir, { source: "scheduled" }).catch((err) => {
-            console.error("[scopelybot-passthrough] scheduled cycle failed:", err);
-          });
-        }, interval);
-        // Don't keep the process alive solely for this timer
-        intervalHandle.unref?.();
-        console.log(`[scopelybot-passthrough] runner enabled, interval=${interval}ms`);
+      }, interval);
+      // Don't keep the process alive solely for this timer.
+      intervalHandle.unref?.();
+      api.lifecycle.registerRuntimeLifecycle({
+        id: "scopelybot-passthrough-runner",
+        description: "Clears the scheduled passthrough-cycle interval",
+        cleanup: () => {
+          if (intervalHandle) {
+            clearInterval(intervalHandle);
+            intervalHandle = null;
+          }
+        },
       });
-      api.registerHook("gateway:shutdown", () => {
-        if (intervalHandle) {
-          clearInterval(intervalHandle);
-          intervalHandle = null;
-        }
-      });
+      console.log(`[scopelybot-passthrough] runner enabled, interval=${interval}ms`);
     } else {
       console.log(
         "[scopelybot-passthrough] runner disabled (set PASSTHROUGH_RUNNER_ENABLED=1 and SCOPELY_REPO_PATH to enable)",
@@ -259,24 +275,27 @@ const plugin = {
 
     // Daily digest (Slice 4, SCOPELYBOT_DAILY_DIGEST=1): a minute tick that
     // fires at most once per UTC day past SCOPELYBOT_DIGEST_HOUR_UTC, with the
-    // last-posted date persisted in the workspace (restart-safe). Same
-    // startup/shutdown lifecycle as the passthrough runner.
+    // last-posted date persisted in the workspace (restart-safe). Interval
+    // starts here in register() per the scheduling pattern above.
     if (dailyDigestEnabled()) {
-      api.registerHook("gateway:startup", () => {
-        digestHandle = setInterval(() => {
-          void runDigestTick(workspaceDir).catch((err) => {
-            console.error("[scopelybot-digest] tick failed:", err);
-          });
-        }, 60_000);
-        digestHandle.unref?.();
-        console.log("[scopelybot-digest] daily digest enabled");
+      if (digestHandle) clearInterval(digestHandle); // re-register safety
+      digestHandle = setInterval(() => {
+        void runDigestTick(workspaceDir).catch((err) => {
+          console.error("[scopelybot-digest] tick failed:", err);
+        });
+      }, 60_000);
+      digestHandle.unref?.();
+      api.lifecycle.registerRuntimeLifecycle({
+        id: "scopelybot-daily-digest",
+        description: "Clears the daily-digest minute tick",
+        cleanup: () => {
+          if (digestHandle) {
+            clearInterval(digestHandle);
+            digestHandle = null;
+          }
+        },
       });
-      api.registerHook("gateway:shutdown", () => {
-        if (digestHandle) {
-          clearInterval(digestHandle);
-          digestHandle = null;
-        }
-      });
+      console.log("[scopelybot-digest] daily digest enabled");
     }
 
     console.log(


### PR DESCRIPTION
## Incident fix

2026-07-21 prod: enabling `SCOPELYBOT_DAILY_DIGEST=1` killed every scopelybot tool — `[plugins] scopelybot failed during register: hook registration missing name`. Immediate mitigation was pulling the flag; this PR is the real fix.

Two stacked defects in the interval wiring:

1. **Fatal**: `api.registerHook` requires unique `opts.name` (registry.ts throws), and a throw inside `register()` fails the entire plugin.
2. **Dead even if named**: `gateway:startup` fires exactly once ~250ms after boot, only to listeners that exist at boot (`src/gateway/server-startup-post-attach.ts`). scopelybot registers lazily on first inbound → its startup hook can never fire. The passthrough runner had the identical wiring (unhit only because its flag was never set on prod).

## Fix

- Drop both `gateway:startup`/`gateway:shutdown` hook pairs.
- Start the unref'd intervals directly in `register()` (re-register guard included).
- Cleanup via `api.lifecycle.registerRuntimeLifecycle` — diagnostic-based (logs, never throws; registry.ts:2232), cleanup runs on plugin disable/reset/delete/restart via `runPluginHostCleanup`.

## Verification

- `vitest run --config test/vitest/vitest.extensions.config.ts extensions/scopelybot`: **245/245, 32 files**
- `tsc --noEmit`: zero errors in `extensions/scopelybot/index.ts`; repo-wide AgentTool baseline unchanged.

## Deploy notes

After merge: prod pull, re-enable `- SCOPELYBOT_DAILY_DIGEST=1` in `docker-compose.prod.yml` (currently commented at line 88), `docker compose up -d` recreate, verify `[scopelybot-digest] daily digest enabled` on first inbound registration.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J