### PR TITLE
fix(scopelybot): thread comfort + CONFIRM prompts at the thread ROOT

### DIFF
--- a/extensions/scopelybot/index.ts
+++ b/extensions/scopelybot/index.ts
@@ -3,7 +3,11 @@ import { registerAdminTools } from "./src/admin-tools.js";
 import { createApproverStore } from "./src/approver-store.js";
 import { registerApproverTools } from "./src/approver-tools.js";
 import { createAuditLogger } from "./src/audit.js";
-import { rememberChannelThreadAnchor, sendComfortMessage } from "./src/comfort.js";
+import {
+  rememberChannelThreadAnchor,
+  resolveInboundThreadAnchor,
+  sendComfortMessage,
+} from "./src/comfort.js";
 import type { ScopelyBotConfig } from "./src/config.js";
 import { configuredWriteApprovers, resolveScopelyBotConfig } from "./src/config.js";
 import { tryExecuteConfirm } from "./src/confirm.js";
@@ -155,12 +159,14 @@ const plugin = {
       }
       const text = typeof event.content === "string" ? event.content : "";
       if (CONFIRM_RE.test(text.trim())) return;
-      const messageId =
-        typeof event.metadata?.messageId === "string" ? event.metadata.messageId : undefined;
-      rememberChannelThreadAnchor(ctx.conversationId, messageId);
+      // Thread at the ROOT: for a thread-reply inbound, metadata.messageId is the
+      // child and metadata.threadId is the root — anchoring at the child makes the
+      // comfort message and the CONFIRM prompt invisible in the thread (2026-07-22).
+      const threadAnchor = resolveInboundThreadAnchor(event.metadata ?? {});
+      rememberChannelThreadAnchor(ctx.conversationId, threadAnchor);
       // Slice 4: the inbound text drives deterministic domain classification
       // (context-aware comfort) and the trivial-greeting skip inside comfort.ts.
-      void sendComfortMessage(ctx.conversationId, messageId, text);
+      void sendComfortMessage(ctx.conversationId, threadAnchor, text);
     });
 
     // Confirm gate execution: a human `CONFIRM <code>` reply runs the staged action.

--- a/extensions/scopelybot/src/comfort.test.ts
+++ b/extensions/scopelybot/src/comfort.test.ts
@@ -13,7 +13,7 @@ vi.hoisted(() => {
   process.env.SCOPELYBOT_ZOOM_CHANNEL = "chan@conference.xmpp.zoom.us";
 });
 
-import { pickComfortText, sendComfortMessage } from "./comfort.js";
+import { pickComfortText, resolveInboundThreadAnchor, sendComfortMessage } from "./comfort.js";
 
 describe("pickComfortText — deterministic domain classification", () => {
   const cases: Array<[string, string]> = [
@@ -74,5 +74,29 @@ describe("sendComfortMessage greeting skip", () => {
       "hi, how many sessions are in progress?",
     );
     expect(fetchMock).toHaveBeenCalled(); // token fetch happened → send path taken
+  });
+});
+
+describe("resolveInboundThreadAnchor — thread-root anchoring (2026-07-22 incident)", () => {
+  // Zoom renders a bot reply inside a thread ONLY when reply_main_message_id is
+  // the thread ROOT. For a thread-reply inbound, messageId is the child message;
+  // threadId (canonical MessageThreadId from the zoom adapter) is the root.
+  it("prefers threadId (root) when the inbound is a thread reply", () => {
+    expect(
+      resolveInboundThreadAnchor({ messageId: "child-msg-id", threadId: "root-msg-id" }),
+    ).toBe("root-msg-id");
+  });
+
+  it("falls back to messageId for a top-level inbound (no threadId)", () => {
+    expect(resolveInboundThreadAnchor({ messageId: "top-level-id" })).toBe("top-level-id");
+  });
+
+  it("returns undefined when neither id is present", () => {
+    expect(resolveInboundThreadAnchor({})).toBeUndefined();
+  });
+
+  it("ignores non-string / blank values", () => {
+    expect(resolveInboundThreadAnchor({ messageId: 42, threadId: "   " })).toBeUndefined();
+    expect(resolveInboundThreadAnchor({ messageId: "m-1", threadId: 99 })).toBe("m-1");
   });
 });

--- a/extensions/scopelybot/src/comfort.ts
+++ b/extensions/scopelybot/src/comfort.ts
@@ -183,6 +183,29 @@ export function rememberChannelThreadAnchor(channelJid: string, messageId?: stri
   threadAnchors.set(channelJid, { messageId, expiresAt: Date.now() + ANCHOR_TTL_MS });
 }
 
+// Resolve which message id a direct send (comfort / CONFIRM prompt) should
+// thread under. Zoom only renders a bot reply inside a thread when its
+// reply_main_message_id is the thread ROOT. For an inbound that is itself a
+// thread reply, metadata.messageId is the CHILD message and metadata.threadId
+// (canonical, from the zoom adapter's MessageThreadId) is the root — anchoring
+// at the child silently orphans the message: it exists via the API but never
+// renders in the thread the humans are watching (live incident 2026-07-22:
+// two CONFIRM prompts "never popped up" and expired unseen). Prefer the root.
+export function resolveInboundThreadAnchor(metadata: {
+  messageId?: unknown;
+  threadId?: unknown;
+}): string | undefined {
+  const threadId =
+    typeof metadata.threadId === "string" && metadata.threadId.trim().length > 0
+      ? metadata.threadId.trim()
+      : undefined;
+  const messageId =
+    typeof metadata.messageId === "string" && metadata.messageId.trim().length > 0
+      ? metadata.messageId.trim()
+      : undefined;
+  return threadId ?? messageId;
+}
+
 export function getChannelThreadAnchor(channelJid: string): string | undefined {
   const entry = threadAnchors.get(channelJid);
   if (!entry) return undefined;


### PR DESCRIPTION
## Live incident (2026-07-22, vipbot_prod)

Chad + John watched a thread where the bot's staged-write CONFIRM prompts "never popped up" — **CONFIRM 6379** (00:48Z) and **CONFIRM 5390** (00:58Z) both existed via the API but never rendered in the thread, and expired unseen. Screenshot-confirmed: the comfort messages were missing from the thread view too.

## Root cause

Zoom renders a bot reply inside a thread **only when `reply_main_message_id` is the thread ROOT**. The scopelybot `message_received` hook anchored its direct sends (comfort message + the deterministic CONFIRM prompt via the channel thread-anchor stash) at the inbound **message id**. When the inbound is itself a thread reply (exactly how PMs work — they reply inside the request thread), the anchor points at the CHILD message → Zoom accepts the API call but orphans the message invisibly.

The core zoom adapter already resolves this correctly for coordinator replies (`resolveZoomReplyMainMessageId` returns the thread parent); only scopelybot's **direct** sends bypassed it.

## Fix

`resolveInboundThreadAnchor(metadata)` — prefers canonical `metadata.threadId` (the zoom adapter's `MessageThreadId` = thread root; chain verified `monitor-handler.ts:2740` → `message-hook-mappers.ts:154` → `:412`) and falls back to `messageId` for top-level inbounds, so the previously-working case is byte-identical. Used for both the comfort reply target and the CONFIRM-prompt thread-anchor stash.

## Evidence

- 4 new tests (root preferred, top-level fallback, absent/blank/non-string guards)
- Suite: **269/269** across the extension
- `tsc --noEmit`: no new errors in changed files (repo AgentTool baseline unchanged)
- Deploy note: bind-mounted TS → prod needs only `git pull` + container restart (no image rebuild); verify no pending CONFIRM before restarting.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J