### PR TITLE
fix(scopelybot): surface backend 4xx validation detail on failed confirms

### DIFF
--- a/extensions/scopelybot/src/confirm.test.ts
+++ b/extensions/scopelybot/src/confirm.test.ts
@@ -99,3 +99,59 @@ describe("ScopelyBot confirmation actor gate", () => {
     expect(result).toContain("No pending action");
   });
 });
+
+// Live gap 2026-07-21: a category-validation 400 ("UCaaS — Base" isn't a real
+// category) surfaced as a bare "Failed (HTTP 400)" — the human had to read
+// server code to learn why. 4xx bodies now surface redacted; 5xx stay hidden
+// (the test above pins that).
+describe("backend error detail on 4xx", () => {
+  beforeEach(() => {
+    takePendingMock.mockReset();
+    logger.mockReset();
+  });
+
+  it("surfaces the DRF validation message on a 400 (the live pricing-item shape)", async () => {
+    takePendingMock.mockReturnValue({
+      summary: "create pricing item chad_test_price_item on goto/pt 9 @ 1.00",
+      run: vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        data: {
+          category: [
+            "Category must be one of: Core, Call Routing, Hardware & Paging, Porting, " +
+              "SBC / PBX, SSO, Integrations, Training, Go-Live, T&M, Order Minimum. " +
+              "Got 'UCaaS — Base'.",
+          ],
+        },
+      }),
+    });
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 1234",
+      actor: approver,
+      conversationId: "vipbot_prod",
+      approverIds: [approver],
+      logger,
+    });
+    expect(result).toContain("HTTP 400");
+    expect(result).toContain("Category must be one of");
+    expect(result).toContain("Got 'UCaaS — Base'");
+  });
+
+  it("drops HTML error pages instead of relaying markup", async () => {
+    takePendingMock.mockReturnValue({
+      summary: "update pricing item 5",
+      run: vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 404, data: "<html><body>Not Found</body></html>" }),
+    });
+    const result = await tryExecuteConfirm({
+      text: "CONFIRM 1234",
+      actor: approver,
+      conversationId: "vipbot_prod",
+      approverIds: [approver],
+      logger,
+    });
+    expect(result).toContain("HTTP 404");
+    expect(result).not.toContain("<html>");
+  });
+});

--- a/extensions/scopelybot/src/confirm.ts
+++ b/extensions/scopelybot/src/confirm.ts
@@ -16,6 +16,39 @@ export function isApprovedWriteActor(actor: string, approverIds: string[]): bool
   return Boolean(normalized) && allowed.size > 0 && allowed.has(normalized);
 }
 
+// Compact, redacted extract of a backend error body so a failed confirm
+// explains itself. Live gap 2026-07-21: a category-validation 400 surfaced
+// as a bare "Failed (HTTP 400)" — the backend's message ("Category must be
+// one of: …") never reached the human, who had no way to know WHY without
+// server logs. Handles DRF shapes ({field: [msgs]}, {detail: "…"}) and
+// plain-text bodies; HTML error pages are dropped (noise, not signal).
+// CALLERS surface this for 4xx ONLY: client-error bodies are validation
+// feedback meant for the requester, while 5xx bodies are server internals
+// (stack traces, proxies' HTML) and stay hidden — pinned by the existing
+// "hides backend failure bodies" 502 test.
+export function formatBackendErrorDetail(data: unknown): string {
+  if (!data) return "";
+  let text = "";
+  if (typeof data === "string") {
+    text = data;
+  } else if (typeof data === "object" && !Array.isArray(data)) {
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(data as Record<string, unknown>).slice(0, 3)) {
+      const msg = Array.isArray(value)
+        ? value.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).join(" ")
+        : typeof value === "string"
+          ? value
+          : JSON.stringify(value);
+      parts.push(key === "detail" ? msg : `${key}: ${msg}`);
+    }
+    text = parts.join("; ");
+  } else if (Array.isArray(data)) {
+    text = data.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).join(" ");
+  }
+  if (/^\s*</.test(text)) return ""; // HTML error page — no useful detail
+  return redactText(text, 400).trim();
+}
+
 // Called from the before_dispatch handler. If the inbound text is `CONFIRM <code>`
 // for a live pending action, execute it and return a human-readable result string.
 // Returns null when the message is not a confirm (so normal handling continues).
@@ -72,13 +105,16 @@ export async function tryExecuteConfirm(params: {
       const lines = bundle.results
         .slice(0, 10)
         .map((r) => {
-          const item = r as { summary: string; ok: boolean; status: number };
-          return item.ok ? `✅ ${item.summary}` : `❌ ${item.summary} (HTTP ${item.status})`;
+          const item = r as { summary: string; ok: boolean; status: number; detail?: string };
+          if (item.ok) return `✅ ${item.summary}`;
+          const itemDetail = item.detail ? ` — ${item.detail}` : "";
+          return `❌ ${item.summary} (HTTP ${item.status})${itemDetail}`;
         })
         .join("\n");
       return `⚠️ Applied ${bundle.applied ?? 0} of ${bundle.results.length}:\n${lines}`;
     }
-    return `❌ Failed (HTTP ${res.status}): ${action.summary}.`;
+    const detail = res.status >= 400 && res.status < 500 ? formatBackendErrorDetail(res.data) : "";
+    return `❌ Failed (HTTP ${res.status}): ${action.summary}.${detail ? ` — ${detail}` : ""}`;
   } catch (err) {
     const msg = redactText(err instanceof Error ? err.message : String(err), 500);
     params.logger({

--- a/extensions/scopelybot/src/gated.ts
+++ b/extensions/scopelybot/src/gated.ts
@@ -8,6 +8,7 @@
 // so the bot cannot self-mutate. Tests assert scopelyFetch is not called during execute().
 
 import { getChannelThreadAnchor, sendScopelyText } from "./comfort.js";
+import { formatBackendErrorDetail } from "./confirm.js";
 import { makeCode, putPending } from "./pending-confirm.js";
 import { redactText } from "./redaction.js";
 import { jsonResult } from "./scopely-api.js";
@@ -19,7 +20,9 @@ type StagedItem = { summary: string; run: (ctx?: { actor?: string }) => FetchRes
 
 // Per-item outcome of a confirmed bundle, surfaced back to the human so partial
 // application is never silent (deletes/updates over HTTP are not transactional).
-export type BundleItemResult = { summary: string; ok: boolean; status: number };
+// `detail` carries the backend's redacted error message on failure so the
+// human sees WHY (e.g. a validation message), not just a status code.
+export type BundleItemResult = { summary: string; ok: boolean; status: number; detail?: string };
 
 // Open coalescing bundles, keyed by channel. A bundle collects every stageWrite
 // issued within the debounce window (one agent turn typically stages its writes
@@ -78,7 +81,17 @@ async function flushItems(channel: string, items: StagedItem[]): Promise<void> {
       for (const it of items) {
         try {
           const res = await it.run(ctx);
-          results.push({ summary: it.summary, ok: res.ok, status: res.status });
+          // 4xx only — same boundary as confirm.ts (5xx bodies stay hidden).
+          const detail =
+            !res.ok && res.status >= 400 && res.status < 500
+              ? formatBackendErrorDetail(res.data)
+              : "";
+          results.push({
+            summary: it.summary,
+            ok: res.ok,
+            status: res.status,
+            ...(detail ? { detail } : {}),
+          });
         } catch {
           results.push({ summary: it.summary, ok: false, status: 0 });
         }


### PR DESCRIPTION
## Live gap (2026-07-21, pricing-item test in vipbot_prod)

A confirmed `create pricing item` failed HTTP 400 because `"UCaaS — Base"` isn't a valid category — but the human saw only `❌ Failed (HTTP 400)`. The backend's own validation message (`Category must be one of: Core, Call Routing, …`) was swallowed; diagnosing required reading server code.

## Fix

- `formatBackendErrorDetail()` — compact, redacted extract of DRF-shaped (`{field: [msgs]}`, `{detail}`) and plain-text bodies; HTML pages dropped.
- Appended to the failure text for **4xx only** (client-error bodies are validation feedback for the requester); **5xx stay hidden** (server internals — the existing "hides backend failure bodies" 502 test pins this and passes unchanged).
- Bundled confirms carry per-item `detail` the same way.

## Related config change (already live, runtime-state tier)

The same test exposed the spoke-partitioning gap firing: `scopely-pricing` holds `create_pricing_item` (needs vendor key + project-type id) but had no read tools to resolve them → dead-ended asking the human. Prod `openclaw.json` scopely-pricing allow 15→17 (+`scopely_list_vendors`, +`scopely_list_project_types`; backup `openclaw.json.bak-20260721-pricingreads`) + an id-resolution rule in the spoke IDENTITY. Verified live on the next turn: the spoke ran its own `list_project_types` before staging.

## Verification
- Suite 251/251 (32 files); tsc clean. New regression tests reproduce the exact live 400 shape.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J