### PR TITLE
fix(scopelybot): voice revises bypass correctness fuse + cross-run cooldown

### DIFF
--- a/extensions/scopelybot/src/supervisor.test.ts
+++ b/extensions/scopelybot/src/supervisor.test.ts
@@ -352,15 +352,15 @@ describe("voice lane (v2.1)", () => {
   it("never judges spoke drafts — coordinator (human-facing) only", async () => {
     process.env.SCOPELYBOT_SUPERVISOR_V2 = "1";
     const llmComplete = vi.fn().mockResolvedValue({ text: "PASS" });
-    const res = await superviseFinalize(
-      event(CLEAN_DRAFT, { sessionKey: SPOKE_SESSION }),
-      { logger: auditMock, llmComplete },
-    );
+    const res = await superviseFinalize(event(CLEAN_DRAFT, { sessionKey: SPOKE_SESSION }), {
+      logger: auditMock,
+      llmComplete,
+    });
     expect(res).toBeUndefined();
     expect(llmComplete).not.toHaveBeenCalled();
   });
 
-  it("voice REVISE → framed instruction rides `reason`, charges the shared fuse, audits", async () => {
+  it("voice REVISE → framed instruction rides `reason`, audits", async () => {
     const llmComplete = vi
       .fn()
       .mockResolvedValue({ text: "REVISE: Lead with the answer and drop the filler." });
@@ -374,23 +374,31 @@ describe("voice lane (v2.1)", () => {
     );
   });
 
-  it("caps voice at ONE revision per run — the harness budget is global, the judge is non-deterministic", async () => {
+  it("caps voice per run AND per sessionKey cooldown — one turn can span multiple announce runs", async () => {
+    let t = 2_000_000;
     const llmComplete = vi.fn().mockResolvedValue({ text: "REVISE: Tighten the phrasing." });
-    const first = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    const deps = { logger: auditMock, now: () => t, llmComplete };
+    const first = await superviseFinalize(event(CLEAN_DRAFT), deps);
     expect(first).toMatchObject({ action: "revise" });
     // Second finalize pass in the SAME run (the revised draft): judge not consulted.
-    const second = await superviseFinalize(event(CLEAN_DRAFT), { logger: auditMock, llmComplete });
+    const second = await superviseFinalize(event(CLEAN_DRAFT), deps);
     expect(second).toBeUndefined();
     expect(llmComplete).toHaveBeenCalledTimes(1);
-    // A different run judges again.
-    const third = await superviseFinalize(event(CLEAN_DRAFT, { runId: "run-2" }), {
-      logger: auditMock,
-      llmComplete,
-    });
-    expect(third).toMatchObject({ action: "revise" });
+    // A DIFFERENT run inside the cooldown window (the 2026-07-21 S23 shape:
+    // the turn re-routed and the second spoke completion opened a fresh
+    // announce runId) — judge still not consulted.
+    t += 30_000;
+    const third = await superviseFinalize(event(CLEAN_DRAFT, { runId: "run-2" }), deps);
+    expect(third).toBeUndefined();
+    expect(llmComplete).toHaveBeenCalledTimes(1);
+    // After the cooldown lapses (default 180s) a new run judges again.
+    t += 180_000;
+    const fourth = await superviseFinalize(event(CLEAN_DRAFT, { runId: "run-3" }), deps);
+    expect(fourth).toMatchObject({ action: "revise" });
+    expect(llmComplete).toHaveBeenCalledTimes(2);
   });
 
-  it("voice revisions count toward the SAME fuse as deterministic checks", async () => {
+  it("voice revisions do NOT charge the shared correctness fuse", async () => {
     process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "2";
     let t = 2_000_000;
     const deps = {
@@ -398,12 +406,20 @@ describe("voice lane (v2.1)", () => {
       now: () => t,
       llmComplete: vi.fn().mockResolvedValue({ text: "REVISE: Tighten the phrasing." }),
     };
-    // Revision 1: voice (run-1).
+    // Revision 1: voice — self-capped, must not count toward the fuse.
     expect(await superviseFinalize(event(CLEAN_DRAFT), deps)).toMatchObject({ action: "revise" });
-    // Revision 2: deterministic (run-2) — trips the shared fuse.
+    // Revision 2: deterministic (run-2) — FIRST fuse hit, threshold 2 not
+    // reached (voice didn't count), so this is a normal revise.
     t += 1000;
     expect(
       await superviseFinalize(event("Reply CONFIRM 4821 to proceed.", { runId: "run-2" }), deps),
+    ).toMatchObject({ action: "revise" });
+    expect(sendScopelyTextMock).not.toHaveBeenCalled();
+    // Revision 3: deterministic (run-3) — second fuse hit trips it, and the
+    // escalation correctly reflects VERIFICATION failures only.
+    t += 1000;
+    expect(
+      await superviseFinalize(event("Reply CONFIRM 9999 to proceed.", { runId: "run-3" }), deps),
     ).toEqual({ action: "continue" });
     expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
   });

--- a/extensions/scopelybot/src/supervisor.ts
+++ b/extensions/scopelybot/src/supervisor.ts
@@ -466,28 +466,58 @@ function isFused(fuseKey: string, now: number): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Voice-judge per-run once guard. The harness does not enforce per-check
-// retry budgets (see the revise-return comment), and an LLM judge is
-// non-deterministic across passes — without this cap a picky judge could
-// burn all 3 harness revisions on voice alone. Bounded FIFO so the set
-// cannot grow without limit across a long-lived process.
+// Voice-judge caps. The harness does not enforce per-check retry budgets
+// (see the revise-return comment), and an LLM judge is non-deterministic
+// across passes — without caps a picky judge could burn all 3 harness
+// revisions on voice alone. TWO independent caps (2026-07-21 S23 live find:
+// one logical turn can span MULTIPLE announce runs — the coordinator's
+// completion-event answer re-routes, the second spoke completion starts a
+// FRESH runId — so a per-run guard alone let voice fire twice in one turn,
+// burn the correctness fuse, and post a false "couldn't verify" escalation
+// on a fully-grounded answer):
+//   1. Per-run once guard (bounded FIFO) — at most one voice revise per run.
+//   2. Per-sessionKey cooldown — after a voice revise, the judge is not even
+//      CALLED again for that conversation until the cooldown lapses,
+//      covering the multi-announce-run turn shape.
+// Because these self-caps bound voice churn, voice revises do NOT record
+// into the shared correctness fuse (see superviseFinalize) — a tone opinion
+// must never trip an escalation that claims a verification failure.
 // ---------------------------------------------------------------------------
 
 const VOICE_JUDGED_RUNS_MAX = 200;
 const voiceRevisedRuns = new Set<string>();
 
-function markVoiceRevised(runKey: string): void {
+// sessionKey → epoch-ms until which the voice judge stays quiet. Bounded FIFO.
+const VOICE_COOLDOWN_KEYS_MAX = 200;
+const voiceCooldownUntil = new Map<string, number>();
+
+function voiceCooldownMs(): number {
+  const raw = Number(process.env.SCOPELYBOT_SUPERVISOR_VOICE_COOLDOWN_MS ?? String(180_000));
+  return Number.isFinite(raw) && raw >= 0 ? raw : 180_000;
+}
+
+function markVoiceRevised(runKey: string, sessionKey: string, now: number): void {
   voiceRevisedRuns.add(runKey);
   if (voiceRevisedRuns.size > VOICE_JUDGED_RUNS_MAX) {
     const oldest = voiceRevisedRuns.values().next().value;
     if (oldest !== undefined) voiceRevisedRuns.delete(oldest);
   }
+  voiceCooldownUntil.set(sessionKey, now + voiceCooldownMs());
+  if (voiceCooldownUntil.size > VOICE_COOLDOWN_KEYS_MAX) {
+    const oldest = voiceCooldownUntil.keys().next().value;
+    if (oldest !== undefined) voiceCooldownUntil.delete(oldest);
+  }
+}
+
+function voiceOnCooldown(sessionKey: string, now: number): boolean {
+  return (voiceCooldownUntil.get(sessionKey) ?? 0) > now;
 }
 
 // Test hook: clear all fuse state between test cases.
 export function resetSupervisorStateForTest(): void {
   fuseBySession.clear();
   voiceRevisedRuns.clear();
+  voiceCooldownUntil.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -515,9 +545,11 @@ export async function superviseFinalize(
 
   // Voice lane (v2.1, SCOPELYBOT_SUPERVISOR_VOICE=1): only when the
   // deterministic plane is satisfied, only for human-facing coordinator
-  // drafts, and at most once per run (the harness's revision budget is
-  // global, not per-check — a non-deterministic judge must self-cap).
-  // judgeVoice never throws: error/timeout/malformed output all fail open.
+  // drafts, at most once per run AND once per sessionKey-cooldown window
+  // (one logical turn can span multiple announce runs — the harness's
+  // revision budget is global, not per-check, and a non-deterministic judge
+  // must self-cap). judgeVoice never throws: error/timeout/malformed output
+  // all fail open.
   const runKey = event.runId ?? event.turnId ?? "";
   if (
     verdict.ok &&
@@ -525,11 +557,16 @@ export async function superviseFinalize(
     scope.profile === "coordinator" &&
     deps.llmComplete &&
     runKey &&
-    !voiceRevisedRuns.has(runKey)
+    !voiceRevisedRuns.has(runKey) &&
+    !voiceOnCooldown(sessionKey, now)
   ) {
-    const voice = await judgeVoice(draft, { complete: deps.llmComplete, logger: deps.logger, now: deps.now });
+    const voice = await judgeVoice(draft, {
+      complete: deps.llmComplete,
+      logger: deps.logger,
+      now: deps.now,
+    });
     if (!voice.ok) {
-      markVoiceRevised(runKey);
+      markVoiceRevised(runKey, sessionKey, now);
       verdict = {
         ok: false,
         checkId: "voice",
@@ -539,6 +576,32 @@ export async function superviseFinalize(
     }
   }
   if (verdict.ok) return undefined;
+
+  // Voice revises bypass the shared correctness fuse: they are already
+  // bounded by the per-run + cooldown caps above, and the fuse's escalation
+  // text claims a VERIFICATION failure — which a tone opinion is not
+  // (2026-07-21 S23 live find: a voice re-fire tripped the fuse and posted a
+  // false "couldn't fully verify" escalation on a grounded answer).
+  if (verdict.checkId === "voice") {
+    deps.logger({
+      ts: new Date(now).toISOString(),
+      tool: "scopely_supervisor",
+      actor: "system",
+      params: { checkId: verdict.checkId, sessionKey, profile: scope.profile },
+      resultSummary: `revise: ${verdict.checkId}`,
+    });
+    return {
+      action: "revise",
+      // Same substrate fact as the deterministic return below: only `reason`
+      // reaches the model, so the framed instruction rides there.
+      reason: verdict.instruction,
+      retry: {
+        instruction: verdict.instruction,
+        idempotencyKey: `scopelybot-supervisor:${event.turnId ?? event.runId ?? "turn"}:${verdict.checkId}`,
+        maxAttempts: 1,
+      },
+    };
+  }
 
   const tripped = recordRevisionAndCheckFuse(scope.fuseKey, now);
   deps.logger({


### PR DESCRIPTION
## S23 live find (prod, 2026-07-21 04:38–04:39Z)

Probe: "give me a quick summary of current session counts by status" in vipbot_prod. Audit trail showed the full pipeline exercising — voice revise → `unsupported_state_claim` revise → **fresh tool read** (`scopely_session_status_counts`, re-grounding worked) → `fuse_tripped after voice` → false escalation post ("I couldn't fully verify parts of my last answer… Flagging Chad Simon") on an answer that was **fully grounded** (total 713 matched the ORM oracle).

Root cause (gateway warn lines): one logical turn spanned **two announce runs** — the completion-event answer re-routed, and the second spoke completion opened a fresh `runId`. The per-run voice once-guard correctly saw a new run, the judge fired a second time, and that tone revise landed as the 3rd revision in the shared fuse window.

## Fix

1. **Per-sessionKey voice cooldown** (default 180s, `SCOPELYBOT_SUPERVISOR_VOICE_COOLDOWN_MS`): after a voice revise the judge isn't even called again for that conversation until the window lapses — covers the multi-announce-run turn shape.
2. **Voice revises no longer charge the shared correctness fuse.** They're self-capped (once/run + cooldown), and the fuse's escalation text claims a *verification* failure — which a tone opinion is not. Deterministic checks keep the fuse exactly as before.

## Verification

- `vitest run --config test/vitest/vitest.extensions.config.ts extensions/scopelybot`: **245/245, 32 files** (voice fuse-interplay tests rewritten: no-fuse-charge, cross-run cooldown, cooldown expiry)
- `tsc --noEmit`: clean on changed files.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J