### PR TITLE
fix(scopelybot): 204 No Content misreported as confirm failure

### DIFF
--- a/extensions/scopelybot/src/scopely-api.test.ts
+++ b/extensions/scopelybot/src/scopely-api.test.ts
@@ -1,0 +1,78 @@
+// scopelyFetch response-body parsing tests. Regression anchor (live 2026-07-21):
+// DRF answers DELETE with 204 No Content but STILL sets
+// Content-Type: application/json on the empty body — the old resp.json() call
+// threw "Unexpected end of JSON input", which the confirm executor reported as
+// "❌ Error executing DELETE …" on a delete that had already SUCCEEDED on the
+// backend. A successful mutation must never be reported as a failure by the
+// bot's own response parsing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Auth is out of scope here — stub the cookie/login plumbing entirely.
+vi.mock("./scopely-auth.js", () => ({
+  scopelyEnsureAuth: () => Promise.resolve(),
+  scopelyCookieHeader: () => "access=t",
+  scopelyClearSession: () => {},
+}));
+
+import { scopelyFetch } from "./scopely-api.js";
+
+const fetchMock = vi.fn();
+
+function httpResponse(opts: { status: number; body: string; contentType?: string }) {
+  return {
+    ok: opts.status >= 200 && opts.status < 300,
+    status: opts.status,
+    headers: {
+      get: (name: string) => (name === "content-type" ? (opts.contentType ?? null) : null),
+    },
+    text: () => Promise.resolve(opts.body),
+    json: () => Promise.resolve(JSON.parse(opts.body)),
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("scopelyFetch body parsing", () => {
+  it("204 No Content with a JSON content-type resolves ok — never throws (live DELETE regression)", async () => {
+    fetchMock.mockResolvedValue(
+      httpResponse({ status: 204, body: "", contentType: "application/json" }),
+    );
+    const res = await scopelyFetch("/api/admin/x/");
+    expect(res).toEqual({ ok: true, status: 204, data: "" });
+  });
+
+  it("parses a valid JSON body (normal path unchanged)", async () => {
+    fetchMock.mockResolvedValue(
+      httpResponse({
+        status: 200,
+        body: '{"count":1}',
+        contentType: "application/json; charset=utf-8",
+      }),
+    );
+    const res = await scopelyFetch("/api/admin/x/");
+    expect(res).toEqual({ ok: true, status: 200, data: { count: 1 } });
+  });
+
+  it("falls back to raw text when the JSON content-type lies about the body", async () => {
+    fetchMock.mockResolvedValue(
+      httpResponse({ status: 502, body: "Bad Gateway", contentType: "application/json" }),
+    );
+    const res = await scopelyFetch("/api/admin/x/");
+    expect(res).toEqual({ ok: false, status: 502, data: "Bad Gateway" });
+  });
+
+  it("non-JSON content-type returns the body as text", async () => {
+    fetchMock.mockResolvedValue(
+      httpResponse({ status: 200, body: "<html>", contentType: "text/html" }),
+    );
+    const res = await scopelyFetch("/api/admin/x/");
+    expect(res).toEqual({ ok: true, status: 200, data: "<html>" });
+  });
+});

--- a/extensions/scopelybot/src/scopely-api.ts
+++ b/extensions/scopelybot/src/scopely-api.ts
@@ -36,9 +36,21 @@ export async function scopelyFetch(
     return scopelyFetch(path, { ...opts, retried: true });
   }
 
-  const data = resp.headers.get("content-type")?.includes("application/json")
-    ? await resp.json()
-    : await resp.text();
+  // Read as text first, then parse. DRF answers DELETE with 204 No Content but
+  // STILL sets Content-Type: application/json on the empty body — resp.json()
+  // throws "Unexpected end of JSON input", which surfaced live (2026-07-21) as
+  // a false "❌ Error executing DELETE …" on a delete that had SUCCEEDED.
+  // Empty or malformed bodies fall back to the raw text: an honest payload
+  // beats an exception that misreports a completed mutation as a failure.
+  const raw = await resp.text();
+  let data: unknown = raw;
+  if (resp.headers.get("content-type")?.includes("application/json") && raw.trim() !== "") {
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      // Content-Type lied — keep the raw text.
+    }
+  }
 
   return { ok: resp.ok, status: resp.status, data };
 }


### PR DESCRIPTION
Live find 2026-07-21 during the pricing-item E2E exercise: a confirmed DELETE succeeded on the backend (item 1078 verified gone via ORM) but the bot posted `❌ Error executing DELETE pricing item id 1078 on goto/pt 9.` — audit shows `error: exception, Unexpected end of JSON input`.

Root cause: `scopely-api.ts` picked `resp.json()` from the Content-Type header alone; DRF sets `application/json` on a 204's empty body, so the parse threw and the confirm executor's catch path reported a completed mutation as a failure.

Fix: read the body as text first, JSON-parse only non-empty bodies, fall back to raw text on a lying content-type. New `scopely-api.test.ts` (4 tests) pins the 204 regression + normal parse + fallback paths.

Suite: 33 files / 255 tests green; no tsc errors in changed files (repo AgentTool baseline unchanged).

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J