### PR TITLE
fix(scopelybot): security checks bypass the fuse + audit corrections

### DIFF
--- a/extensions/scopelybot/src/daily-digest.test.ts
+++ b/extensions/scopelybot/src/daily-digest.test.ts
@@ -38,9 +38,7 @@ function mockAllReads() {
       return Promise.resolve(ok({ total_sessions: 713, in_progress: 391, orgs: 12 }));
     if (p === "/api/admin/approvals/") return Promise.resolve(ok({ count: 2, results: [{}, {}] }));
     if (p.startsWith("/api/admin/sessions/"))
-      return Promise.resolve(
-        ok({ count: 1, results: [{ id: 42, company_name: "Globex" }] }),
-      );
+      return Promise.resolve(ok({ count: 1, results: [{ id: 42, company_name: "Globex" }] }));
     if (p.startsWith("/api/extraction-monitor/"))
       return Promise.resolve(ok({ count: 0, results: [] }));
     return Promise.resolve({ ok: false, status: 404, data: "" });
@@ -106,7 +104,8 @@ describe("buildDigest", () => {
   it("a failing section renders unavailable without suppressing the digest", async () => {
     scopelyFetchMock.mockImplementation((p: string) => {
       if (p === "/api/admin/stats/") return Promise.reject(new Error("down"));
-      if (p === "/api/admin/approvals/") return Promise.resolve({ ok: false, status: 502, data: "" });
+      if (p === "/api/admin/approvals/")
+        return Promise.resolve({ ok: false, status: 502, data: "" });
       return Promise.resolve(ok({ count: 0, results: [] }));
     });
     const digest = await buildDigest({});
@@ -127,6 +126,18 @@ describe("chunkDigestText", () => {
       expect(chunk.startsWith("line")).toBe(true); // line-boundary splits
     }
     expect(chunks.join("\n")).toBe(lines.join("\n")); // lossless
+  });
+
+  it("hard-slices a single line longer than the limit — every chunk stays under it (review fix)", () => {
+    // Reviewer repro: one line > 2×limit previously produced an over-limit
+    // chunk ([4000, 5000] for a 9000-char line at limit 4000).
+    const chunks = chunkDigestText("x".repeat(9000), 4000);
+    expect(chunks).toEqual(["x".repeat(4000), "x".repeat(4000), "x".repeat(1000)]);
+    // Oversize line arriving after accumulated content: current is flushed
+    // first, then the line is slice-looped — nothing exceeds the limit.
+    const mixed = chunkDigestText(`header\n${"y".repeat(9000)}\nfooter`, 4000);
+    for (const chunk of mixed) expect(chunk.length).toBeLessThanOrEqual(4000);
+    expect(mixed.join("")).toContain("footer");
   });
 });
 

--- a/extensions/scopelybot/src/daily-digest.ts
+++ b/extensions/scopelybot/src/daily-digest.ts
@@ -141,9 +141,7 @@ export async function buildDigest(previousStats: Record<string, unknown>): Promi
   }
 
   try {
-    const cutoff = new Date(Date.now() - STUCK_AFTER_DAYS * 86_400_000)
-      .toISOString()
-      .slice(0, 10);
+    const cutoff = new Date(Date.now() - STUCK_AFTER_DAYS * 86_400_000).toISOString().slice(0, 10);
     const stuck = await scopelyFetch(
       `/api/admin/sessions/?status=in_progress&date_to=${cutoff}&limit=5`,
     );
@@ -200,15 +198,24 @@ export function chunkDigestText(text: string, limit = CHUNK_LIMIT): string[] {
   let current = "";
   for (const line of text.split("\n")) {
     const candidate = current ? `${current}\n${line}` : line;
-    if (candidate.length > limit && current) {
-      chunks.push(current);
-      current = line;
-    } else if (candidate.length > limit) {
-      chunks.push(candidate.slice(0, limit));
-      current = candidate.slice(limit);
-    } else {
+    if (candidate.length <= limit) {
       current = candidate;
+      continue;
     }
+    if (current) {
+      chunks.push(current);
+      current = "";
+    }
+    // A single line can exceed the limit on its own — hard-slice it
+    // repeatedly (review fix 2026-07-21: a one-shot slice let the remainder
+    // exceed the limit whenever one line was > 2×limit, and the
+    // push-current-then-carry path could emit an oversize carried line).
+    let rest = line;
+    while (rest.length > limit) {
+      chunks.push(rest.slice(0, limit));
+      rest = rest.slice(limit);
+    }
+    current = rest;
   }
   if (current) chunks.push(current);
   return chunks;

--- a/extensions/scopelybot/src/daily-digest.ts
+++ b/extensions/scopelybot/src/daily-digest.ts
@@ -5,11 +5,13 @@
 // tools use and formatted entirely in code (no model in the loop; the digest
 // is a report, not a conversation).
 //
-// Scheduling rides the passthrough-runner pattern (gateway:startup interval,
-// unref'd, gateway:shutdown cleanup — index.ts) but fires once per day: a
-// minute-granularity tick checks "past the configured hour AND not yet posted
-// today (UTC)", with the last-posted date persisted in the workspace so a
-// container restart can neither double-post nor skip a day.
+// Scheduling: an unref'd interval started directly in register() with cleanup
+// via api.lifecycle.registerRuntimeLifecycle (index.ts — NOT gateway:startup,
+// which never fires for this lazily-registered plugin; see the scheduling
+// pattern comment there). Fires once per day: a minute-granularity tick
+// checks "past the configured hour AND not yet posted today (UTC)", with the
+// last-posted date persisted in the workspace so a container restart can
+// neither double-post nor skip a day.
 //
 // Failure posture: every fetch is independent and fail-soft — a section that
 // errors renders as "unavailable" instead of suppressing the digest. Sends

--- a/extensions/scopelybot/src/supervisor.test.ts
+++ b/extensions/scopelybot/src/supervisor.test.ts
@@ -406,21 +406,24 @@ describe("voice lane (v2.1)", () => {
       now: () => t,
       llmComplete: vi.fn().mockResolvedValue({ text: "REVISE: Tighten the phrasing." }),
     };
+    // Quality-lane failure (unsupported_state_claim) — the fuse-charging
+    // class (security drafts are fuse-exempt too, tested in the fuse suite).
+    const qualityBad = (runId: string) =>
+      event("Org 314 has 1250 sessions and owes $4,200.", {
+        runId,
+        messages: [{ role: "user", content: "how many sessions?" }],
+      });
     // Revision 1: voice — self-capped, must not count toward the fuse.
     expect(await superviseFinalize(event(CLEAN_DRAFT), deps)).toMatchObject({ action: "revise" });
-    // Revision 2: deterministic (run-2) — FIRST fuse hit, threshold 2 not
-    // reached (voice didn't count), so this is a normal revise.
+    // Revision 2: deterministic quality (run-2) — FIRST fuse hit, threshold 2
+    // not reached (voice didn't count), so this is a normal revise.
     t += 1000;
-    expect(
-      await superviseFinalize(event("Reply CONFIRM 4821 to proceed.", { runId: "run-2" }), deps),
-    ).toMatchObject({ action: "revise" });
+    expect(await superviseFinalize(qualityBad("run-2"), deps)).toMatchObject({ action: "revise" });
     expect(sendScopelyTextMock).not.toHaveBeenCalled();
-    // Revision 3: deterministic (run-3) — second fuse hit trips it, and the
-    // escalation correctly reflects VERIFICATION failures only.
+    // Revision 3: deterministic quality (run-3) — second fuse hit trips it,
+    // and the escalation correctly reflects VERIFICATION failures only.
     t += 1000;
-    expect(
-      await superviseFinalize(event("Reply CONFIRM 9999 to proceed.", { runId: "run-3" }), deps),
-    ).toEqual({ action: "continue" });
+    expect(await superviseFinalize(qualityBad("run-3"), deps)).toEqual({ action: "continue" });
     expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
   });
 
@@ -440,43 +443,86 @@ describe("voice lane (v2.1)", () => {
 });
 
 describe("fuse", () => {
+  // Quality-lane failure (unsupported_state_claim: state claim + zero
+  // evidence). SECURITY drafts (CONFIRM/secret) are fuse-exempt as of the
+  // 2026-07-21 audit fix, so fuse behavior is exercised with quality drafts.
+  const NO_EVIDENCE_TURN = [{ role: "user", content: "how many sessions?" }];
+  const qualityBad = (overrides?: Record<string, unknown>) =>
+    event("Org 314 has 1250 sessions and owes $4,200.", {
+      messages: NO_EVIDENCE_TURN,
+      ...overrides,
+    });
+
   it("trips after N revisions: accepts the draft, posts escalation, then cools down", async () => {
     process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "2";
     process.env.SCOPELYBOT_ESCALATION_OWNER = "John Rudolph";
-    const bad = () => event("Reply CONFIRM 4821 to proceed.");
     let t = 1_000_000;
     const deps = { logger: auditMock, now: () => t };
 
     // Revision 1: normal revise.
-    expect(await superviseFinalize(bad(), deps)).toMatchObject({ action: "revise" });
+    expect(await superviseFinalize(qualityBad(), deps)).toMatchObject({ action: "revise" });
     // Revision 2: fuse trips — draft accepted, escalation posted naming the owner.
     t += 1000;
-    expect(await superviseFinalize(bad(), deps)).toEqual({ action: "continue" });
+    expect(await superviseFinalize(qualityBad(), deps)).toEqual({ action: "continue" });
     expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
     expect(String(sendScopelyTextMock.mock.calls[0][1])).toContain("John Rudolph");
     expect(auditMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ resultSummary: "fuse_tripped after confirm_code_leak" }),
+      expect.objectContaining({ resultSummary: "fuse_tripped after unsupported_state_claim" }),
     );
-    // Cooldown: pass-through, no further checks, no extra escalation.
+    // Cooldown: pass-through for quality checks, no extra escalation.
     t += 1000;
-    expect(await superviseFinalize(bad(), deps)).toEqual({ action: "continue" });
+    expect(await superviseFinalize(qualityBad(), deps)).toEqual({ action: "continue" });
     expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
     // After cooldown expires the checks are live again.
     t += 11 * 60_000;
-    expect(await superviseFinalize(bad(), deps)).toMatchObject({ action: "revise" });
+    expect(await superviseFinalize(qualityBad(), deps)).toMatchObject({ action: "revise" });
+  });
+
+  it("SECURITY checks never charge the fuse and bypass an active cooldown (audit HIGH)", async () => {
+    process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "2";
+    let t = 1_000_000;
+    const deps = { logger: auditMock, now: () => t };
+
+    // Two security revises: if they charged the fuse, threshold 2 would trip.
+    expect(await superviseFinalize(event("Reply CONFIRM 4821 to proceed."), deps)).toMatchObject({
+      action: "revise",
+    });
+    t += 1000;
+    expect(await superviseFinalize(event("Reply CONFIRM 9999 to proceed."), deps)).toMatchObject({
+      action: "revise",
+    });
+    expect(sendScopelyTextMock).not.toHaveBeenCalled();
+    // Quality revise #1: first real fuse hit — proves security didn't charge.
+    t += 1000;
+    expect(await superviseFinalize(qualityBad(), deps)).toMatchObject({ action: "revise" });
+    // Quality revise #2: trips, cooldown starts.
+    t += 1000;
+    expect(await superviseFinalize(qualityBad(), deps)).toEqual({ action: "continue" });
+    // DURING cooldown quality checks pass through…
+    t += 1000;
+    expect(await superviseFinalize(qualityBad(), deps)).toEqual({ action: "continue" });
+    // …but a CONFIRM-code draft is STILL revised: the egress security plane
+    // never sleeps (previously the fused pass-through suppressed leak checks
+    // for the whole cooldown window).
+    t += 1000;
+    expect(await superviseFinalize(event("Reply CONFIRM 1234 to proceed."), deps)).toMatchObject({
+      action: "revise",
+    });
+    const jwt = `token: eyJ${"a".repeat(24)}.${"b".repeat(16)}`;
+    expect(await superviseFinalize(event(jwt), deps)).toMatchObject({ action: "revise" });
   });
 
   it("fuse state is per coordinator session key", async () => {
     process.env.SCOPELYBOT_SUPERVISOR_FUSE_N = "1";
     const deps = { logger: auditMock, now: () => 5_000_000 };
     // Session A trips immediately (threshold 1).
-    expect(await superviseFinalize(event("Reply CONFIRM 1111 now."), deps)).toEqual({
+    expect(await superviseFinalize(qualityBad(), deps)).toEqual({
       action: "continue",
     });
     // A different scopelybot session is unaffected by A's cooldown.
     expect(
       await superviseFinalize(
-        event("Reply CONFIRM 2222 now.", { sessionKey: "agent:scopelybot:zoom:thread:other" }),
+        qualityBad({ sessionKey: "agent:scopelybot:zoom:thread:other" }),
         deps,
       ),
     ).toEqual({ action: "continue" }); // trips its own fuse (threshold 1) — but independently
@@ -492,20 +538,20 @@ describe("fuse", () => {
     const spawnB = "agent:scopely-observe:subagent:bbbbbbbb-2222";
 
     // Spawn A: revision 1 on the shared agent:scopely-observe fuse.
-    expect(
-      await superviseFinalize(event("Reply CONFIRM 1111 now.", { sessionKey: spawnA }), deps),
-    ).toMatchObject({ action: "revise" });
+    expect(await superviseFinalize(qualityBad({ sessionKey: spawnA }), deps)).toMatchObject({
+      action: "revise",
+    });
     // Spawn B (fresh UUID): revision 2 — trips the SHARED fuse.
     t += 1000;
-    expect(
-      await superviseFinalize(event("Reply CONFIRM 2222 now.", { sessionKey: spawnB }), deps),
-    ).toEqual({ action: "continue" });
+    expect(await superviseFinalize(qualityBad({ sessionKey: spawnB }), deps)).toEqual({
+      action: "continue",
+    });
     expect(sendScopelyTextMock).toHaveBeenCalledTimes(1);
     // A different spoke agent is unaffected.
     t += 1000;
     expect(
       await superviseFinalize(
-        event("Reply CONFIRM 3333 now.", { sessionKey: "agent:scopely-users:subagent:cccc" }),
+        qualityBad({ sessionKey: "agent:scopely-users:subagent:cccc" }),
         deps,
       ),
     ).toMatchObject({ action: "revise" });

--- a/extensions/scopelybot/src/supervisor.ts
+++ b/extensions/scopelybot/src/supervisor.ts
@@ -5,10 +5,10 @@
 // Wired into `before_agent_finalize`: reviews a DRAFT final reply before it is
 // accepted, and either lets it through (`continue`) or requests a bounded
 // revision pass. Bounds: the harness's global MAX_BEFORE_AGENT_FINALIZE_
-// REVISIONS=3 per run (run.ts:217) plus this module's fuse — the harness does
-// NOT enforce per-check retry budgets (retry.{idempotencyKey,maxAttempts} are
-// typed but unconsumed; only `reason` reaches the model, see the revise-return
-// comment below). All checks are DETERMINISTIC string/shape predicates — no
+// REVISIONS=3 per run (run.ts:217), the harness's per-(run, idempotencyKey)
+// maxAttempts budget over the retry block (lifecycle-hook-helpers.ts — audit
+// correction 2026-07-21: the retry fields ARE consumed), plus this module's
+// fuse. All checks are DETERMINISTIC string/shape predicates — no
 // model in the supervisor's own loop (per the v2 research: deterministic
 // claim-vs-evidence is the highest-confidence egress pattern; LLM self-checks
 // are a documented failure mode).
@@ -435,7 +435,15 @@ function resolveScope(sessionKey: string): SessionScope {
 // Fuse — per-fuse-key sliding window of revision timestamps + cooldown.
 // ---------------------------------------------------------------------------
 
+// Leak classes are the SECURITY plane: never suppressed by the fuse cooldown,
+// never charge the fuse (see superviseFinalize). The fuse governs only the
+// churn-prone quality checks.
+const SECURITY_CHECKS = new Set(["confirm_code_leak", "secret_leak"]);
+
 type FuseState = { revisions: number[]; fusedUntil: number };
+// Bounded FIFO (2026-07-21 review finding: this map previously grew one
+// permanent entry per coordinator/spoke fuse key for the process lifetime).
+const FUSE_KEYS_MAX = 500;
 const fuseBySession = new Map<string, FuseState>();
 
 function fuseFor(fuseKey: string): FuseState {
@@ -443,6 +451,10 @@ function fuseFor(fuseKey: string): FuseState {
   if (!s) {
     s = { revisions: [], fusedUntil: 0 };
     fuseBySession.set(fuseKey, s);
+    if (fuseBySession.size > FUSE_KEYS_MAX) {
+      const oldest = fuseBySession.keys().next().value;
+      if (oldest !== undefined) fuseBySession.delete(oldest);
+    }
   }
   return s;
 }
@@ -539,9 +551,42 @@ export async function superviseFinalize(
   if (!draft.trim()) return undefined;
 
   const now = deps.now ? deps.now() : Date.now();
-  if (isFused(scope.fuseKey, now)) return { action: "continue" };
+  const fused = isFused(scope.fuseKey, now);
 
   let verdict = reviewDraft(draft, collectTurnEvidence(event.messages), scope.profile);
+
+  // SECURITY checks (leak classes) bypass the fuse entirely — they neither
+  // charge it nor honor its cooldown (2026-07-21 audit HIGH: the fused
+  // pass-through otherwise suppresses confirm_code_leak/secret_leak for the
+  // whole cooldown window, so a fuse trip would disable the egress security
+  // plane for ~10 min). Churn is still bounded WITHOUT the fuse: the harness
+  // enforces both the global 3-revisions/run cap and a per-(run, checkId)
+  // maxAttempts=1 budget from the retry block below
+  // (src/agents/harness/lifecycle-hook-helpers.ts finalize retry budget), so
+  // a persistently-leaking draft gets at most one revise per check per run,
+  // then finalizes. These checks are low-false-positive by design.
+  if (!verdict.ok && SECURITY_CHECKS.has(verdict.checkId)) {
+    deps.logger({
+      ts: new Date(now).toISOString(),
+      tool: "scopely_supervisor",
+      actor: "system",
+      params: { checkId: verdict.checkId, sessionKey, profile: scope.profile },
+      resultSummary: `revise: ${verdict.checkId}`,
+    });
+    return {
+      action: "revise",
+      reason: verdict.instruction,
+      retry: {
+        instruction: verdict.instruction,
+        idempotencyKey: `scopelybot-supervisor:${event.turnId ?? event.runId ?? "turn"}:${verdict.checkId}`,
+        maxAttempts: 1,
+      },
+    };
+  }
+
+  // Fused cooldown pass-through applies only to the QUALITY lanes (voice +
+  // grounding/format checks) — the churn-prone classes the fuse exists for.
+  if (fused) return { action: "continue" };
 
   // Voice lane (v2.1, SCOPELYBOT_SUPERVISOR_VOICE=1): only when the
   // deterministic plane is satisfied, only for human-facing coordinator
@@ -592,8 +637,9 @@ export async function superviseFinalize(
     });
     return {
       action: "revise",
-      // Same substrate fact as the deterministic return below: only `reason`
-      // reaches the model, so the framed instruction rides there.
+      // Same shape as the deterministic return below: reason carries the full
+      // framed instruction; the retry block adds the harness's per-(run,
+      // checkId) budget (see the corrected substrate-fact comment there).
       reason: verdict.instruction,
       retry: {
         instruction: verdict.instruction,
@@ -632,15 +678,16 @@ export async function superviseFinalize(
 
   return {
     action: "revise",
-    // SUBSTRATE FACT (verified 2026-07-21): the harness feeds ONLY `reason`
-    // back to the model — run.ts builds the retry prompt as
-    // BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX + "\n\n" + outcome.reason
-    // (src/agents/embedded-agent-runner/run.ts:276, attempt.ts:3193). The
-    // `retry.{instruction,idempotencyKey,maxAttempts}` fields exist in the
-    // typed contract (hook-types.ts:377) but nothing consumes them today, so
-    // the actionable instruction MUST ride in `reason` or it is silently
-    // dropped. The real revision bounds are the harness's global cap
-    // (MAX_BEFORE_AGENT_FINALIZE_REVISIONS=3 per run) plus this module's fuse.
+    // SUBSTRATE FACT (corrected 2026-07-21 after audit): the retry block IS
+    // consumed — src/agents/harness/lifecycle-hook-helpers.ts enforces a
+    // per-(runId, idempotencyKey) budget of maxAttempts and merges
+    // retry.instruction INTO the reason before run.ts builds the retry prompt
+    // (BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX + reason, run.ts:276,
+    // attempt.ts:3193). So the retry fields are LOAD-BEARING: they give each
+    // checkId a 1-shot-per-run cap on top of the global
+    // MAX_BEFORE_AGENT_FINALIZE_REVISIONS=3. `reason` still carries the full
+    // instruction so the prompt is complete even for a hypothetical consumer
+    // that reads only reason. Do not delete the retry block.
     reason: verdict.instruction,
     retry: {
       instruction: verdict.instruction,

--- a/extensions/scopelybot/src/voice-judge.ts
+++ b/extensions/scopelybot/src/voice-judge.ts
@@ -29,6 +29,15 @@
 //      per-run once guard here — the harness does not enforce per-check
 //      retry budgets, and an LLM judge is non-deterministic across passes.
 //   7. Fail-open everywhere: judge error/timeout/malformed = no opinion.
+//
+// ACCEPTED RESIDUAL (audit 2026-07-21, monitored): the fact firewall blocks
+// token-expressed facts (digits/emails/ids) but not WORD-expressed ones — a
+// guard-passing instruction like "sound more positive" could in principle
+// nudge the author into flipping a polarity ("denied"→"approved"). Layered
+// mitigations: judge sees a REDACTED draft only; temp 0; the fixed
+// fact-preserving frame; the revised draft re-runs the full deterministic
+// plane (leak + grounding checks). Watch `revise: voice` audit entries for
+// drift; if observed, narrow the remit to formatting-only.
 
 import type { AuditLogger } from "./audit.js";
 import { redactText } from "./redaction.js";


### PR DESCRIPTION
## Context

The voice-judge auditor and slice-4 reviewer (spawned pre-deploy, reported late) delivered findings after PRs #86–#89 shipped. Every claim was re-verified against HEAD; this PR fixes what stands.

## Fixes

1. **[HIGH, audit — security] Fused cooldown suppressed the egress security plane.** `isFused` short-circuited before `reviewDraft`, so after any fuse trip a draft containing a CONFIRM code or secret passed unchecked for the ~10-min cooldown (composable from the shipped tests: voice/quality trip + the cooldown pass-through). Fix: `confirm_code_leak`/`secret_leak` now bypass the fuse entirely — never charge it, never honor its cooldown. Churn stays bounded without the fuse by the harness's global 3/run cap **plus** its per-(run, idempotencyKey) `maxAttempts=1` budget (verified in `lifecycle-hook-helpers.ts`). New test pins security-revise-during-cooldown + no-fuse-charge.
2. **[Comment correction, audit] The "retry fields are unconsumed" substrate-fact comments were wrong** — `lifecycle-hook-helpers.ts` consumes `idempotencyKey`+`maxAttempts` (per-run/per-key budget) and merges `retry.instruction` into `reason`. The retry block is load-bearing; corrected in all three places.
3. **[Low, review] `chunkDigestText` emitted over-limit chunks** when a single line exceeded the limit (one-shot slice + oversize-carry path). Now slice-loops; regression test with the reviewer's 9000-char repro.
4. **[Low, review] `fuseBySession` unbounded** — bounded FIFO 500 (same class as `voiceRevisedRuns`).
5. **[MED, audit — accepted residual] Word-expressed fact drift** through the voice judge documented as accepted+monitored in `voice-judge.ts` (mitigation stack + narrowing trigger).

## Already addressed pre-review (no action)

- Digest tick reentrancy → `tickInFlight` (42b7bde6). Voice-fuse coupling to the *correctness* escalation + cross-run cooldown → PR #89. Auditor's HIGH #2 (phantom routed-turn fuse) → retracted by the auditor after verifying announce-run separation. Redaction/timeout/timer-cleanup → shipped in #86.

## Verification

- `vitest run --config test/vitest/vitest.extensions.config.ts extensions/scopelybot`: **247/247, 32 files**
- `tsc --noEmit`: clean on changed files (repo AgentTool baseline unchanged)

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J