### PR TITLE
rescue(dev-box): zoom per-channel plainText + fallbackOnSilent opt-ins, dev compose plumbing

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,12 +39,20 @@ services:
     - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
     - CLAWDBOT_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
     - BIGHEAD_API_URL=http://bighead:8000
+    - BIGHEAD_OPS_BASE_URL=${BIGHEAD_OPS_BASE_URL:-http://bighead:8000}
+    - BIGHEAD_OPS_TOKEN=${BIGHEAD_OPS_TOKEN}
+    - PRESALES_PE_OPS_BASE_URL=${PRESALES_PE_OPS_BASE_URL:-http://presales_knowledge_expert:8007}
+    - PRESALES_PE_OPS_TOKEN=${PRESALES_PE_OPS_TOKEN}
     - ZW2_USERNAME=${ZW2_USERNAME}
     - ZW2_PASSWORD=${ZW2_PASSWORD}
     - ZW2_URL=${ZW2_URL}
     - ZOOM_CLIENT_ID=${ZOOM_CLIENT_ID}
     - ZOOM_CLIENT_SECRET=${ZOOM_CLIENT_SECRET}
     - ZOOM_ACCOUNT_ID=${ZOOM_ACCOUNT_ID}
+    # fleet-mcp plugin: zoomteamchat S2S Zoom creds for channel-member lookup
+    - FLEET_ZOOM_CLIENT_ID=${FLEET_ZOOM_CLIENT_ID}
+    - FLEET_ZOOM_CLIENT_SECRET=${FLEET_ZOOM_CLIENT_SECRET}
+    - FLEET_ZOOM_ACCOUNT_ID=${FLEET_ZOOM_ACCOUNT_ID}
     - ZOOM_BOT_JID=${ZOOM_BOT_JID}
     - ZOOM_WEBHOOK_SECRET_TOKEN=${ZOOM_WEBHOOK_SECRET_TOKEN}
     - ZOOM_REPORT_ACCOUNT_ID=${ZOOM_REPORT_ACCOUNT_ID}
@@ -99,16 +107,22 @@ services:
     - PASSTHROUGH_INTERVAL_MS=${PASSTHROUGH_INTERVAL_MS:-}
     - PASSTHROUGH_TEST_TIMEOUT_MS=${PASSTHROUGH_TEST_TIMEOUT_MS:-}
     - OPENCLAW_BUNDLED_PLUGINS_DIR=/app/extensions
+    - PRAXIS_API_URL=http://praxis:8000
+    - PRAXIS_API_TOKEN=${PRAXIS_API_TOKEN}
     - DEVRELAY_URL=${DEVRELAY_URL}
     - DEVRELAY_INSECURE_TLS=${DEVRELAY_INSECURE_TLS}
     - DEVRELAY_TOKEN=${DEVRELAY_TOKEN}
+    - DEVRELAY_IDENTITY=${DEVRELAY_IDENTITY}
     - DEVRELAY_ACTIVITY_ZOOM_CHANNEL=${DEVRELAY_ACTIVITY_ZOOM_CHANNEL}
+    - DEVRELAY_AGENT_ZOOM_CHANNEL=${DEVRELAY_AGENT_ZOOM_CHANNEL}
     volumes:
     - ./extensions:/app/extensions
     - ./src:/app/src
     - ./.data/openclaw:/root/.openclaw
     - ./.data/claude-mem:/root/.claude-mem
     - ./code:/app/code
+    # DevRelay app source, READ-ONLY, for devrelay-bot troubleshooting (read code to locate errors). No write access.
+    - /root/web/devrelay:/app/code/devrelay:ro
     - ./scripts/tests:/app/tests
     ports:
     - 18789:18789
@@ -129,6 +143,9 @@ services:
     # 2048m mirrors the noob-root box's deliberate cap (memory-pressured host).
     # Node heap allows 3072m — the cgroup cap wins; OOM-restart is the accepted
     # tradeoff on the dev box.
+    networks:
+    - default
+    - devrelay_default
     mem_limit: 2048m
     memswap_limit: 4g
     cpus: '4.0'
@@ -142,6 +159,7 @@ services:
     - "noob-root.tailcc6c5f.ts.net:100.114.142.100"
     labels:
     - traefik.enable=true
+    - traefik.docker.network=proxy
     - traefik.http.routers.openclaw.rule=Host(`molty-dev.cloudwarriors.ai`)
     - traefik.http.routers.openclaw.entrypoints=websecure
     - traefik.http.routers.openclaw.tls.certresolver=letsencrypt
@@ -160,4 +178,6 @@ services:
 networks:
   default:
     name: proxy
+    external: true
+  devrelay_default:
     external: true

--- a/extensions/zoom/src/send.ts
+++ b/extensions/zoom/src/send.ts
@@ -297,6 +297,45 @@ function cleanMarkdownUrls(text: string): string {
   return text.replace(/\*\*(https?:\/\/[^\s*]+)\*\*/g, "$1");
 }
 
+/**
+ * Convert common Markdown to clean plain text for Zoom Team Chat. Zoom bot cards render with
+ * is_markdown_support=false, so raw markdown shows as literal junk (e.g. "**bold**", "- bullet",
+ * "## header") and the message reads like a blob. We CONVERT rather than blindly strip, to keep
+ * readability: list markers become "• ", emphasis/headers lose only their markers (text kept), and
+ * links become "text (url)" so the URL stays usable. Applied only when the channel opts in via
+ * ZoomChannelConfig.plainText (see shouldPlainText).
+ */
+function toPlainTextForZoom(input: string): string {
+  let t = input;
+  // Fenced code blocks -> keep inner text, drop the ``` fences.
+  t = t.replace(/```[a-zA-Z0-9]*\n?([\s\S]*?)```/g, "$1");
+  // Headers: "## Title" -> "Title".
+  t = t.replace(/^\s{0,3}#{1,6}\s+/gm, "");
+  // Bullet list markers at line start: "- ", "* ", "+ " -> "• ".
+  t = t.replace(/^(\s*)[-*+]\s+/gm, "$1• ");
+  // Links [text](url) -> "text (url)".
+  t = t.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1 ($2)");
+  // Bold/italic: **x** / __x__ / *x* / _x_ -> x (double markers first).
+  t = t.replace(/\*\*([^*]+)\*\*/g, "$1").replace(/__([^_]+)__/g, "$1");
+  t = t.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1$2").replace(/(^|[^_])_([^_\n]+)_/g, "$1$2");
+  // Strikethrough ~~x~~ -> x.
+  t = t.replace(/~~([^~]+)~~/g, "$1");
+  // Inline code `x` -> x.
+  t = t.replace(/`([^`]+)`/g, "$1");
+  // Collapse 3+ blank lines to a single blank line (tidier in chat).
+  t = t.replace(/\n{3,}/g, "\n\n");
+  return t;
+}
+
+/**
+ * Whether outbound text to `to` should be converted to plain text, per the per-channel
+ * ZoomChannelConfig.plainText opt-in. Returns false (no conversion) for any channel without the
+ * flag, so existing channels/bots are unaffected.
+ */
+function shouldPlainText(zoomCfg: ZoomConfig | undefined, to: string): boolean {
+  return zoomCfg?.channels?.[to]?.plainText === true;
+}
+
 /** Parse mentions and generate at_items */
 function parseMentions(text: string): { cleanText: string; atItems: ZoomAtItem[] } {
   const atItems: ZoomAtItem[] = [];
@@ -352,8 +391,12 @@ export async function sendZoomTextMessage(
   params: SendZoomMessageParams,
 ): Promise<SendZoomMessageResult> {
   const { cfg, isChannel, replyToMessageId, speakerName } = params;
-  const text = cleanMarkdownUrls(params.text);
   const zoomCfg = cfg.channels?.zoom as ZoomConfig | undefined;
+  // Plain-text channels (opt-in via ZoomChannelConfig.plainText) get a full markdown->plaintext
+  // pass; all others keep the original behavior (only URL-bold cleanup).
+  const text = shouldPlainText(zoomCfg, params.to)
+    ? toPlainTextForZoom(cleanMarkdownUrls(params.text))
+    : cleanMarkdownUrls(params.text);
   const creds = resolveZoomCredentials(zoomCfg);
 
   if (!creds) {

--- a/extensions/zoom/src/types.ts
+++ b/extensions/zoom/src/types.ts
@@ -4,6 +4,20 @@ export type ZoomChannelConfig = {
   requireMention?: boolean;
   observeMode?: boolean;
   reviewChannelJid?: string;
+  /**
+   * When true, outbound messages to this channel are converted from Markdown to clean plain text
+   * before send. Zoom Team Chat bot cards do NOT render Markdown (is_markdown_support=false), so
+   * raw markdown (**bold**, "- " bullets, ## headers) otherwise shows as literal junk. Opt-in per
+   * channel; defaults to off so existing channels are unchanged. See toPlainTextForZoom in send.ts.
+   */
+  plainText?: boolean;
+  /**
+   * When true, a silent/empty model reply (which OpenClaw normally DROPS silently) is replaced with
+   * a visible fallback message, so an inbound message in this channel never goes unanswered. Opt-in
+   * per channel; defaults to off so channels/bots that intentionally stay silent (NO_REPLY) are
+   * unaffected. Enforced in src/auto-reply/reply/route-reply.ts (shouldFallbackOnSilent).
+   */
+  fallbackOnSilent?: boolean;
   tools?: {
     allow?: string[];
     deny?: string[];

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -37,6 +37,28 @@ function loadDeliverRuntime() {
   return messageRuntimeLoader.load();
 }
 
+/** Visible fallback shown (only for opted-in channels) when the model produced no reply. */
+const SILENT_REPLY_FALLBACK_TEXT =
+  "I couldn't put together an answer for that — could you rephrase or give me a bit more detail?";
+
+/**
+ * Whether a channel has opted into converting silent/empty replies into a visible fallback
+ * (so an inbound message NEVER goes unanswered). Strictly opt-in per Zoom channel via
+ * `channels.zoom.channels[<jid>].fallbackOnSilent: true`. Any other channel returns false and
+ * keeps the default behavior (silent drop), so bots that intentionally stay quiet are unaffected.
+ */
+function shouldFallbackOnSilent(
+  cfg: OpenClawConfig,
+  channel: OriginatingChannelType,
+  to: string,
+): boolean {
+  if (normalizeMessageChannel(channel) !== "zoom") return false;
+  const zoomCfg = cfg.channels?.zoom as
+    | { channels?: Record<string, { fallbackOnSilent?: boolean } | undefined> }
+    | undefined;
+  return zoomCfg?.channels?.[to]?.fallbackOnSilent === true;
+}
+
 export type RouteReplyParams = {
   /** The reply payload to send. */
   payload: ReplyPayload;
@@ -128,7 +150,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     : cfg.messages?.responsePrefix === "auto"
       ? undefined
       : cfg.messages?.responsePrefix;
-  const normalized = normalizeReplyPayload(payload, {
+  const normalizedInitial = normalizeReplyPayload(payload, {
     responsePrefix,
     transformReplyPayload: messaging?.transformReplyPayload
       ? (nextPayload) =>
@@ -139,6 +161,19 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
           }) ?? nextPayload
       : undefined,
   });
+  // Loud-failure guard (scoped, opt-in): normalizeReplyPayload returns null when the model
+  // produced an empty/NO_REPLY response, which by default drops the reply SILENTLY — the user
+  // sees nothing. For channels that opt in via `channels.zoom.channels[<jid>].fallbackOnSilent`,
+  // we instead substitute a visible fallback so an inbound message ALWAYS gets a reply (no silent
+  // failure). Strictly scoped: any channel without the flag behaves exactly as before (a bot that
+  // intentionally stays silent via NO_REPLY keeps doing so).
+  let normalized = normalizedInitial;
+  if (!normalized && shouldFallbackOnSilent(cfg, channel, to)) {
+    normalized = normalizeReplyPayload(
+      { ...payload, text: SILENT_REPLY_FALLBACK_TEXT },
+      { responsePrefix },
+    );
+  }
   if (!normalized) {
     return { ok: true };
   }


### PR DESCRIPTION
Rescues the dev-box gateway's uncommitted local work (live since 2026-06-23) ahead of the 54-commit development reconcile, so the pull cannot clobber running code. Unblocks the Praxis conversational-layer pilot (#97 rides the reconcile).

## What's in

- **`extensions/zoom/src/send.ts` + `types.ts`** — per-channel `plainText` opt-in: Markdown *converted* (not stripped) to readable plain text for Zoom bot cards (`is_markdown_support=false` renders raw markdown as literal junk). Off by default; only channels with `ZoomChannelConfig.plainText: true` convert.
- **`src/auto-reply/reply/route-reply.ts`** — per-channel `fallbackOnSilent` opt-in: a silent/empty model reply becomes a visible fallback so an inbound message never goes unanswered. Off by default; NO_REPLY-disciplined bots (scopelybot et al.) unaffected.
- **`docker-compose.dev.yml`** — env plumbing for fleet-mcp S2S zoom creds, praxis API URL, bighead/presales ops endpoints. `${VAR}` references only; no secrets.

## Deliberately NOT committed

- `pnpm-lock.yaml` — its local delta embeds workspace importers for six untracked dev-box-local extensions (`devrelay`, `fleet-mcp`, `macd-support`, …); committing would break `pnpm install` on every other checkout. Stays dirty on the box.
- `skills/praxis/SKILL.md` — the local 06-23 edit is the ancestor of the #97 version already on development (verified: upstream contains `praxis_self_heal`/`praxis_ingest`/write-surface text); upstream supersedes it and the local edit is discarded on reconcile.

## Safety

- `extensions/zoom/` and `src/` are untouched by the 54 incoming commits (verified `git diff --stat HEAD origin/development`) — clean merge, no behavior interleaving.
- Both features are strictly opt-in per channel config → zero effect on prod or any deployment that doesn't set the flags.

https://claude.ai/code/session_01TYA9FT3t4nxDYoUEV8T41J