### PR TITLE
feat(scopelybot): ungrounded_auth_denial supervisor check

### DIFF
--- a/extensions/scopelybot/src/supervisor.test.ts
+++ b/extensions/scopelybot/src/supervisor.test.ts
@@ -216,6 +216,59 @@ describe("evidence model (prod-verified delivery shape)", () => {
   });
 });
 
+// Live incident 2026-07-21: the model told a write approver — whose CONFIRM
+// had executed the five9 batch minutes earlier — that his account "isn't on
+// the authorized sender list". Zero hard tokens, so no grounding check could
+// see it. Auth-denial claims are deterministically checkable: the model is
+// never in the authorization path, so a denial must trace to a tool auth
+// error or the human's own message describing one.
+describe("ungrounded_auth_denial (v2)", () => {
+  const INCIDENT_DRAFT =
+    "I can’t apply this change from the current account because it isn’t on the authorized " +
+    "sender list. No changes were made to Genesys.";
+  beforeEach(() => {
+    process.env.SCOPELYBOT_SUPERVISOR_V2 = "1";
+  });
+
+  it("blocks the exact live fabrication (no auth failure anywhere this turn)", () => {
+    const v = reviewDraft(INCIDENT_DRAFT, ev({ corpus: "", humanText: "Confimed" }));
+    expect(v).toMatchObject({ ok: false, checkId: "ungrounded_auth_denial" });
+    if (!v.ok) expect(v.instruction).toContain("CONFIRM <code>");
+  });
+
+  it("allows the claim when a tool result actually reported an auth failure", () => {
+    expect(
+      reviewDraft(INCIDENT_DRAFT, ev({ corpus: '{"ok":false,"status":403,"data":"Forbidden"}' })),
+    ).toEqual({ ok: true });
+  });
+
+  it("allows meta-conversation when the human described/pasted the denial", () => {
+    expect(
+      reviewDraft(
+        "The denial you saw — “not recognized as authorized” — refers to the sender mapping.",
+        ev({ corpus: "", humanText: "it told John: not recognized as authorized. why?" }),
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("does not fire on explanations of the approval model (FP corpus)", () => {
+    for (const draft of [
+      "John Rudolph is already configured as a ScopelyBot write approver.",
+      "Only write approvers can confirm staged changes; the system checks this at CONFIRM time.",
+      "Once you reply CONFIRM with the code, the system verifies your identity and applies it.",
+    ]) {
+      expect(reviewDraft(draft, ev({ corpus: "" }))).toEqual({ ok: true });
+    }
+  });
+
+  it("does not fire with the v2 flag off (rollout gate)", () => {
+    delete process.env.SCOPELYBOT_SUPERVISOR_V2;
+    expect(reviewDraft(INCIDENT_DRAFT, ev({ corpus: "", humanText: "Confimed" }))).toEqual({
+      ok: true,
+    });
+  });
+});
+
 describe("ungrounded_claim (v2)", () => {
   beforeEach(() => {
     process.env.SCOPELYBOT_SUPERVISOR_V2 = "1";

--- a/extensions/scopelybot/src/supervisor.ts
+++ b/extensions/scopelybot/src/supervisor.ts
@@ -321,6 +321,27 @@ export function findUngroundedTokens(draft: string, evidence: TurnEvidence): str
   return extractHardTokens(draft).filter((token) => !tokenGrounded(token.toLowerCase(), haystack));
 }
 
+// Sender-authorization DENIAL phrasings (not mere explanations of the
+// approval model — "only approvers can confirm" carries no denial and must
+// not match). Deliberately narrow: each pattern requires an explicit
+// negative-authorization assertion about a sender/account/identity.
+const AUTH_DENIAL_RES: RegExp[] = [
+  // Apostrophes: models emit both ASCII ' and typographic ’ (the live
+  // incident draft used ’) — every contraction class must accept both.
+  /\bnot\s+(?:currently\s+)?(?:recognized\s+as\s+|an?\s+)?authoriz/i, // "not authorized", "not recognized as authorized"
+  /\b(?:is|are)n['’]?t\s+(?:currently\s+)?authoriz/i,
+  // No \b before the n['’]t branch: it must match the TAIL of "isn't"/"aren't".
+  /(?:\bnot|n['’]t)\s+(?:on|in)\s+the\s+(?:authorized|allow|approved)[\w-]*\s*(?:sender\s*)?list/i,
+  /\bunauthorized\s+(?:sender|user|account|identity)\b/i,
+  /\b(?:lacks?|without)\s+(?:the\s+)?(?:required\s+)?(?:authorization|write\s+approval)\b/i,
+];
+
+// Ground truth for a REAL authorization failure this turn: an auth-shaped
+// error in a tool result (401/403/permission language) or the human's own
+// message describing/pasting a denial (meta-conversation is answerable).
+const AUTH_FAILURE_MARKER_RE =
+  /\b40[13]\b|unauthorized|not authorized|forbidden|permission denied|not permitted|access denied|not recognized as authorized/i;
+
 // ---------------------------------------------------------------------------
 // Draft review.
 // ---------------------------------------------------------------------------
@@ -367,6 +388,33 @@ export function reviewDraft(
         "Your reply is raw JSON or contains a large JSON dump. Rewrite it as a plain-language answer: " +
         "lead with the answer, keep only the fields the human asked about, no code blocks.",
     };
+  }
+  // Auth-denial fabrication (live incident 2026-07-21): the model told a
+  // write approver — whose CONFIRM had executed minutes earlier — that his
+  // account "isn't on the authorized sender list". Word-only claims carry no
+  // hard tokens, so the grounding checks below can't see them; this is the
+  // one word-claim CATEGORY checkable deterministically, because the model is
+  // NEVER in the authorization path: the system enforces approval at CONFIRM
+  // time, so any sender-authorization denial the model asserts must trace to
+  // a tool result (401/403/permission error) or to the human's own message
+  // (meta-conversation about a denial they experienced/pasted). Neither →
+  // fabricated by construction.
+  if (supervisorV2Enabled() && AUTH_DENIAL_RES.some((re) => re.test(draft))) {
+    const authHaystack = `${evidence.corpus}\n${evidence.humanText}`.toLowerCase();
+    if (!AUTH_FAILURE_MARKER_RE.test(authHaystack)) {
+      return {
+        ok: false,
+        checkId: "ungrounded_auth_denial",
+        reason: "draft claims an authorization denial with no auth failure in this turn's evidence",
+        instruction:
+          "Your reply claims the sender is not authorized, but no tool result or system message " +
+          "this turn reports any authorization failure — and you are never in the authorization " +
+          "path (the system enforces approval when the user replies CONFIRM <code>). Remove the " +
+          "authorization claim and state what actually happened instead: if the action was never " +
+          "staged, route the request so it stages now; if the user replied something other than " +
+          "`CONFIRM <code>`, explain that exact reply format.",
+      };
+    }
   }
   // A clarifying question back to the human is not a state claim.
   const isShortQuestion = draft.trim().length < 120 && draft.trim().endsWith("?");


### PR DESCRIPTION
Closes the word-claim gap for the authorization category after today's live fabrication (false 'isn't on the authorized sender list' to a working approver). Deterministic: auth-denial phrasing in a draft with no 401/403/permission marker in turn evidence or the human's message = fabricated by construction (the model is never in the auth path). Incident draft pinned as regression; FP corpus for approval-model explanations; meta-conversation (human pasted a denial) passes. Suite 265/265.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J