### PR TITLE
polish(scopelybot): digest formatting + stuck threshold from live prod data

### DIFF
--- a/extensions/scopelybot/src/daily-digest.test.ts
+++ b/extensions/scopelybot/src/daily-digest.test.ts
@@ -90,7 +90,7 @@ describe("buildDigest", () => {
     expect(digest.text).toContain("in progress: 391"); // zero delta → no suffix
     expect(digest.text).not.toContain("391 (");
     expect(digest.text).toContain("Pending approvals: 2");
-    expect(digest.text).toContain("Possibly stuck (in progress, created >7d ago): 1 — #42 Globex");
+    expect(digest.text).toContain("Possibly stuck (in progress, created >60d ago): 1 — #42 Globex");
     expect(digest.text).toContain("Extraction failures: none");
     expect(digest.statsSnapshot).toMatchObject({ total_sessions: 713 });
     // The stuck query uses status + created-date cutoff (the only staleness
@@ -99,6 +99,38 @@ describe("buildDigest", () => {
       .map((c) => c[0] as string)
       .find((p) => p.startsWith("/api/admin/sessions/"));
     expect(stuckCall).toMatch(/status=in_progress&date_to=\d{4}-\d{2}-\d{2}&limit=5/);
+  });
+
+  it("formats currency/size keys compact and rate keys as percentages (live-data polish)", async () => {
+    // The first LIVE build rendered "pipeline value: 14570816.5" — raw floats.
+    scopelyFetchMock.mockImplementation((p: string) => {
+      if (p === "/api/admin/stats/")
+        return Promise.resolve(
+          ok({
+            pipeline_value: 14570816.5,
+            avg_deal_size: 79853.67,
+            conversion_rate: 14.7,
+            small_value: 420,
+          }),
+        );
+      return Promise.resolve(ok({ count: 0, results: [] }));
+    });
+    const digest = await buildDigest({ pipeline_value: 14320816.5 });
+    expect(digest.text).toContain("pipeline value: $14.57M (+$250.0k)");
+    expect(digest.text).toContain("avg deal size: $79.9k");
+    expect(digest.text).toContain("conversion rate: 14.7%");
+    expect(digest.text).toContain("small value: $420");
+  });
+
+  it("stuck threshold is env-tunable via SCOPELYBOT_DIGEST_STUCK_DAYS", async () => {
+    process.env.SCOPELYBOT_DIGEST_STUCK_DAYS = "30";
+    try {
+      mockAllReads();
+      const digest = await buildDigest({});
+      expect(digest.text).toContain("created >30d ago");
+    } finally {
+      delete process.env.SCOPELYBOT_DIGEST_STUCK_DAYS;
+    }
   });
 
   it("a failing section renders unavailable without suppressing the digest", async () => {

--- a/extensions/scopelybot/src/daily-digest.ts
+++ b/extensions/scopelybot/src/daily-digest.ts
@@ -37,7 +37,15 @@ export function digestHourUtc(): number {
 // possibly stuck. Created-date is the only staleness dimension the admin
 // sessions list can filter on (no ordering/updated_at params — verified
 // against SessionAdminViewSet._filtered_queryset).
-const STUCK_AFTER_DAYS = 7;
+// Default 60: calibrated against LIVE prod data 2026-07-21 — at the original
+// 7d default the flag caught 381 of ~391 in-progress sessions (zero
+// information); the live distribution was >7d:381, >30d:372, >60d:96,
+// >90d:0, so 60 is the knee where the flag starts discriminating.
+// Env-tunable so the PM can re-calibrate as the pipeline ages.
+export function stuckAfterDays(): number {
+  const raw = Number(process.env.SCOPELYBOT_DIGEST_STUCK_DAYS ?? "60");
+  return Number.isFinite(raw) && raw >= 1 ? Math.floor(raw) : 60;
+}
 
 // Zoom chatbot messages cap near 4096 chars (core adapter chunks agent
 // replies at 4000 — extensions/zoom/src/outbound.ts). sendScopelyText posts
@@ -95,6 +103,21 @@ function countOf(v: unknown): number | undefined {
   return undefined;
 }
 
+// Human-format a stat by key shape (live-data polish 2026-07-21: the raw
+// floats read as "pipeline value: 14570816.5" in the first live build).
+// Currency-ish keys (…_value/_size) render compact ($14.57M / $79.9k);
+// rate keys render as percentages. Deterministic key-suffix rules only.
+function formatStatValue(key: string, value: number): string {
+  if (/_(?:value|size)$/.test(key)) {
+    const abs = Math.abs(value);
+    if (abs >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+    if (abs >= 1_000) return `$${(value / 1_000).toFixed(1)}k`;
+    return `$${value}`;
+  }
+  if (/_rate$/.test(key)) return `${value}%`;
+  return String(value);
+}
+
 // Render "42 (+5)" style deltas for numeric stats present in both snapshots.
 function statsLine(current: Record<string, unknown>, previous: Record<string, unknown>): string {
   const parts: string[] = [];
@@ -103,8 +126,10 @@ function statsLine(current: Record<string, unknown>, previous: Record<string, un
     const prev = previous[key];
     const delta = typeof prev === "number" ? value - prev : undefined;
     const deltaText =
-      delta === undefined || delta === 0 ? "" : ` (${delta > 0 ? "+" : ""}${delta})`;
-    parts.push(`${key.replace(/_/g, " ")}: ${value}${deltaText}`);
+      delta === undefined || delta === 0
+        ? ""
+        : ` (${delta > 0 ? "+" : "-"}${formatStatValue(key, Math.abs(delta))})`;
+    parts.push(`${key.replace(/_/g, " ")}: ${formatStatValue(key, value)}${deltaText}`);
     if (parts.length >= 6) break;
   }
   return parts.length > 0 ? parts.join(", ") : "no numeric stats available";
@@ -143,7 +168,8 @@ export async function buildDigest(previousStats: Record<string, unknown>): Promi
   }
 
   try {
-    const cutoff = new Date(Date.now() - STUCK_AFTER_DAYS * 86_400_000).toISOString().slice(0, 10);
+    const stuckDays = stuckAfterDays();
+    const cutoff = new Date(Date.now() - stuckDays * 86_400_000).toISOString().slice(0, 10);
     const stuck = await scopelyFetch(
       `/api/admin/sessions/?status=in_progress&date_to=${cutoff}&limit=5`,
     );
@@ -163,7 +189,7 @@ export async function buildDigest(previousStats: Record<string, unknown>): Promi
         .filter((s) => s !== "#?");
       lines.push(
         total > 0
-          ? `Possibly stuck (in progress, created >${STUCK_AFTER_DAYS}d ago): ${total}` +
+          ? `Possibly stuck (in progress, created >${stuckDays}d ago): ${total}` +
               (names.length > 0 ? ` — ${names.join(", ")}` : "")
           : "Possibly stuck deals: none",
       );


### PR DESCRIPTION
## Live-data-driven polish

Ran the digest build LIVE in-container against real prod BFF data (no post) before its first scheduled fire. Two issues unit tests couldn't catch:

1. **Raw floats**: `pipeline value: 14570816.5`. Currency-ish keys (`*_value`/`*_size`) now render compact (`$14.57M` / `$79.9k`), rate keys as `%`, deltas formatted the same way.
2. **Mis-calibrated stuck flag**: `>7d` caught **381 of ~391** in-progress sessions — zero information. Measured live across thresholds: >7d:381, >30d:372, **>60d:96**, >90d:0 → 60d is the knee. Default now 60, env-tunable via `SCOPELYBOT_DIGEST_STUCK_DAYS`.

## Verification
- Suite 249/249 (32 files); tsc clean on changed files.
- Deploy plan: prod pull + restart, then a one-off live `runDigestTick` fire to vipbot_prod (the ratified destination) to validate the full post path and today's marker persistence.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J