### PR TITLE
feat(praxis-write): identity-scoped my-issues tools (praxis_my_issues + praxis_my_issue)

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the twelve tools, all optional", () => {
+  it("registers exactly the fourteen tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
@@ -89,12 +89,14 @@ describe("praxis-write registration", () => {
       "praxis_my_issue",
       "praxis_my_issues",
       "praxis_onboard",
+      "praxis_opt_in",
+      "praxis_opt_out",
       "praxis_provide_info",
       "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(12);
+    expect(registerOpts).toHaveLength(14);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -1211,5 +1213,63 @@ describe("praxis_my_issue", () => {
     expect(out.ok).toBe(false);
     expect(out.status).toBe(404);
     expect(out.error).toBe("not_found");
+  });
+});
+
+describe("praxis_opt_in / praxis_opt_out", () => {
+  it("denies opt_in when no requester identity in runtime context", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(await tools.praxis_opt_in.execute("o1", {}));
+    expect(out.denied).toBe("no_requester_identity");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("opt_in POSTs the consent endpoint with the verified runtime identity", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { github_login: "alice-gh", channel: "zoom", consented: true },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_opt_in.execute("o2", {}));
+    expect(out.ok).toBe(true);
+    expect(out.consented).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://praxis:8000/api/v1/my/consent");
+    expect((init as RequestInit).method).toBe("POST");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      channel: "zoom",
+      channel_user_id: "alice",
+    });
+  });
+
+  it("opt_out DELETEs the consent endpoint", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { github_login: "alice-gh", channel: "zoom", consented: false, was_active: true },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_opt_out.execute("o3", {}));
+    expect(out.ok).toBe(true);
+    expect(out.consented).toBe(false);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).method).toBe("DELETE");
+  });
+
+  it("is blocked by the allowlist gate before any fetch", async () => {
+    const { tools } = buildTools({
+      pluginConfig: { allowedUsers: ["someone-else"], allowedChannels: ["dev_praxis"] },
+    });
+    const out = parse(await tools.praxis_opt_in.execute("o4", {}));
+    expect(out.denied).toBe("requester_not_allowlisted");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -78,7 +78,7 @@ afterEach(() => {
 });
 
 describe("praxis-write registration", () => {
-  it("registers exactly the nine write tools, all optional", () => {
+  it("registers exactly the twelve tools, all optional", () => {
     const { tools, registerOpts } = buildTools();
     expect(Object.keys(tools).toSorted()).toEqual([
       "praxis_cancel",
@@ -86,13 +86,15 @@ describe("praxis-write registration", () => {
       "praxis_ingest",
       "praxis_link_github",
       "praxis_link_status",
+      "praxis_my_issue",
+      "praxis_my_issues",
       "praxis_onboard",
       "praxis_provide_info",
       "praxis_self_heal",
       "praxis_submit_verdict",
       "praxis_unblock",
     ]);
-    expect(registerOpts).toHaveLength(10);
+    expect(registerOpts).toHaveLength(12);
     expect(registerOpts.every((o) => o.optional === true)).toBe(true);
   });
 });
@@ -628,7 +630,11 @@ describe("praxis_ingest", () => {
   it("fails closed when the allowlist is unconfigured (no fetch)", async () => {
     const { tools } = buildTools({ pluginConfig: undefined });
     const out = parse(
-      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 1015, reason: "track it" }),
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "track it",
+      }),
     );
     expect(out).toEqual({ ok: false, denied: "write_policy_unconfigured" });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -676,7 +682,11 @@ describe("praxis_ingest", () => {
   it("dry-run previews and makes no HTTP call at all", async () => {
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
-      await tools.praxis_ingest.execute("c1", { full_name: REPO, number: 1015, reason: "track it" }),
+      await tools.praxis_ingest.execute("c1", {
+        full_name: REPO,
+        number: 1015,
+        reason: "track it",
+      }),
     );
     expect(out.preview).toBe(true);
     expect(out.action).toBe("ingest");
@@ -1033,7 +1043,12 @@ describe("praxis_provide_info", () => {
         mockResponse({
           ok: true,
           status: 200,
-          body: { issues: [{ id: 182, source_issue: 65 }, { id: 9, source_issue: 2 }] },
+          body: {
+            issues: [
+              { id: 182, source_issue: 65 },
+              { id: 9, source_issue: 2 },
+            ],
+          },
         }),
       )
       .mockResolvedValueOnce(
@@ -1060,9 +1075,7 @@ describe("praxis_provide_info", () => {
   });
 
   it("returns issue_not_tracked when the ref resolves to nothing", async () => {
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ ok: true, status: 200, body: { issues: [] } }),
-    );
+    fetchMock.mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { issues: [] } }));
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_provide_info.execute("call-8", {
@@ -1101,5 +1114,102 @@ describe("praxis_provide_info", () => {
     expect(out.error).toBe("issue_not_awaiting_info");
     expect(out.state).toBe("in_progress");
     expect(out.message).toContain("in_progress");
+  });
+});
+
+describe("praxis_my_issues", () => {
+  it("denies when no requester identity in runtime context", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: { deliveryContext: { channel: "dev_praxis" } },
+    });
+    const out = parse(await tools.praxis_my_issues.execute("m1", {}));
+    expect(out.denied).toBe("no_requester_identity");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("GETs the identity-scoped my-issues endpoint with the verified runtime identity", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: {
+          github_login: "alice-gh",
+          issues: [
+            {
+              issue_id: 41,
+              ref: "cw/app#10",
+              state: "needs_info",
+              needs_user_action: true,
+              open_question_field: "repro_steps",
+            },
+          ],
+        },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_my_issues.execute("m2", {}));
+    expect(out.ok).toBe(true);
+    expect(out.github_login).toBe("alice-gh");
+    expect(out.issues[0].issue_id).toBe(41);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://praxis:8000/api/v1/my/issues?channel=zoom&channel_user_id=alice");
+    expect((init as RequestInit | undefined)?.method ?? "GET").toBe("GET");
+  });
+
+  it("surfaces identity_not_linked with a praxis_link_github hint", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_my_issues.execute("m3", {}));
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("identity_not_linked");
+    expect(out.hint).toMatch(/praxis_link_github/);
+  });
+
+  it("is blocked by the allowlist gate before any fetch", async () => {
+    const { tools } = buildTools({
+      pluginConfig: { allowedUsers: ["someone-else"], allowedChannels: ["dev_praxis"] },
+    });
+    const out = parse(await tools.praxis_my_issues.execute("m4", {}));
+    expect(out.denied).toBe("requester_not_allowlisted");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("praxis_my_issue", () => {
+  it("requires a positive integer issue_id", async () => {
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_my_issue.execute("d1", {}));
+    expect(out.error).toBe("issue_id_required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("GETs the identity-scoped drill-down and returns the issue", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { github_login: "alice-gh", issue: { issue_id: 41, state: "needs_info" } },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_my_issue.execute("d2", { issue_id: 41 }));
+    expect(out.ok).toBe(true);
+    expect(out.issue.issue_id).toBe(41);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://praxis:8000/api/v1/my/issues/41?channel=zoom&channel_user_id=alice");
+  });
+
+  it("passes through the scoped 404 (cross-user / nonexistent look identical)", async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse({ ok: false, status: 404, body: { error: "not_found" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_my_issue.execute("d3", { issue_id: 999 }));
+    expect(out.ok).toBe(false);
+    expect(out.status).toBe(404);
+    expect(out.error).toBe("not_found");
   });
 });

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -15,6 +15,7 @@ import {
   mintRepoConfirmToken,
   mintSelfHealConfirmToken,
   resolveWritePolicyConfig,
+  type ToolRequestContext,
   type WritePolicyConfig,
 } from "./policy.js";
 import {
@@ -24,6 +25,7 @@ import {
   getLinkStatus,
   getMyIssue,
   getMyIssues,
+  setMyConsent,
   ingestIssue,
   mapStateToUatKindPrefix,
   onboardRepo,
@@ -1141,6 +1143,67 @@ const plugin = {
           return jsonResult({ ok: false, status: res.status, ...body });
         }
         return jsonResult({ ok: true, ...body });
+      },
+    }));
+
+    // Shared body for the two consent tools: identical policy/identity gating, differing only in
+    // opt-in vs opt-out. Takes each tool's own toolContext (registerTool passes it per tool).
+    const runConsentTool = async (
+      toolContext: ToolRequestContext,
+      toolCallId: string,
+      optIn: boolean,
+    ) => {
+      const actor = deriveActorContext(toolContext, toolCallId);
+      const decision = checkPolicy(actor, config);
+      if (!decision.allowed) {
+        return jsonResult({ ok: false, denied: decision.reason });
+      }
+      const channelUserId = actor.requestedBy;
+      if (!channelUserId) {
+        return jsonResult({ ok: false, denied: "no_requester_identity" });
+      }
+      let res: Awaited<ReturnType<typeof setMyConsent>>;
+      try {
+        res = await setMyConsent({
+          channel: "zoom",
+          channel_user_id: channelUserId,
+          opt_in: optIn,
+        });
+      } catch (err) {
+        return errorResult(err);
+      }
+      const body = res.data;
+      if (!res.ok) {
+        return jsonResult({ ok: false, status: res.status, ...body });
+      }
+      return jsonResult({ ok: true, ...body });
+    };
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_opt_in",
+      description:
+        "Opt the chat user IN to proactive Praxis DMs about their issues (a periodic digest of " +
+        "what's on their plate + what needs them). Call this when the user agrees to be kept " +
+        "posted — e.g. 'yes, keep me updated', 'notify me about my issues'. A verified identity " +
+        "alone is NOT consent; Praxis sends nothing proactively until this is set. Uses the " +
+        "verified runtime identity (no model-supplied arguments) and records the user's OWN " +
+        "opt-in. Reversible with praxis_opt_out. Allowlist-gated.",
+      parameters: Type.Object({}),
+      async execute(toolCallId: string, _params: Record<string, unknown>) {
+        return runConsentTool(toolContext, toolCallId, true);
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_opt_out",
+      description:
+        "Opt the chat user OUT of proactive Praxis DMs (stop the periodic digest). Call this when " +
+        "the user asks to stop being messaged / unsubscribe. Uses the verified runtime identity; " +
+        "revokes the user's OWN consent. Reactive answers to their questions are unaffected — " +
+        "this only stops Praxis-initiated messages. Allowlist-gated.",
+      parameters: Type.Object({}),
+      async execute(toolCallId: string, _params: Record<string, unknown>) {
+        return runConsentTool(toolContext, toolCallId, false);
       },
     }));
   },

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -22,6 +22,8 @@ import {
   getApiToken,
   getIssue,
   getLinkStatus,
+  getMyIssue,
+  getMyIssues,
   ingestIssue,
   mapStateToUatKindPrefix,
   onboardRepo,
@@ -1058,6 +1060,87 @@ const plugin = {
             ? `Your Zoom identity is linked to GitHub as ${githubLogin}.`
             : "Your Zoom identity is not linked to a GitHub account yet. Run praxis_link_github to link it.",
         });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_my_issues",
+      description:
+        "List the chat user's OWN open Praxis issues (the ones they reported), across repos — " +
+        "use this when someone asks about 'my issues' / 'my stuff'. Uses the verified runtime " +
+        "identity (no model-supplied arguments); Praxis resolves the linked GitHub login " +
+        "server-side, so a user only ever sees their own issues. Each item carries the internal " +
+        "issue_id that praxis_my_issue / praxis_provide_info / praxis_submit_verdict take, plus " +
+        "needs_user_action + open_question_field so you can lead with what is waiting on them. " +
+        "If the identity is not linked, prompt praxis_link_github. Allowlist-gated.",
+      parameters: Type.Object({}),
+      async execute(toolCallId: string, _params: Record<string, unknown>) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+
+        let res: Awaited<ReturnType<typeof getMyIssues>>;
+        try {
+          res = await getMyIssues({ channel: "zoom", channel_user_id: channelUserId });
+        } catch (err) {
+          return errorResult(err);
+        }
+        const body = res.data;
+        if (!res.ok) {
+          const hint =
+            body?.error === "identity_not_linked"
+              ? "The user's Zoom identity is not linked to GitHub — run praxis_link_github."
+              : undefined;
+          return jsonResult({ ok: false, status: res.status, ...body, ...(hint ? { hint } : {}) });
+        }
+        return jsonResult({ ok: true, ...body });
+      },
+    }));
+
+    optionalApi.registerTool((toolContext) => ({
+      name: "praxis_my_issue",
+      description:
+        "Identity-scoped drill-down into ONE of the chat user's own issues (by internal issue_id " +
+        "from praxis_my_issues). Returns 404 unless the resolved user is that issue's reporter — " +
+        "this is the end-user detail path; NEVER use the org-wide praxis_get_issue for a user " +
+        "asking about their own issue. Allowlist-gated.",
+      parameters: Type.Object({
+        issue_id: Type.Number({ description: "Internal Praxis issue id (from praxis_my_issues)." }),
+      }),
+      async execute(toolCallId: string, params: { issue_id?: number }) {
+        const actor = deriveActorContext(toolContext, toolCallId);
+
+        const decision = checkPolicy(actor, config);
+        if (!decision.allowed) {
+          return jsonResult({ ok: false, denied: decision.reason });
+        }
+        const channelUserId = actor.requestedBy;
+        if (!channelUserId) {
+          return jsonResult({ ok: false, denied: "no_requester_identity" });
+        }
+        const issueId = typeof params.issue_id === "number" ? params.issue_id : Number.NaN;
+        if (!Number.isInteger(issueId) || issueId <= 0) {
+          return jsonResult({ ok: false, error: "issue_id_required" });
+        }
+
+        let res: Awaited<ReturnType<typeof getMyIssue>>;
+        try {
+          res = await getMyIssue(issueId, { channel: "zoom", channel_user_id: channelUserId });
+        } catch (err) {
+          return errorResult(err);
+        }
+        const body = res.data;
+        if (!res.ok) {
+          return jsonResult({ ok: false, status: res.status, ...body });
+        }
+        return jsonResult({ ok: true, ...body });
       },
     }));
   },

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "praxis-write",
   "name": "Praxis Write",
-  "description": "Praxis operator write tools (hardened): onboard a repo, ingest a single untracked GitHub issue, file a self-improvement issue into the Praxis repo, run a self-heal scan that files deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts or relay needs-info answers on behalf of the chat user, or start GitHub account linking. Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/ingest/file-issue/self-heal/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
+  "description": "Praxis operator write tools (hardened): onboard a repo, ingest a single untracked GitHub issue, file a self-improvement issue into the Praxis repo, run a self-heal scan that files deduped GitHub issues, unblock or cancel a stuck issue, submit UAT verdicts or relay needs-info answers on behalf of the chat user, start GitHub account linking, or read the chat user's own issues (identity-scoped my-issues list + drill-down). Default-disabled; each call is allowlist-gated, requires a reason, and onboarding/ingest/file-issue/self-heal/destructive ops run a two-step dry-run/confirm. Authorization binds to the server-side operator; the chat requester is recorded as audit context only.",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -29,6 +29,8 @@
       "praxis_ingest",
       "praxis_link_github",
       "praxis_link_status",
+      "praxis_my_issue",
+      "praxis_my_issues",
       "praxis_onboard",
       "praxis_provide_info",
       "praxis_self_heal",

--- a/extensions/praxis-write/openclaw.plugin.json
+++ b/extensions/praxis-write/openclaw.plugin.json
@@ -32,6 +32,8 @@
       "praxis_my_issue",
       "praxis_my_issues",
       "praxis_onboard",
+      "praxis_opt_in",
+      "praxis_opt_out",
       "praxis_provide_info",
       "praxis_self_heal",
       "praxis_submit_verdict",

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -263,3 +263,30 @@ export async function fileIssue(body: {
     body: JSON.stringify(body),
   });
 }
+
+/** Identity-scoped "my issues" list (Praxis /api/v1/my/issues). The caller forwards only the
+ * verified runtime channel identity; Praxis resolves the GitHub login server-side, so a user can
+ * only ever read their own reported issues. Returns raw result + status for the tool to surface. */
+export async function getMyIssues(params: {
+  channel: string;
+  channel_user_id: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  const qs = new URLSearchParams({
+    channel: params.channel,
+    channel_user_id: params.channel_user_id,
+  }).toString();
+  return praxisFetch<Record<string, unknown>>(`/api/v1/my/issues?${qs}`);
+}
+
+/** Identity-scoped drill-down (Praxis /api/v1/my/issues/{id}): 404 unless the resolved user is
+ * that issue's reporter — the end-user detail path; org-wide /issues/{id} stays operator-only. */
+export async function getMyIssue(
+  issueId: number,
+  params: { channel: string; channel_user_id: string },
+): Promise<PraxisResponse<Record<string, unknown>>> {
+  const qs = new URLSearchParams({
+    channel: params.channel,
+    channel_user_id: params.channel_user_id,
+  }).toString();
+  return praxisFetch<Record<string, unknown>>(`/api/v1/my/issues/${issueId}?${qs}`);
+}

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -290,3 +290,20 @@ export async function getMyIssue(
   }).toString();
   return praxisFetch<Record<string, unknown>>(`/api/v1/my/issues/${issueId}?${qs}`);
 }
+
+/** Self-serve proactive-outreach consent for the caller (Praxis /api/v1/my/consent). `opt_in`
+ * true = POST (opt in), false = DELETE (opt out). Only the verified runtime identity is forwarded;
+ * Praxis resolves the login and records the caller's OWN consent as a user opt-in. */
+export async function setMyConsent(params: {
+  channel: string;
+  channel_user_id: string;
+  opt_in: boolean;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  return praxisFetch<Record<string, unknown>>("/api/v1/my/consent", {
+    method: params.opt_in ? "POST" : "DELETE",
+    body: JSON.stringify({
+      channel: params.channel,
+      channel_user_id: params.channel_user_id,
+    }),
+  });
+}

--- a/skills/praxis/SKILL.md
+++ b/skills/praxis/SKILL.md
@@ -3,9 +3,11 @@ name: praxis
 description: >
   Support and triage for Praxis, the GitHub-issue resolution orchestrator. Diagnose stuck or
   blocked issues, explain why an issue is where it is, and read its event trace — then escalate any
-  fix to a human (this skill is read-only). Use the praxis_* tools.
+  fix to a human (this skill is read-only). Use the praxis_* tools. Also covers the user-scoped
+  conversation flow ("my issues") when the praxis-write plugin is enabled for the agent.
   Triggers: "why is issue X stuck", "diagnose praxis issue", "what's blocking", "praxis status",
-  "is praxis stuck", "check praxis", "list blocked issues", "praxis issue [id]".
+  "is praxis stuck", "check praxis", "list blocked issues", "praxis issue [id]", "my issues",
+  "what's the status of my stuff", "my open issues".
 metadata:
   openclaw:
     emoji: "🩺"
@@ -70,9 +72,34 @@ fuse is why the issue is blocked.
    **None of those are available in this skill.** Tell the human exactly what action is needed and
    who must take it; do not attempt it yourself.
 
+## User-scoped conversation ("my issues")
+
+When someone asks about **their own** issues in a DM ("what's going on with my stuff?", "any of my
+issues need me?"), use the identity-scoped path from the `praxis-write` plugin (if enabled for this
+agent) — it derives the verified Zoom identity from runtime context and Praxis resolves the linked
+GitHub login server-side, so a user only ever sees their own issues:
+
+1. **List** — `praxis_my_issues` (no arguments). Lead with the items where `needs_user_action` is
+   true; each carries the internal `issue_id`, `ref`, `state`, and `open_question_field`.
+2. **Drill down** — `praxis_my_issue` with that `issue_id`. NEVER use the org-wide
+   `praxis_get_issue` / `praxis_list_issues` for a user asking about their own issues — those are
+   operator tools with no per-user scoping.
+3. **Act** — an issue in `needs_info` with an `open_question_field`: collect the missing detail
+   conversationally, then relay it with `praxis_provide_info`. An issue in `user_uat`: ask for
+   their verdict and submit it with `praxis_submit_verdict` (`pass` / `fail <reason>`).
+4. **Unlinked?** — if any of these return `identity_not_linked`, offer `praxis_link_github` and
+   check with `praxis_link_status` after they tap the link.
+
+**Agent configuration note:** an end-user-facing agent should allowlist the user-scoped tools
+(`praxis_my_issues`, `praxis_my_issue`, `praxis_provide_info`, `praxis_submit_verdict`,
+`praxis_link_github`, `praxis_link_status`) and deliberately EXCLUDE the org-wide reads
+(`praxis_list_issues`, `praxis_get_issue`, `praxis_list_events`, `praxis_diagnose_issue`) and the
+operator writes — the allowlist, not this document, is the enforcement.
+
 ## Boundary (read-only)
 
-This skill and its tools only **read** Praxis. There are no unblock/cancel/override/reply tools here
-by design. If your diagnosis concludes a mutation is needed, surface the recommendation and escalate
-to a human operator — never imply you performed it. (Hardened, opt-in write tools are a separate
-future phase, gated behind explicit policy.)
+This skill's own tools only **read** Praxis. There are no unblock/cancel/override tools here by
+design. If your diagnosis concludes a mutation is needed, surface the recommendation and escalate
+to a human operator — never imply you performed it. Hardened, opt-in write tools (verdicts,
+needs-info relay, unblock/cancel, my-issues) live in the separate `praxis-write` plugin, each
+allowlist-gated and identity-bound.


### PR DESCRIPTION
## Summary
The openclaw half of the user-scoped conversational layer: tools that let a chat user ask about *their own* Praxis issues and manage their own proactive-outreach subscription. Pairs with cloudwarriors-ai/praxis#184 (reads) and #185 (consent). All identity-scoped and read/self-only; ship dark until an end-user agent allowlists them.

## What's in it
**Identity-scoped reads**
- **`praxis_my_issues`** (no args) — the caller's own open reported issues; leads with `needs_user_action` items, each carrying the internal `issue_id`.
- **`praxis_my_issue`** (`issue_id`) — identity-scoped drill-down; 404 unless the resolved user is that issue's reporter.

**Self-serve consent** (the conversational opt-in for #185's proactive rail)
- **`praxis_opt_in`** — "yes, keep me posted": records the user's own proactive-outreach consent.
- **`praxis_opt_out`** — "stop messaging me": revokes it. Reactive replies are unaffected.
- Both call `/api/v1/my/consent`; consent is recorded as `user_opt_in`, self-attributed.

Across all four: identity comes **only** from the trusted runtime context (verified Zoom sender), never from model-supplied args — a prompt cannot act as someone else. Praxis resolves the GitHub login server-side. Client fns (`getMyIssues`/`getMyIssue`/`setMyConsent`), manifest entries, and the `skills/praxis` "my issues" playbook updated.

## Boundary
These are user-scoped, self-only surfaces. An end-user-facing agent should allowlist these plus the existing behalf-action tools (`praxis_provide_info`, `praxis_submit_verdict`, link tools) and **exclude** the org-wide operator reads (`praxis_list_issues`, `praxis_get_issue`, `praxis_diagnose_issue`) — the allowlist, not this code, is the enforcement.

## Verification
- Extension tests green (**111/111**); oxfmt clean; 0 `tsgo` errors in `extensions/praxis-write`.
- Rebased onto current `development`; clean replay.
- Proven end-to-end on a local rig: real Zoom DM "keep me posted" → `praxis_opt_in` → Praxis records consent → the proactive digest then flows.

## Reconciliation note
Touches the same files as the unmerged conversation-contract branch (`44b8989`, `codex/praxis-channel-conversation`). A trial merge shows the code auto-merges (disjoint regions — these are new read/consent tools; that work edits the mutating verdict/provide_info tools); only `skills/praxis/SKILL.md` prose overlaps, and it's complementary. Whichever lands second resolves that one prose conflict.

## Pairs with
cloudwarriors-ai/praxis#184 (endpoints these read tools call) and #185 (the consent endpoint the opt-in/out tools call).
