### PR TITLE
fix(scopelybot): fail-loud deployment-key validation on pricing writes

### DIFF
--- a/extensions/scopelybot/src/deployment-keys.ts
+++ b/extensions/scopelybot/src/deployment-keys.ts
@@ -1,0 +1,30 @@
+// Shared deployment-type key lookup for fail-loud parameter validation.
+//
+// Deployment-type keys are DATA-DEFINED (admin deployment-type templates), not
+// an enum we can hardcode. Several backend surfaces are SILENT about unknown
+// keys: an unknown deployment filter returns all-zero counts (issue #81, live
+// 2026-07-21: deployment="prod" → confident "0 sessions" vs 713 real), and a
+// pricing row gated on an unknown deployment type never matches any real
+// deployment, so it silently drops from every quote (live 2026-07-21: the
+// model wrote the pricing CATEGORY "core" into deployment_types on two items —
+// backend validation accepted it, and the rows were unpriceable). Where the
+// backend is silent, the tool layer must fail loud BEFORE the call/stage.
+//
+// Callers FAIL OPEN when this returns [] (lookup error/empty): validation must
+// never turn a backend outage into a false rejection of a valid request.
+
+import { scopelyFetch } from "./scopely-api.js";
+
+// Fetch the valid deployment-type keys from the live template list.
+// Returns [] on any failure so callers can fail open.
+export async function fetchDeploymentTypeKeys(): Promise<string[]> {
+  try {
+    const templates = await scopelyFetch(`/api/admin/deployment-type-templates/`);
+    if (!templates.ok) return [];
+    const data = templates.data as { results?: unknown[] } | unknown[] | null;
+    const rows = Array.isArray(data) ? data : Array.isArray(data?.results) ? data.results : [];
+    return rows.map((row) => String((row as Record<string, unknown>)?.key ?? "")).filter(Boolean);
+  } catch {
+    return [];
+  }
+}

--- a/extensions/scopelybot/src/pricing-tools.test.ts
+++ b/extensions/scopelybot/src/pricing-tools.test.ts
@@ -113,6 +113,9 @@ describe("pricing-tools", () => {
   });
 
   // Core safety guarantee: every write stages, none touch prod during execute().
+  // (Carve-out: when deployment keys are supplied, execute runs ONE read-only
+  // template GET for validation — the WRITE_TOOLS args here omit them, so the
+  // no-fetch assertion stays strict for the mutation path.)
   it("ALL write tools STAGE only — execute() never calls scopelyFetch", async () => {
     const t = buildTools();
     for (const [name, args] of Object.entries(WRITE_TOOLS)) {
@@ -122,8 +125,106 @@ describe("pricing-tools", () => {
     expect(fetchMock, "no write tool may call scopelyFetch before CONFIRM").not.toHaveBeenCalled();
   });
 
+  // Live incident 2026-07-21: asked to "Make it core", the model wrote the
+  // pricing CATEGORY "core" into deployment_types on two dialpad items. The
+  // backend accepted it (validator only checks "list of strings") but the
+  // pricing engine's deployment gate means such rows silently drop from every
+  // quote. Deployment keys are validated pre-stage against the live template
+  // list; the backend stays the loud authority for category.
+  describe("deployment-key validation (silent-drop guard)", () => {
+    const TEMPLATES = {
+      ok: true,
+      status: 200,
+      data: [{ key: "autopilot" }, { key: "copilot" }, { key: "bespoke" }, { key: "tnm" }],
+    };
+    const ITEM_ARGS = {
+      vendor_key: "dialpad",
+      project_type_id: 99,
+      pricing_key: "workflows",
+      display_name: "Workflows",
+      unit_price: "0.00",
+      category: "Core",
+    };
+
+    it("rejects an unknown deployment_types key BEFORE staging (incident regression)", async () => {
+      const t = buildTools();
+      fetchMock.mockResolvedValueOnce(TEMPLATES);
+      const res = parse(
+        await t.scopely_create_pricing_item.execute("x", {
+          ...ITEM_ARGS,
+          deployment_types: ["core"],
+        }),
+      );
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain("Unknown deployment type key(s): core");
+      expect(res.error).toContain("autopilot, copilot, bespoke, tnm");
+      expect(res.error).toContain("pricing CATEGORY");
+      // Nothing staged: no confirm prompt was delivered, only the lookup fired.
+      expect(sendScopelyTextMock).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(String(fetchMock.mock.calls[0][0])).toContain("deployment-type-templates");
+    });
+
+    it("rejects unknown keys in unit_price_by_deployment (same silent-drop key space)", async () => {
+      const t = buildTools();
+      fetchMock.mockResolvedValueOnce(TEMPLATES);
+      const res = parse(
+        await t.scopely_update_pricing_item.execute("x", {
+          vendor_key: "dialpad",
+          project_type_id: 99,
+          id: 1080,
+          unit_price_by_deployment: { prod: "5.00" },
+        }),
+      );
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain("Unknown deployment type key(s): prod");
+      expect(sendScopelyTextMock).not.toHaveBeenCalled();
+    });
+
+    it("valid keys stage normally on defaults and items", async () => {
+      const t = buildTools();
+      fetchMock.mockResolvedValue(TEMPLATES);
+      const item = parse(
+        await t.scopely_create_pricing_item.execute("x", {
+          ...ITEM_ARGS,
+          deployment_types: ["bespoke", "copilot"],
+        }),
+      );
+      expect(item.staged).toBe(true);
+      const dflt = parse(
+        await t.scopely_update_pricing_default.execute("x", {
+          id: 3,
+          deployment_types: ["tnm"],
+        }),
+      );
+      expect(dflt.staged).toBe(true);
+    });
+
+    it("FAILS OPEN when the template lookup errors — never blocks a valid request", async () => {
+      const t = buildTools();
+      fetchMock.mockRejectedValueOnce(new Error("backend down"));
+      const res = parse(
+        await t.scopely_create_pricing_item.execute("x", {
+          ...ITEM_ARGS,
+          deployment_types: ["bespoke"],
+        }),
+      );
+      expect(res.staged).toBe(true);
+    });
+
+    it("skips the lookup entirely when no deployment keys are supplied", async () => {
+      const t = buildTools();
+      const res = parse(await t.scopely_create_pricing_item.execute("x", ITEM_ARGS));
+      expect(res.staged).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("create_pricing_default confirms to POST with supplied fields", async () => {
     const t = buildTools();
+    // deployment_types present → execute runs the read-only template lookup
+    // first; feed it valid keys so staging proceeds.
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200, data: [{ key: "autopilot" }] });
     const code = codeOf(
       await t.scopely_create_pricing_default.execute("x", {
         scope_category: "ucaas",
@@ -142,7 +243,7 @@ describe("pricing-tools", () => {
       conversationId: CHANNEL,
       logger: noopLogger as never,
     });
-    const [path, opts] = fetchMock.mock.calls[0];
+    const [path, opts] = fetchMock.mock.calls.at(-1)!;
     expect(path).toBe("/api/admin/pricing-defaults/");
     expect(opts.method).toBe("POST");
     expect(JSON.parse(opts.body)).toEqual({

--- a/extensions/scopelybot/src/pricing-tools.ts
+++ b/extensions/scopelybot/src/pricing-tools.ts
@@ -2,12 +2,49 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
+import { fetchDeploymentTypeKeys } from "./deployment-keys.js";
 import { describeChanges, pickBody, stageWrite } from "./gated.js";
 import { buildQuery, errorResult, jsonResult, scopelyFetch } from "./scopely-api.js";
 
 // Pricing-config tools (Scopely VIP admin). All IsPlatformStaff. Reads run
 // immediately; writes are confirm-gated. Prices are decimal STRINGS (e.g. "15.00").
 // unit_price_by_deployment is a dict {deployment_key: "price"}; deployment_types is a string list.
+
+// Fail-loud deployment-key validation for pricing writes (live incident
+// 2026-07-21): asked to "Make it core", the model wrote the pricing CATEGORY
+// "core" into deployment_types on two dialpad items. The backend accepted it
+// (its validator only checks "list of strings"), but the pricing engine gates
+// CCaaS rows on `effective_deployment in deployment_types` — so rows with an
+// unknown deployment type NEVER match a real deployment and silently drop from
+// every quote. Category is validated loudly by the backend (400 naming the
+// enum); deployment keys are the SILENT failure, so they get the pre-stage
+// gate here — same pattern as the issue-#81 fix in support-tools.
+// Returns an error string naming the unknown + valid keys, or null to proceed.
+// FAILS OPEN (null) when the template lookup errors: validation must never
+// turn a backend outage into a false rejection.
+async function rejectUnknownDeploymentKeys(
+  params: Record<string, unknown>,
+): Promise<string | null> {
+  const referenced: string[] = [];
+  if (Array.isArray(params.deployment_types)) {
+    referenced.push(...params.deployment_types.map(String));
+  }
+  const overrides = params.unit_price_by_deployment;
+  if (overrides && typeof overrides === "object" && !Array.isArray(overrides)) {
+    referenced.push(...Object.keys(overrides));
+  }
+  if (referenced.length === 0) return null;
+  const validKeys = await fetchDeploymentTypeKeys();
+  if (validKeys.length === 0) return null; // fail open — lookup unavailable
+  const unknown = [...new Set(referenced.filter((k) => !validKeys.includes(k)))];
+  if (unknown.length === 0) return null;
+  return (
+    `Unknown deployment type key(s): ${unknown.join(", ")}. Valid keys: ${validKeys.join(", ")}. ` +
+    `A pricing row gated on an unknown deployment type never matches a real deployment and ` +
+    `silently drops from every quote. Note "Core" is a pricing CATEGORY, not a deployment ` +
+    `type — do not put category values in deployment_types. Fix the keys and retry.`
+  );
+}
 
 const PRICING_FIELDS = [
   "pricing_key",
@@ -29,16 +66,22 @@ function pricingBodyParams(extra: Record<string, unknown> = {}) {
     unit_price: Type.String({ description: 'Unit price as a decimal string, e.g. "15.00"' }),
     unit_price_by_deployment: Type.Optional(
       Type.Record(Type.String(), Type.String(), {
-        description: 'Per-deployment price overrides, e.g. {"autopilot":"18.00"}',
+        description:
+          'Per-deployment price overrides keyed by deployment-type KEY, e.g. {"autopilot":"18.00"}. ' +
+          "Unknown keys are rejected with the valid list.",
       }),
     ),
     category: Type.String({
-      description: "Pricing category (must be a valid UCaaS pricing category)",
+      description:
+        "Pricing category (must be a valid UCaaS pricing category, e.g. Core, Integrations). " +
+        "This is NOT a deployment type.",
     }),
     sort_order: Type.Optional(Type.Number({ description: "Sort order (default 0)" })),
     deployment_types: Type.Optional(
       Type.Array(Type.String(), {
-        description: 'Deployment type keys, e.g. ["autopilot","copilot"]',
+        description:
+          'Deployment type KEYS, e.g. ["autopilot","copilot","bespoke"] — NOT a pricing category ' +
+          'like "Core". Unknown keys are rejected with the valid list.',
       }),
     ),
     is_active: Type.Optional(Type.Boolean({ description: "Active flag (default true)" })),
@@ -105,6 +148,8 @@ export function registerPricingTools(api: OpenClawPluginApi, logger: AuditLogger
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
+            const keyError = await rejectUnknownDeploymentKeys(params);
+            if (keyError) return jsonResult({ ok: false, error: keyError });
             const body = pickBody(params, ["scope_category", ...PRICING_FIELDS]);
             return stageWrite(
               `create pricing default ${params.scope_category as string}/${params.pricing_key as string} @ ${params.unit_price as string}`,
@@ -138,12 +183,20 @@ export function registerPricingTools(api: OpenClawPluginApi, logger: AuditLogger
           unit_price_by_deployment: Type.Optional(Type.Record(Type.String(), Type.String())),
           category: Type.Optional(Type.String()),
           sort_order: Type.Optional(Type.Number()),
-          deployment_types: Type.Optional(Type.Array(Type.String())),
+          deployment_types: Type.Optional(
+            Type.Array(Type.String(), {
+              description:
+                "Deployment type KEYS (e.g. autopilot, copilot, bespoke) — NOT a pricing " +
+                "category. Unknown keys are rejected with the valid list.",
+            }),
+          ),
           is_active: Type.Optional(Type.Boolean()),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
           try {
             const id = params.id as number;
+            const keyError = await rejectUnknownDeploymentKeys(params);
+            if (keyError) return jsonResult({ ok: false, error: keyError });
             const body = pickBody(params, PRICING_FIELDS);
             if (Object.keys(body).length === 0) {
               return jsonResult({ ok: false, error: "No fields to update." });
@@ -232,6 +285,8 @@ export function registerPricingTools(api: OpenClawPluginApi, logger: AuditLogger
           try {
             const vendorKey = params.vendor_key as string;
             const ptPk = params.project_type_id as number;
+            const keyError = await rejectUnknownDeploymentKeys(params);
+            if (keyError) return jsonResult({ ok: false, error: keyError });
             const body = pickBody(params, PRICING_FIELDS);
             return stageWrite(
               `create pricing item ${params.pricing_key as string} on ${vendorKey}/pt ${ptPk} @ ${params.unit_price as string}`,
@@ -268,7 +323,13 @@ export function registerPricingTools(api: OpenClawPluginApi, logger: AuditLogger
           unit_price_by_deployment: Type.Optional(Type.Record(Type.String(), Type.String())),
           category: Type.Optional(Type.String()),
           sort_order: Type.Optional(Type.Number()),
-          deployment_types: Type.Optional(Type.Array(Type.String())),
+          deployment_types: Type.Optional(
+            Type.Array(Type.String(), {
+              description:
+                "Deployment type KEYS (e.g. autopilot, copilot, bespoke) — NOT a pricing " +
+                "category. Unknown keys are rejected with the valid list.",
+            }),
+          ),
           is_active: Type.Optional(Type.Boolean()),
         }),
         async execute(_id: string, params: Record<string, unknown>) {
@@ -276,6 +337,8 @@ export function registerPricingTools(api: OpenClawPluginApi, logger: AuditLogger
             const vendorKey = params.vendor_key as string;
             const ptPk = params.project_type_id as number;
             const id = params.id as number;
+            const keyError = await rejectUnknownDeploymentKeys(params);
+            if (keyError) return jsonResult({ ok: false, error: keyError });
             const body = pickBody(params, PRICING_FIELDS);
             if (Object.keys(body).length === 0) {
               return jsonResult({ ok: false, error: "No fields to update." });

--- a/extensions/scopelybot/src/support-tools.ts
+++ b/extensions/scopelybot/src/support-tools.ts
@@ -5,6 +5,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { AuditLogger } from "./audit.js";
 import { wrapToolWithAudit } from "./audit.js";
 import type { ScopelyBotConfig } from "./config.js";
+import { fetchDeploymentTypeKeys } from "./deployment-keys.js";
 import { traceScopelyLogs, listScopelyServices } from "./devtools-client.js";
 import { stageWrite } from "./gated.js";
 import { buildQuery, errorResult, jsonResult, scopelyFetch } from "./scopely-api.js";
@@ -215,18 +216,14 @@ export function registerSupportTools(
             // returns all-zero counts for an unknown deployment_type value —
             // observed live 2026-07-21 when the model guessed deployment="prod"
             // and confidently reported "0 sessions" against 713 real ones.
-            // Valid keys are data-defined (deployment-type templates), so we
-            // check against the live list instead of hardcoding an enum. Same
-            // self-correction pattern that fixed the S7 container guessing.
+            // Valid keys are data-defined, fetched via the shared helper
+            // (deployment-keys.ts — also guards pricing writes); an empty
+            // list means the lookup failed and we fail open.
             const deployment =
               typeof params.deployment === "string" ? params.deployment.trim() : "";
             if (deployment) {
-              const templates = await scopelyFetch(`/api/admin/deployment-type-templates/`);
-              const rows = Array.isArray(templates.data)
-                ? templates.data
-                : ((asRecord(templates.data).results as unknown[]) ?? []);
-              const validKeys = rows.map((row) => String(asRecord(row).key ?? "")).filter(Boolean);
-              if (templates.ok && validKeys.length > 0 && !validKeys.includes(deployment)) {
+              const validKeys = await fetchDeploymentTypeKeys();
+              if (validKeys.length > 0 && !validKeys.includes(deployment)) {
                 return jsonResult({
                   ok: false,
                   error:


### PR DESCRIPTION
Closes the gap behind today's live find: `deployment_types: ['core']` on pricing items 1080/1081 — the model conflated the pricing category with the deployment-type key space, the backend accepted it, and the rows became silently unpriceable (pricing engine's deployment gate, `services/pricing.py:272` in the scopely repo).

This is the #81 class (grounded-but-wrong param, backend silent) and gets the #81 fix pattern at the tool layer: validate against the live `/api/admin/deployment-type-templates/` list pre-stage, reject with the valid keys named, fail open on lookup error. Shared helper `deployment-keys.ts` now backs both this and the existing session-counts filter validation (one lookup implementation). Category is NOT pre-validated — the backend fails loud there (enum-naming 400, surfaced since #92).

+5 tests incl. the exact incident regression. Suite 260/260; no tsc errors in changed files.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J