### PR TITLE
praxis-dm relay: thread correlation, verdict redirect, prod-round verdicts

### DIFF
--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 import {
+  conversationIdempotencyKey,
   mintConfirmToken,
   mintFileIssueConfirmToken,
   mintIngestConfirmToken,
@@ -16,9 +17,17 @@ type ToolDef = {
   ) => Promise<{ content: { text: string }[] }>;
 };
 
-const ISSUE = { id: 5, state: "blocked", state_reason: "no_response", version: 12 };
-const ISSUE_DEV_UAT = { id: 7, state: "dev_uat", state_reason: "", version: 3 };
-const ISSUE_USER_UAT = { id: 8, state: "user_uat", state_reason: "", version: 5 };
+const ISSUE = {
+  id: 5,
+  repo: "cw/app",
+  source_issue: 5,
+  state: "blocked",
+  state_reason: "no_response",
+  version: 12,
+  contracts: ["conversation_ack_v1"],
+};
+const ISSUE_DEV_UAT = { ...ISSUE, id: 7, source_issue: 70, state: "dev_uat", version: 3 };
+const ISSUE_USER_UAT = { ...ISSUE, id: 8, source_issue: 80, state: "user_uat", version: 5 };
 
 function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Response {
   return {
@@ -35,6 +44,7 @@ function mockResponse(opts: { ok: boolean; status: number; body: unknown }): Res
 const DEFAULT_CTX = {
   requesterSenderId: "alice",
   deliveryContext: { channel: "dev_praxis", threadId: 1 },
+  currentMessageId: "1",
   sessionId: "s1",
 };
 
@@ -62,6 +72,16 @@ function parse(res: { content: { text: string }[] }) {
 }
 
 const ALLOW_ALICE = { allowedUsers: ["alice"], allowedChannels: ["dev_praxis"] };
+
+function expectedConversationKey(purpose: "verdict" | "info", issueId: number, toolCallId: string) {
+  return conversationIdempotencyKey(purpose, issueId, {
+    requestedBy: "alice",
+    channel: "dev_praxis",
+    messageId: "1",
+    inboundMessageId: "1",
+    toolCallId,
+  });
+}
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -150,7 +170,12 @@ describe("two-step dry-run / confirm", () => {
 
     expect(out.preview).toBe(true);
     expect(out.action).toBe("unblock");
-    expect(out.issue).toEqual(ISSUE);
+    expect(out.issue).toEqual({
+      id: ISSUE.id,
+      state: ISSUE.state,
+      state_reason: ISSUE.state_reason,
+      version: ISSUE.version,
+    });
     expect(typeof out.confirm_token).toBe("string");
     // Exactly one call (the GET) — no POST mutation.
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -269,16 +294,57 @@ describe("praxis_submit_verdict", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects a missing reason before any fetch", async () => {
+  it("requires a concrete summary for fail before any fetch", async () => {
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_submit_verdict.execute("c1", {
         issue_id: 7,
-        verdict: "pass",
+        verdict: "fail",
         reason: "  ",
       }),
     );
-    expect(out).toEqual({ ok: false, error: "reason_required" });
+    expect(out).toEqual({ ok: false, error: "failure_summary_required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails before mutation when the server does not advertise the acknowledgement contract", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { ...ISSUE_DEV_UAT, contracts: undefined },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("contract-gate", {
+        issue_id: 7,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.denied).toBe("server_contract_unconfirmed");
+    expect(out.message).toContain("Upgrade Praxis");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails before mutation when the transport omits a trusted inbound message id", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: {
+        requesterSenderId: "alice",
+        deliveryContext: { channel: "dev_praxis", threadId: 1 },
+        sessionId: "s1",
+      },
+    });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("missing-message-id", {
+        issue_id: 7,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.denied).toBe("inbound_message_id_required");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -303,21 +369,37 @@ describe("praxis_submit_verdict", () => {
     ).toBe(true);
   });
 
-  it("submits uat1_pass for a dev_uat issue with verified Zoom identity", async () => {
+  it("submits a stage-neutral pass for a dev_uat issue with verified Zoom identity", async () => {
     fetchMock
       .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_DEV_UAT }))
       .mockResolvedValueOnce(
-        mockResponse({ ok: true, status: 200, body: { applied: true, state: "done" } }),
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "user_uat",
+            message:
+              "Thanks - I recorded your development pass for cw/app#70. Praxis is moving it to user validation now.",
+          },
+        }),
       );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_submit_verdict.execute("c2", {
         issue_id: 7,
         verdict: "pass",
-        reason: "UAT complete, feature verified",
+        reason: "Validated checkout against build 2026.07.29.",
       }),
     );
-    expect(out).toEqual({ ok: true, status: 200, applied: true, state: "done" });
+    expect(out).toEqual({
+      ok: true,
+      status: 200,
+      applied: true,
+      state: "user_uat",
+      message:
+        "Thanks - I recorded your development pass for cw/app#70. Praxis is moving it to user validation now.",
+    });
 
     const post = fetchMock.mock.calls.find(
       (c: unknown[]) => (c[1] as RequestInit | undefined)?.method === "POST",
@@ -328,26 +410,233 @@ describe("praxis_submit_verdict", () => {
     expect(post[0]).toBe("http://praxis:8000/api/v1/issues/7/events");
     const body = JSON.parse((post[1] as RequestInit).body as string);
     expect(body).toEqual({
-      kind: "uat1_pass",
-      reason: "UAT complete, feature verified",
+      kind: "uat_pass",
+      reason: "Validated checkout against build 2026.07.29.",
       requested_by: "alice",
       channel: "zoom",
       channel_user_id: "alice",
+      message_id: "1",
+      idempotency_key: expectedConversationKey("verdict", 7, "c2"),
+      expected_state: "dev_uat",
+      expected_version: 3,
     });
   });
 
-  it("submits uat2_fail for a user_uat issue", async () => {
+  it("accepts a bare user pass and returns the frozen acknowledgement", async () => {
     fetchMock
       .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
       .mockResolvedValueOnce(
-        mockResponse({ ok: true, status: 200, body: { applied: true, state: "in_progress" } }),
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "done",
+            message: "Thanks - I recorded your pass for cw/app#80. This Praxis run is complete.",
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("bare-pass", {
+        issue_id: 8,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.message).toBe(
+      "Thanks - I recorded your pass for cw/app#80. This Praxis run is complete.",
+    );
+    const post = fetchMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeDefined();
+    if (!post) {
+      throw new Error("expected verdict POST");
+    }
+    const body = JSON.parse((post[1] as RequestInit).body as string);
+    expect(body.reason).toBe("Pass verdict submitted without additional rationale.");
+    expect(body.message_id).toBe("1");
+    expect(body.idempotency_key).toBe(expectedConversationKey("verdict", 8, "bare-pass"));
+  });
+
+  it("relays the server acknowledgement verbatim without deriving identity from the GET response", async () => {
+    const canonical = "Praxis supplied this acknowledgement from its authoritative issue record.";
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { ...ISSUE_USER_UAT, repo: undefined, source_issue: undefined },
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "done", message: canonical },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("fallback-ref", {
+        issue_id: 8,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.message).toBe(canonical);
+  });
+
+  it.each([
+    "api_key=super-secret-value",
+    "gho_123456789012",
+    "github_pat_12345678901234567890",
+    "Bearer abcdefghijklmnop12345678",
+  ])("surfaces Praxis rejection of a secret-shaped failure summary", async (reason) => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          body: { error: "invalid_failure_summary" },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("unsafe", {
+        issue_id: 8,
+        verdict: "fail",
+        reason,
+      }),
+    );
+    expect(out).toMatchObject({
+      ok: false,
+      status: 400,
+      error: "invalid_failure_summary",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a server-rejected failure summary to be corrected for the same inbound message", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          body: { error: "invalid_failure_summary" },
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "in_progress",
+            message:
+              "Thanks - I recorded the failed check for cw/app#80: Checkout remains disabled after reload.\n\nPraxis is sending it back for rework. I'll notify you when another version is ready.",
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+
+    const rejected = parse(
+      await tools.praxis_submit_verdict.execute("invalid-summary", {
+        issue_id: 8,
+        verdict: "fail",
+        reason: "works as expected",
+      }),
+    );
+    const corrected = parse(
+      await tools.praxis_submit_verdict.execute("corrected-summary", {
+        issue_id: 8,
+        verdict: "fail",
+        reason: "Checkout remains disabled after reload.",
+      }),
+    );
+
+    expect(rejected.error).toBe("invalid_failure_summary");
+    expect(corrected.ok).toBe(true);
+    const posts = fetchMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    const firstBody = JSON.parse((posts[0][1] as RequestInit).body as string);
+    const correctedBody = JSON.parse((posts[1][1] as RequestInit).body as string);
+    expect(correctedBody.idempotency_key).toBe(firstBody.idempotency_key);
+    expect(correctedBody.reason).toBe("Checkout remains disabled after reload.");
+  });
+
+  it("surfaces Praxis rejection of a control character in a failure summary", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 400,
+          body: { error: "invalid_failure_summary" },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("unsafe-control", {
+        issue_id: 8,
+        verdict: "fail",
+        reason: "screen went blank\u0001after save",
+      }),
+    );
+    expect(out).toMatchObject({
+      ok: false,
+      status: 400,
+      error: "invalid_failure_summary",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not claim a verdict was recorded without applied or idempotent confirmation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: false, state: "user_uat" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("unconfirmed", {
+        issue_id: 8,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("verdict_not_confirmed");
+    expect(out.retryable).toBe(false);
+    expect(out.message).toContain("Do not retry");
+  });
+
+  it("submits a stage-neutral fail for a user_uat issue", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "in_progress",
+            message:
+              "Thanks - I recorded the failed check for cw/app#80: Bearer token refresh still fails after login\n\nPraxis is sending it back for rework. I'll notify you when another version is ready.",
+          },
+        }),
       );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_submit_verdict.execute("c3", {
         issue_id: 8,
         verdict: "fail",
-        reason: "button still broken",
+        reason: "Bearer token refresh still fails after login",
       }),
     );
     expect(out.ok).toBe(true);
@@ -359,9 +648,84 @@ describe("praxis_submit_verdict", () => {
       throw new Error("expected a POST call");
     }
     const body = JSON.parse((post[1] as RequestInit).body as string);
-    expect(body.kind).toBe("uat2_fail");
+    expect(body.kind).toBe("uat_fail");
+    expect(out.message).toContain("cw/app#80: Bearer token refresh still fails after login");
     expect(body.channel).toBe("zoom");
     expect(body.channel_user_id).toBe("alice");
+    expect(body.message_id).toBe("1");
+    expect(body.idempotency_key).toBe(expectedConversationKey("verdict", 8, "c3"));
+  });
+
+  it("fails closed when Praxis confirms the verdict but omits canonical acknowledgement copy", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "done" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("missing-ack", {
+        issue_id: 8,
+        verdict: "pass",
+      }),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("acknowledgement_missing");
+    expect(out.mutation_recorded).toBe(true);
+    expect(out.retryable).toBe(false);
+    expect(out.message).toContain("did not return canonical acknowledgement");
+  });
+
+  it("keeps the same idempotency key when an ambiguous dev pass is retried after state advances", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_DEV_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "user_uat" } }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: false,
+            idempotent: true,
+            state: "user_uat",
+            message:
+              "Thanks - I recorded your development pass for cw/app#70. Praxis is moving it to user validation now.",
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+
+    const first = parse(
+      await tools.praxis_submit_verdict.execute("tool-first", {
+        issue_id: 7,
+        verdict: "pass",
+      }),
+    );
+    const retry = parse(
+      await tools.praxis_submit_verdict.execute("tool-retry", {
+        issue_id: 7,
+        verdict: "fail",
+        reason: "A regenerated tool call misread the same human message.",
+      }),
+    );
+
+    expect(first.error).toBe("acknowledgement_missing");
+    expect(retry.ok).toBe(true);
+    expect(retry.message).toContain("development pass");
+    const posts = fetchMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    const firstBody = JSON.parse((posts[0][1] as RequestInit).body as string);
+    const retryBody = JSON.parse((posts[1][1] as RequestInit).body as string);
+    expect(firstBody.kind).toBe("uat_pass");
+    expect(firstBody.reason).toBe("Pass verdict submitted without additional rationale.");
+    expect(retryBody.kind).toBe("uat_pass");
+    expect(retryBody).toEqual(firstBody);
+    expect(retryBody.idempotency_key).toBe(firstBody.idempotency_key);
   });
 
   it("surfaces identity_not_linked with a link instruction", async () => {
@@ -1011,10 +1375,63 @@ describe("praxis_provide_info", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("posts kind=info_provided with the trusted Zoom identity and the toolCallId as idempotency key", async () => {
-    fetchMock.mockResolvedValue(
-      mockResponse({ ok: true, status: 200, body: { applied: true, state: "assessing" } }),
+  it("fails before mutation when the server does not advertise the acknowledgement contract", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: true,
+        status: 200,
+        body: { ...ISSUE, id: 7, contracts: undefined },
+      }),
     );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("contract-gate", {
+        issue_id: 7,
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(out.denied).toBe("server_contract_unconfirmed");
+    expect(out.message).toContain("Upgrade Praxis");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails before mutation when the transport omits a trusted inbound message id", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: {
+        requesterSenderId: "alice",
+        deliveryContext: { channel: "dev_praxis", threadId: 1 },
+        sessionId: "s1",
+      },
+    });
+    const out = parse(
+      await tools.praxis_provide_info.execute("missing-message-id", {
+        issue_id: 7,
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(out.denied).toBe("inbound_message_id_required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts info with trusted Zoom identity and inbound-message idempotency", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7, source_issue: 70 } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "assessing",
+            message: "Thanks - I recorded that information. Praxis is reassessing cw/app#70 now.",
+          },
+        }),
+      );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_provide_info.execute("call-42", {
@@ -1024,8 +1441,12 @@ describe("praxis_provide_info", () => {
     );
     expect(out.ok).toBe(true);
     expect(out.applied).toBe(true);
+    expect(out.message).toBe(
+      "Thanks - I recorded that information. Praxis is reassessing cw/app#70 now.",
+    );
 
-    const [url, init] = fetchMock.mock.calls[0];
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchMock.mock.calls[1];
     expect(url).toBe("http://praxis:8000/api/v1/issues/7/events");
     expect((init as RequestInit).method).toBe("POST");
     const sent = JSON.parse((init as RequestInit).body as string);
@@ -1035,7 +1456,8 @@ describe("praxis_provide_info", () => {
       requested_by: "alice",
       channel: "zoom",
       channel_user_id: "alice",
-      idempotency_key: "call-42",
+      message_id: "1",
+      idempotency_key: expectedConversationKey("info", 7, "call-42"),
     });
   });
 
@@ -1053,8 +1475,18 @@ describe("praxis_provide_info", () => {
           },
         }),
       )
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 182 } }))
       .mockResolvedValueOnce(
-        mockResponse({ ok: true, status: 200, body: { applied: true, state: "assessing" } }),
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "assessing",
+            message:
+              "Thanks - I recorded that information. Praxis is reassessing cloudwarriors-ai/praxis-e2e-sandbox#65 now.",
+          },
+        }),
       );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
@@ -1069,11 +1501,135 @@ describe("praxis_provide_info", () => {
     expect(lookupUrl).toBe(
       "http://praxis:8000/api/v1/issues?repo=cloudwarriors-ai%2Fpraxis-e2e-sandbox",
     );
-    const [postUrl, postInit] = fetchMock.mock.calls[1];
+    const [capabilityUrl] = fetchMock.mock.calls[1];
+    expect(capabilityUrl).toBe("http://praxis:8000/api/v1/issues/182");
+    const [postUrl, postInit] = fetchMock.mock.calls[2];
     expect(postUrl).toBe("http://praxis:8000/api/v1/issues/182/events");
     const sent = JSON.parse((postInit as RequestInit).body as string);
     expect(sent.kind).toBe("info_provided");
     expect(sent.channel_user_id).toBe("alice");
+    expect(out.message).toBe(
+      "Thanks - I recorded that information. Praxis is reassessing cloudwarriors-ai/praxis-e2e-sandbox#65 now.",
+    );
+  });
+
+  it("does not mislabel an issue-id write with a conflicting model-supplied ref", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7, source_issue: 70 } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: true,
+            state: "assessing",
+            message: "Thanks - I recorded that information. Praxis is reassessing cw/app#70 now.",
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("call-8", {
+        issue_id: 7,
+        issue: "cw/wrong#999",
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://praxis:8000/api/v1/issues/7");
+    expect(fetchMock.mock.calls[1][0]).toBe("http://praxis:8000/api/v1/issues/7/events");
+    expect(out.message).toBe(
+      "Thanks - I recorded that information. Praxis is reassessing cw/app#70 now.",
+    );
+  });
+
+  it("does not claim an answer was recorded without applied or idempotent confirmation", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: false, state: "needs_info" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("unconfirmed", {
+        issue_id: 7,
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("answer_not_confirmed");
+    expect(out.retryable).toBe(false);
+    expect(out.message).toContain("Do not retry");
+  });
+
+  it("fails closed when Praxis confirms the answer but omits canonical acknowledgement copy", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: true, state: "assessing" } }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("missing-info-ack", {
+        issue_id: 7,
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("acknowledgement_missing");
+    expect(out.mutation_recorded).toBe(true);
+    expect(out.retryable).toBe(false);
+    expect(out.message).toContain("did not return canonical acknowledgement");
+  });
+
+  it("reuses the first answer payload when the same inbound message is retried differently", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { applied: false, state: "needs_info" } }),
+      )
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: {
+            applied: false,
+            idempotent: true,
+            state: "assessing",
+            message: "Thanks - I recorded that information. Praxis is reassessing cw/app#70 now.",
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+
+    const first = parse(
+      await tools.praxis_provide_info.execute("info-first", {
+        issue_id: 7,
+        answer: "Checkout fails after selecting annual billing.",
+      }),
+    );
+    const retry = parse(
+      await tools.praxis_provide_info.execute("info-retry", {
+        issue_id: 7,
+        answer: "A regenerated tool call paraphrased the human differently.",
+      }),
+    );
+
+    expect(first.error).toBe("answer_not_confirmed");
+    expect(retry.ok).toBe(true);
+    const posts = fetchMock.mock.calls.filter(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    const firstBody = JSON.parse((posts[0][1] as RequestInit).body as string);
+    const retryBody = JSON.parse((posts[1][1] as RequestInit).body as string);
+    expect(retryBody).toEqual(firstBody);
+    expect(firstBody.reason).toBe("Checkout fails after selecting annual billing.");
   });
 
   it("returns issue_not_tracked when the ref resolves to nothing", async () => {
@@ -1089,10 +1645,33 @@ describe("praxis_provide_info", () => {
     expect(out.message).toContain("cw/app#404");
   });
 
-  it("surfaces identity_not_linked with the link instruction", async () => {
-    fetchMock.mockResolvedValue(
-      mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
+  it("preserves the structured 404 body for a stale numeric issue id", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 404, body: { detail: "Not found." } }),
     );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("stale-id", {
+        issue_id: 999999,
+        answer: "the checkout page",
+      }),
+    );
+
+    expect(out).toEqual({
+      ok: false,
+      status: 404,
+      detail: "Not found.",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://praxis:8000/api/v1/issues/999999");
+  });
+
+  it("surfaces identity_not_linked with the link instruction", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
+      );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_provide_info.execute("c3", { issue_id: 7, answer: "the login page" }),
@@ -1102,13 +1681,15 @@ describe("praxis_provide_info", () => {
   });
 
   it("surfaces issue_not_awaiting_info with the issue state", async () => {
-    fetchMock.mockResolvedValue(
-      mockResponse({
-        ok: false,
-        status: 409,
-        body: { error: "issue_not_awaiting_info", state: "in_progress" },
-      }),
-    );
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 7 } }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 409,
+          body: { error: "issue_not_awaiting_info", state: "in_progress" },
+        }),
+      );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(
       await tools.praxis_provide_info.execute("c4", { issue_id: 7, answer: "the login page" }),

--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1967,3 +1967,98 @@ describe("thread-correlated issue resolution", () => {
     expect(body.reason).toBe("Expected: the timer freezes at the final time.");
   });
 });
+
+describe("open-ask issue resolution (no thread, no explicit issue)", () => {
+  const OPEN_ASK = {
+    github_login: "alice-gh",
+    issue: { issue_id: 42, ref: "cw/app#420", state: "needs_info" },
+  };
+  // No threadId in context: forces the ladder down to the open-ask rung.
+  const CTX_NO_THREAD = {
+    requesterSenderId: "alice",
+    deliveryContext: { channel: "dev_praxis" },
+    currentMessageId: "1",
+    sessionId: "s1",
+  };
+
+  it("resolves the waiting issue from the server instead of guessing", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: OPEN_ASK }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 42, state: "needs_info" } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "assessing", message: "Answer recorded for cw/app#420." },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE, toolContext: CTX_NO_THREAD });
+    const out = parse(
+      await tools.praxis_provide_info.execute("open-ask", { answer: "the right face is blue" }),
+    );
+    expect(out.ok).toBe(true);
+    expect(out.resolved_from_open_ask).toBe("cw/app#420");
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/api/v1/my/open-ask");
+    const post = fetchMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(String(post?.[0])).toContain("/api/v1/issues/42/events");
+  });
+
+  it("refuses with the candidate list when two issues are waiting, and mutates nothing", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 409,
+        body: {
+          error: "ambiguous_open_ask",
+          candidates: [{ ref: "cw/app#420" }, { ref: "cw/app#421" }],
+        },
+      }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE, toolContext: CTX_NO_THREAD });
+    const out = parse(
+      await tools.praxis_provide_info.execute("ambiguous", { answer: "colors are wrong" }),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("ambiguous_open_ask");
+    expect(out.candidates).toEqual(["cw/app#420", "cw/app#421"]);
+    // Exactly one call: the resolver. No issue GET, no event POST.
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
+  it("refuses when nothing is waiting on the user", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 404, body: { error: "no_open_ask" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE, toolContext: CTX_NO_THREAD });
+    const out = parse(
+      await tools.praxis_provide_info.execute("none-waiting", { answer: "anything" }),
+    );
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("issue_required");
+  });
+
+  it("an explicit issue_id still short-circuits the resolver entirely", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 5, state: "needs_info" } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "assessing", message: "Recorded." },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE, toolContext: CTX_NO_THREAD });
+    const out = parse(
+      await tools.praxis_provide_info.execute("explicit", { issue_id: 5, answer: "detail" }),
+    );
+    expect(out.ok).toBe(true);
+    const urls = fetchMock.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(urls.some((u: string) => u.includes("/my/open-ask"))).toBe(false);
+  });
+});

--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1854,3 +1854,116 @@ describe("praxis_opt_in / praxis_opt_out", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+describe("thread-correlated issue resolution", () => {
+  const THREAD_RESOLVED = {
+    github_login: "alice-gh",
+    issue: { issue_id: 8, ref: "cw/app#80", state: "user_uat", needs_user_action: true },
+  };
+
+  it("submit_verdict resolves the issue from the trusted reply thread when issue_id is omitted", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: THREAD_RESOLVED }))
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "done", message: "Recorded your pass for cw/app#80." },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("thread-pass", { verdict: "pass" }),
+    );
+
+    expect(out.ok).toBe(true);
+    expect(out.resolved_from_thread).toBe("cw/app#80");
+    // First call resolves the thread with the runtime-provided id, never a model value.
+    const resolveUrl = String(fetchMock.mock.calls[0][0]);
+    expect(resolveUrl).toContain("/api/v1/my/thread-issue");
+    expect(resolveUrl).toContain("thread_ref=1");
+    expect(resolveUrl).toContain("channel_user_id=alice");
+    // The verdict lands on the RESOLVED issue id.
+    const post = fetchMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(String(post?.[0])).toContain("/api/v1/issues/8/events");
+  });
+
+  it("submit_verdict with an explicit issue_id never queries the thread resolver", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: ISSUE_USER_UAT }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "done", message: "Recorded." },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_submit_verdict.execute("explicit-wins", { issue_id: 8, verdict: "pass" }),
+    );
+    expect(out.ok).toBe(true);
+    const urls = fetchMock.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(urls.some((u: string) => u.includes("/my/thread-issue"))).toBe(false);
+  });
+
+  it("submit_verdict without issue_id outside a resolvable thread asks for lookup", async () => {
+    // Unknown thread: resolver 404s -> fail closed with guidance, nothing mutated.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 404, body: { error: "not_found" } }),
+    );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_submit_verdict.execute("no-thread", { verdict: "pass" }));
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("issue_required");
+    expect(fetchMock.mock.calls.length).toBe(1);
+  });
+
+  it("submit_verdict without issue_id and without a threadId in context asks for lookup without any fetch", async () => {
+    const { tools } = buildTools({
+      pluginConfig: ALLOW_ALICE,
+      toolContext: {
+        requesterSenderId: "alice",
+        deliveryContext: { channel: "dev_praxis" },
+        currentMessageId: "1",
+        sessionId: "s1",
+      },
+    });
+    const out = parse(await tools.praxis_submit_verdict.execute("no-ctx", { verdict: "pass" }));
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("issue_required");
+    expect(fetchMock.mock.calls.length).toBe(0);
+  });
+
+  it("provide_info resolves the issue from the trusted reply thread when no ref is given", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: true, status: 200, body: THREAD_RESOLVED }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: true, status: 200, body: { ...ISSUE, id: 8, state: "needs_info" } }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { applied: true, state: "assessing", message: "Answer recorded for cw/app#80." },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(
+      await tools.praxis_provide_info.execute("thread-answer", {
+        answer: "Expected: the timer freezes at the final time.",
+      }),
+    );
+    expect(out.ok).toBe(true);
+    expect(out.resolved_from_thread).toBe("cw/app#80");
+    const post = fetchMock.mock.calls.find(
+      (call: unknown[]) => (call[1] as RequestInit | undefined)?.method === "POST",
+    );
+    expect(String(post?.[0])).toContain("/api/v1/issues/8/events");
+    const body = JSON.parse((post?.[1] as RequestInit).body as string);
+    expect(body.reason).toBe("Expected: the timer freezes at the final time.");
+  });
+});

--- a/extensions/praxis-write/index.test.ts
+++ b/extensions/praxis-write/index.test.ts
@@ -1911,15 +1911,63 @@ describe("thread-correlated issue resolution", () => {
   });
 
   it("submit_verdict without issue_id outside a resolvable thread asks for lookup", async () => {
-    // Unknown thread: resolver 404s -> fail closed with guidance, nothing mutated.
-    fetchMock.mockResolvedValueOnce(
-      mockResponse({ ok: false, status: 404, body: { error: "not_found" } }),
-    );
+    // Unknown thread: resolver 404s, then the open-ask rung also finds nothing -> fail closed
+    // with guidance, nothing mutated. TWO probes now (thread, then open-ask) — the second rung
+    // was added 2026-08-05 so a wrong-tool guess still finds the waiting issue.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 404, body: { error: "not_found" } }))
+      .mockResolvedValueOnce(
+        mockResponse({ ok: false, status: 404, body: { error: "no_open_ask" } }),
+      );
     const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
     const out = parse(await tools.praxis_submit_verdict.execute("no-thread", { verdict: "pass" }));
     expect(out.ok).toBe(false);
     expect(out.error).toBe("issue_required");
-    expect(fetchMock.mock.calls.length).toBe(1);
+    expect(fetchMock.mock.calls.length).toBe(2);
+  });
+
+  it("submit_verdict redirects to provide_info when the issue awaits an ANSWER", async () => {
+    // A PraxisQuestion row only ever exists for a needs-info ask (UAT asks create none), so an
+    // open-ask hit PROVES this is an answer misfiled as a verdict. Redirect instead of submitting
+    // something the reducer would refuse — and never make the user repeat themselves.
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 404, body: { error: "not_found" } }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: true,
+          status: 200,
+          body: { issue: { issue_id: 225, ref: "cw/app#36", state: "needs_info" } },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_submit_verdict.execute("redirect", { verdict: "pass" }));
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("answer_expected");
+    expect(out.issue_id).toBe(225);
+    expect(out.ref).toBe("cw/app#36");
+    expect(String(out.message)).toContain("praxis_provide_info");
+    // Nothing was mutated: only the two resolution probes ran.
+    expect(fetchMock.mock.calls.length).toBe(2);
+  });
+
+  it("submit_verdict surfaces candidates instead of guessing when the open ask is ambiguous", async () => {
+    fetchMock
+      .mockResolvedValueOnce(mockResponse({ ok: false, status: 404, body: { error: "not_found" } }))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 409,
+          body: {
+            error: "ambiguous_open_ask",
+            candidates: [{ ref: "cw/app#36" }, { ref: "cw/app#41" }],
+          },
+        }),
+      );
+    const { tools } = buildTools({ pluginConfig: ALLOW_ALICE });
+    const out = parse(await tools.praxis_submit_verdict.execute("ambig", { verdict: "pass" }));
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe("ambiguous_open_ask");
+    expect(out.candidates).toEqual(["cw/app#36", "cw/app#41"]);
   });
 
   it("submit_verdict without issue_id and without a threadId in context asks for lookup without any fetch", async () => {
@@ -1932,10 +1980,15 @@ describe("thread-correlated issue resolution", () => {
         sessionId: "s1",
       },
     });
+    // No thread context at all, so the thread rung is skipped entirely; the open-ask rung still
+    // runs (one probe) before failing closed. Was 0 probes before 2026-08-05.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({ ok: false, status: 404, body: { error: "no_open_ask" } }),
+    );
     const out = parse(await tools.praxis_submit_verdict.execute("no-ctx", { verdict: "pass" }));
     expect(out.ok).toBe(false);
     expect(out.error).toBe("issue_required");
-    expect(fetchMock.mock.calls.length).toBe(0);
+    expect(fetchMock.mock.calls.length).toBe(1);
   });
 
   it("provide_info resolves the issue from the trusted reply thread when no ref is given", async () => {

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -250,7 +250,7 @@ const plugin = {
       {
         kind: UatVerdictKind;
         reason: string;
-        expected_state: "dev_uat" | "user_uat";
+        expected_state: "dev_uat" | "user_uat" | "prod_uat";
         expected_version: number;
       }
     >();
@@ -932,7 +932,7 @@ const plugin = {
             ok: false,
             error: "issue_not_awaiting_verdict",
             state: issue.state,
-            message: `Issue #${issueId} is not awaiting a UAT verdict (state=${issue.state}). Only issues in dev_uat or user_uat can receive a verdict.`,
+            message: `Issue #${issueId} is not awaiting a UAT verdict (state=${issue.state}). Only issues in dev_uat, user_uat, or prod_uat can receive a verdict.`,
           });
         }
 
@@ -948,7 +948,7 @@ const plugin = {
           intent = {
             kind: proposedKind,
             reason: proposedReason,
-            expected_state: issue.state as "dev_uat" | "user_uat",
+            expected_state: issue.state as "dev_uat" | "user_uat" | "prod_uat",
             expected_version: issue.version,
           };
           verdictIntents.set(conversationKey, intent);

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -36,6 +36,7 @@ import {
   startGithubLink,
   submitCommand,
   resolveIssueRef,
+  resolveOpenAsk,
   resolveThreadIssue,
   submitNeedsInfoAnswer,
   submitVerdict,
@@ -98,6 +99,34 @@ async function resolveIssueFromReplyThread(
     return null;
   }
   if (!res.ok) {
+    return null;
+  }
+  const issue = (res.data as { issue?: Record<string, unknown> }).issue;
+  const issueId = Number(issue?.issue_id);
+  if (!Number.isInteger(issueId) || issueId <= 0) {
+    return null;
+  }
+  return { issueId, ref: String(issue?.ref ?? "") };
+}
+
+/** Resolve the issue from the server's OPEN-ASK set — the last inference removed from the model.
+ * Praxis returns the single issue with a question addressed to this identity; several candidates
+ * refuse (ambiguous) rather than pick, and the caller surfaces the list to the human. Returns
+ * {issueId, ref} on a clean resolve, {ambiguous} when the human must choose, null otherwise. */
+async function resolveIssueFromOpenAsk(
+  channelUserId: string,
+): Promise<{ issueId?: number; ref?: string; ambiguous?: string[] } | null> {
+  let res: Awaited<ReturnType<typeof resolveOpenAsk>>;
+  try {
+    res = await resolveOpenAsk({ channel: "zoom", channel_user_id: channelUserId });
+  } catch {
+    return null;
+  }
+  if (!res.ok) {
+    const data = res.data as { error?: string; candidates?: { ref?: string }[] };
+    if (data?.error === "ambiguous_open_ask") {
+      return { ambiguous: (data.candidates ?? []).map((c) => String(c.ref ?? "")).filter(Boolean) };
+    }
     return null;
   }
   const issue = (res.data as { issue?: Record<string, unknown> }).issue;
@@ -1065,13 +1094,34 @@ const plugin = {
         if (!hasExplicit && fromThread) {
           issueId = fromThread.issueId;
         }
+        // Last rung: the server's open-ask set. An answer with no thread and no named issue
+        // belongs to whichever issue is actually WAITING on this person — resolved from data,
+        // never from the model's memory of the conversation.
+        let fromOpenAsk: Awaited<ReturnType<typeof resolveIssueFromOpenAsk>> = null;
+        if (!hasExplicit && !fromThread) {
+          fromOpenAsk = await resolveIssueFromOpenAsk(channelUserId);
+          if (fromOpenAsk?.ambiguous?.length) {
+            return jsonResult({
+              ok: false,
+              error: "ambiguous_open_ask",
+              candidates: fromOpenAsk.ambiguous,
+              message:
+                "More than one issue is waiting on you: " +
+                `${fromOpenAsk.ambiguous.join(", ")}. Ask which one this answers, then call ` +
+                "again with that issue.",
+            });
+          }
+          if (fromOpenAsk?.issueId) {
+            issueId = fromOpenAsk.issueId;
+          }
+        }
         if (!Number.isInteger(issueId) || issueId <= 0) {
           return jsonResult({
             ok: false,
             error: "issue_required",
             message:
-              "No issue was given and this message is not a reply in a Praxis ask's thread. " +
-              "Call praxis_my_issues to find the issue with the open question, then retry.",
+              "No issue was given, this message is not a reply in a Praxis ask's thread, and " +
+              "nothing is currently waiting on you. Call praxis_my_issues to check status.",
           });
         }
         let issueResponse: Awaited<ReturnType<typeof getIssueResponse>>;
@@ -1182,6 +1232,7 @@ const plugin = {
           ok: res.ok,
           status: res.status,
           ...(fromThread ? { resolved_from_thread: fromThread.ref } : {}),
+          ...(fromOpenAsk?.ref ? { resolved_from_open_ask: fromOpenAsk.ref } : {}),
           ...res.data,
         });
       },

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -854,12 +854,42 @@ const plugin = {
           : await resolveIssueFromReplyThread(toolContext, channelUserId);
         const issueId = hasExplicit ? explicitId : (fromThread?.issueId ?? 0);
         if (!Number.isInteger(issueId) || issueId <= 0) {
+          // Last rung, and it is a REDIRECT rather than parity with praxis_provide_info.
+          // `PraxisQuestion` rows are only ever created for needs-info asks (UAT verdict asks
+          // create none), so an open-ask hit PROVES the issue is waiting on an ANSWER, not a
+          // verdict — submitting one here would just be refused by the reducer. Turning the
+          // wrong-tool guess into the right instruction is the whole point: on 2026-08-05 the
+          // model chose this tool for an answer and the user had to be asked twice.
+          const fromOpenAsk = await resolveIssueFromOpenAsk(channelUserId);
+          if (fromOpenAsk?.ambiguous?.length) {
+            return jsonResult({
+              ok: false,
+              error: "ambiguous_open_ask",
+              candidates: fromOpenAsk.ambiguous,
+              message:
+                "More than one issue is waiting on you: " +
+                `${fromOpenAsk.ambiguous.join(", ")}. Ask which one this refers to, then call again.`,
+            });
+          }
+          if (fromOpenAsk?.issueId) {
+            return jsonResult({
+              ok: false,
+              error: "answer_expected",
+              issue_id: fromOpenAsk.issueId,
+              ref: fromOpenAsk.ref,
+              message:
+                `${fromOpenAsk.ref || "That issue"} is waiting for an ANSWER to an open question, ` +
+                "not a UAT verdict. Call praxis_provide_info with the user's message verbatim — " +
+                "do not ask them to repeat it.",
+            });
+          }
           return jsonResult({
             ok: false,
             error: "issue_required",
             message:
-              "No issue_id was given and this message is not a reply in a Praxis ask's thread. " +
-              "Call praxis_my_issues to find the issue awaiting a verdict, then retry.",
+              "No issue_id was given, the reply thread did not resolve to a Praxis ask, and " +
+              "nothing is waiting on you. Call praxis_my_issues to find the issue awaiting a " +
+              "verdict, then retry with its issue_id.",
           });
         }
         if (!actor.inboundMessageId) {

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import {
   type ActorContext,
   checkPolicy,
+  conversationIdempotencyKey,
   confirmTokenMatches,
   deriveActorContext,
   idempotencyKey,
@@ -22,6 +23,7 @@ import {
   fileIssue,
   getApiToken,
   getIssue,
+  getIssueResponse,
   getLinkStatus,
   getMyIssue,
   getMyIssues,
@@ -44,10 +46,9 @@ import {
 // rejected server-side too. `unblock` is its own tool.
 const CANCEL_KINDS = ["cancelled", "duplicate", "superseded", "source_closed"] as const;
 
-// The verdict values the model may supply; the tool maps them to the full kind
-// (uat1_pass / uat2_pass etc.) after reading the issue state.
+// The verdict values the model may supply; the tool maps them to a stage-neutral wire kind.
+// Praxis resolves the persisted uat1/uat2 event after idempotency lookup.
 const VERDICT_VALUES = ["pass", "fail"] as const;
-type VerdictValue = (typeof VERDICT_VALUES)[number];
 
 // Default target for praxis_file_issue: the Praxis repo itself, so a self-improvement issue Praxis
 // can then work lands in its own repo. Mirrors the server's PRAXIS_SELF_HEAL_REPO default; kept
@@ -61,6 +62,14 @@ const PraxisWriteConfigSchema = z.strictObject({
 
 function jsonResult(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+}
+
+function mutationWasRecorded(data: Record<string, unknown>): boolean {
+  return data.applied === true || data.idempotent === true;
+}
+
+function supportsConversationAckV1(issue: PraxisIssueState): boolean {
+  return issue.contracts?.includes("conversation_ack_v1") === true;
 }
 
 function errorResult(err: unknown) {
@@ -169,6 +178,18 @@ const plugin = {
 
   register(api: OpenClawPluginApi) {
     const config = resolveWritePolicyConfig(api.pluginConfig);
+    // Freeze the first full UAT intent for each inbound human message so model retries resend an
+    // identical stage-neutral command. The server also checks the optimistic state/version token.
+    const verdictIntents = new Map<
+      string,
+      {
+        kind: UatVerdictKind;
+        reason: string;
+        expected_state: "dev_uat" | "user_uat";
+        expected_version: number;
+      }
+    >();
+    const infoAnswers = new Map<string, string>();
 
     // Register every tool as `optional: true` so per-agent allowlists scope them — an operator
     // must name the tool / plugin id / "group:plugins" in an agent's `tools.allow`. Combined with
@@ -406,7 +427,7 @@ const plugin = {
 
         // Surface Praxis's structured guards as actionable messages.
         if (!res.ok) {
-          const body = res.data as Record<string, unknown>;
+          const body = res.data;
           if (body.error === "repo_not_onboarded") {
             return jsonResult({
               ok: false,
@@ -719,9 +740,9 @@ const plugin = {
           description:
             "pass — UAT succeeded; fail — UAT failed and the issue should return for fixes",
         }),
-        reason: Type.String({
-          description: "Human-readable UAT verdict rationale (required, recorded for audit)",
-        }),
+        reason: Type.Optional(
+          Type.String({ description: "Required failure summary for fail; optional for pass" }),
+        ),
       }),
       async execute(toolCallId: string, params: Record<string, unknown>) {
         const actor = deriveActorContext(toolContext, toolCallId);
@@ -748,24 +769,46 @@ const plugin = {
           });
         }
 
-        const reason = typeof params.reason === "string" ? params.reason.trim() : "";
-        if (!reason) {
-          return jsonResult({ ok: false, error: "reason_required" });
+        const suppliedReason = typeof params.reason === "string" ? params.reason.trim() : "";
+        if (verdictValue === "fail" && suppliedReason.length < 3) {
+          return jsonResult({ ok: false, error: "failure_summary_required" });
         }
-
         const issueId = Number(params.issue_id);
         if (!Number.isInteger(issueId) || issueId <= 0) {
           return jsonResult({ ok: false, error: "invalid_issue_id" });
         }
-
+        if (!actor.inboundMessageId) {
+          return jsonResult({
+            ok: false,
+            denied: "inbound_message_id_required",
+            message:
+              "This transport did not provide a trusted inbound message id, so Praxis refused to mutate without retry-safe idempotency.",
+          });
+        }
         // Read the issue state to determine the UAT kind prefix (uat1 or uat2).
         // UAT states only exit on a human verdict, so reading then submitting is
         // race-safe for this surface.
-        let issue: PraxisIssueState;
+        let issueResponse: Awaited<ReturnType<typeof getIssueResponse>>;
         try {
-          issue = await getIssue(issueId);
+          issueResponse = await getIssueResponse(issueId);
         } catch (err) {
           return errorResult(err);
+        }
+        if (!issueResponse.ok) {
+          return jsonResult({
+            ok: false,
+            status: issueResponse.status,
+            ...issueResponse.data,
+          });
+        }
+        const issue = issueResponse.data;
+        if (!supportsConversationAckV1(issue)) {
+          return jsonResult({
+            ok: false,
+            denied: "server_contract_unconfirmed",
+            message:
+              "The connected Praxis server does not advertise conversation_ack_v1. Upgrade Praxis before submitting channel replies.",
+          });
         }
 
         const kindPrefix = mapStateToUatKindPrefix(issue.state);
@@ -778,16 +821,41 @@ const plugin = {
           });
         }
 
-        const kind: UatVerdictKind = `${kindPrefix}_${verdictValue as VerdictValue}`;
+        const proposedKind: UatVerdictKind = verdictValue === "pass" ? "uat_pass" : "uat_fail";
+        // Keep bare pass convenient without writing false audit evidence about who validated.
+        const proposedReason =
+          verdictValue === "fail"
+            ? suppliedReason
+            : suppliedReason || "Pass verdict submitted without additional rationale.";
+        const conversationKey = conversationIdempotencyKey("verdict", issueId, actor);
+        let intent = verdictIntents.get(conversationKey);
+        if (!intent) {
+          intent = {
+            kind: proposedKind,
+            reason: proposedReason,
+            expected_state: issue.state as "dev_uat" | "user_uat",
+            expected_version: issue.version,
+          };
+          verdictIntents.set(conversationKey, intent);
+          if (verdictIntents.size > 2048) {
+            const oldest = verdictIntents.keys().next().value;
+            if (oldest) {
+              verdictIntents.delete(oldest);
+            }
+          }
+        }
 
         let res: Awaited<ReturnType<typeof submitVerdict>>;
         try {
           res = await submitVerdict(issueId, {
-            kind,
-            reason,
+            kind: intent.kind,
+            reason: intent.reason,
             requested_by: channelUserId,
             channel: "zoom",
             channel_user_id: channelUserId,
+            message_id: actor.inboundMessageId,
+            idempotency_key: conversationKey,
+            ...intent,
           });
         } catch (err) {
           return errorResult(err);
@@ -795,7 +863,12 @@ const plugin = {
 
         // Surface structured Praxis errors as user-friendly messages.
         if (!res.ok) {
-          const body = res.data as Record<string, unknown>;
+          const body = res.data;
+          // These server validations happen before an event is written. Forget the proposed
+          // payload so the model can correct its interpretation of the same inbound human message.
+          if (body.error === "invalid_failure_summary" || body.error === "invalid_verdict_reason") {
+            verdictIntents.delete(conversationKey);
+          }
           if (body.error === "identity_not_linked") {
             return jsonResult({
               ok: false,
@@ -822,8 +895,31 @@ const plugin = {
                 "No verified identity was forwarded to Praxis. This is a configuration error.",
             });
           }
+          return jsonResult({ ok: false, status: res.status, ...res.data });
         }
-
+        if (!mutationWasRecorded(res.data)) {
+          return jsonResult({
+            ...res.data,
+            ok: false,
+            status: res.status,
+            error: "verdict_not_confirmed",
+            retryable: false,
+            message:
+              "Praxis did not confirm whether the verdict was recorded. Do not retry this message; check issue status first.",
+          });
+        }
+        if (typeof res.data.message !== "string" || !res.data.message.trim()) {
+          return jsonResult({
+            ...res.data,
+            ok: false,
+            status: res.status,
+            error: "acknowledgement_missing",
+            mutation_recorded: true,
+            retryable: false,
+            message:
+              "Praxis recorded the verdict but did not return canonical acknowledgement copy. Do not retry this message; check issue status.",
+          });
+        }
         return jsonResult({ ok: res.ok, status: res.status, ...res.data });
       },
     }));
@@ -872,7 +968,14 @@ const plugin = {
         if (!answer) {
           return jsonResult({ ok: false, error: "answer_required" });
         }
-
+        if (!actor.inboundMessageId) {
+          return jsonResult({
+            ok: false,
+            denied: "inbound_message_id_required",
+            message:
+              "This transport did not provide a trusted inbound message id, so Praxis refused to mutate without retry-safe idempotency.",
+          });
+        }
         // Resolve the issue: prefer the thread-root "owner/repo#N" ref (what humans and the
         // root card speak); fall back to an explicit praxis id.
         let issueId = Number(params.issue_id);
@@ -896,24 +999,60 @@ const plugin = {
         if (!Number.isInteger(issueId) || issueId <= 0) {
           return jsonResult({ ok: false, error: "invalid_issue_id" });
         }
+        let issueResponse: Awaited<ReturnType<typeof getIssueResponse>>;
+        try {
+          issueResponse = await getIssueResponse(issueId);
+        } catch (err) {
+          return errorResult(err);
+        }
+        if (!issueResponse.ok) {
+          return jsonResult({
+            ok: false,
+            status: issueResponse.status,
+            ...issueResponse.data,
+          });
+        }
+        const issue = issueResponse.data;
+        if (!supportsConversationAckV1(issue)) {
+          return jsonResult({
+            ok: false,
+            denied: "server_contract_unconfirmed",
+            message:
+              "The connected Praxis server does not advertise conversation_ack_v1. Upgrade Praxis before submitting channel replies.",
+          });
+        }
+
+        const conversationKey = conversationIdempotencyKey("info", issueId, actor);
+        let frozenAnswer = infoAnswers.get(conversationKey);
+        if (frozenAnswer === undefined) {
+          frozenAnswer = answer;
+          infoAnswers.set(conversationKey, frozenAnswer);
+          if (infoAnswers.size > 2048) {
+            const oldest = infoAnswers.keys().next().value;
+            if (oldest) {
+              infoAnswers.delete(oldest);
+            }
+          }
+        }
 
         let res: Awaited<ReturnType<typeof submitNeedsInfoAnswer>>;
         try {
-          // toolCallId as idempotency key: a model retry of the same call never
-          // double-applies the answer.
+          // The trusted inbound provider message, not the model tool call, binds idempotency.
+          // A model retry or a replay after state advancement cannot double-apply the answer.
           res = await submitNeedsInfoAnswer(issueId, {
-            reason: answer,
+            reason: frozenAnswer,
             requested_by: channelUserId,
             channel: "zoom",
             channel_user_id: channelUserId,
-            idempotency_key: toolCallId,
+            message_id: actor.inboundMessageId,
+            idempotency_key: conversationKey,
           });
         } catch (err) {
           return errorResult(err);
         }
 
         if (!res.ok) {
-          const body = res.data as Record<string, unknown>;
+          const body = res.data;
           if (body.error === "identity_not_linked") {
             return jsonResult({
               ok: false,
@@ -939,8 +1078,31 @@ const plugin = {
                 "Your linked GitHub account is not the asked reporter or a maintainer for this issue.",
             });
           }
+          return jsonResult({ ok: false, status: res.status, ...res.data });
         }
-
+        if (!mutationWasRecorded(res.data)) {
+          return jsonResult({
+            ...res.data,
+            ok: false,
+            status: res.status,
+            error: "answer_not_confirmed",
+            retryable: false,
+            message:
+              "Praxis did not confirm whether the information was recorded. Do not retry this message; check issue status first.",
+          });
+        }
+        if (typeof res.data.message !== "string" || !res.data.message.trim()) {
+          return jsonResult({
+            ...res.data,
+            ok: false,
+            status: res.status,
+            error: "acknowledgement_missing",
+            mutation_recorded: true,
+            retryable: false,
+            message:
+              "Praxis recorded the information but did not return canonical acknowledgement copy. Do not retry this message; check issue status.",
+          });
+        }
         return jsonResult({ ok: res.ok, status: res.status, ...res.data });
       },
     }));
@@ -976,7 +1138,7 @@ const plugin = {
         }
 
         if (!res.ok) {
-          const body = res.data as Record<string, unknown>;
+          const body = res.data;
           if (body.error === "linking_not_configured") {
             return jsonResult({
               ok: false,
@@ -996,7 +1158,7 @@ const plugin = {
           }
         }
 
-        const body = res.data as Record<string, unknown>;
+        const body = res.data;
         const url = typeof body.url === "string" ? body.url : undefined;
         if (!url) {
           return jsonResult({
@@ -1047,11 +1209,11 @@ const plugin = {
           return jsonResult({
             ok: false,
             status: res.status,
-            ...(res.data as Record<string, unknown>),
+            ...res.data,
           });
         }
 
-        const body = res.data as Record<string, unknown>;
+        const body = res.data;
         const linked = body.linked === true;
         const githubLogin = typeof body.github_login === "string" ? body.github_login : undefined;
         return jsonResult({

--- a/extensions/praxis-write/index.ts
+++ b/extensions/praxis-write/index.ts
@@ -36,6 +36,7 @@ import {
   startGithubLink,
   submitCommand,
   resolveIssueRef,
+  resolveThreadIssue,
   submitNeedsInfoAnswer,
   submitVerdict,
   type UatVerdictKind,
@@ -70,6 +71,41 @@ function mutationWasRecorded(data: Record<string, unknown>): boolean {
 
 function supportsConversationAckV1(issue: PraxisIssueState): boolean {
   return issue.contracts?.includes("conversation_ack_v1") === true;
+}
+
+/** Resolve the praxis issue from the runtime-provided reply thread. TRUSTED context only —
+ * the thread id comes from deliveryContext (never model-supplied), and Praxis role-gates the
+ * resolution server-side (unknown/foreign threads are undisclosed 404s). Returns null when the
+ * message was not a threaded reply or the thread does not resolve for this identity; callers
+ * fall back to explicit refs. */
+async function resolveIssueFromReplyThread(
+  toolContext: ToolRequestContext,
+  channelUserId: string,
+): Promise<{ issueId: number; ref: string } | null> {
+  const raw = toolContext.deliveryContext?.threadId;
+  const threadRef = raw === undefined || raw === null ? "" : String(raw).trim();
+  if (!threadRef) {
+    return null;
+  }
+  let res: Awaited<ReturnType<typeof resolveThreadIssue>>;
+  try {
+    res = await resolveThreadIssue({
+      channel: "zoom",
+      channel_user_id: channelUserId,
+      thread_ref: threadRef,
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) {
+    return null;
+  }
+  const issue = (res.data as { issue?: Record<string, unknown> }).issue;
+  const issueId = Number(issue?.issue_id);
+  if (!Number.isInteger(issueId) || issueId <= 0) {
+    return null;
+  }
+  return { issueId, ref: String(issue?.ref ?? "") };
 }
 
 function errorResult(err: unknown) {
@@ -735,7 +771,13 @@ const plugin = {
         "Allowlist-gated; no dry-run/confirm step (UAT states only exit on a human verdict, so " +
         "the read→submit is race-safe). For needs-info answers use praxis_provide_info.",
       parameters: Type.Object({
-        issue_id: Type.Number({ description: "The Praxis issue id (not the GitHub issue number)" }),
+        issue_id: Type.Optional(
+          Type.Number({
+            description:
+              "The Praxis issue id (not the GitHub issue number). OMIT when the user replied " +
+              "in the ask's own thread — the trusted reply thread resolves the issue.",
+          }),
+        ),
         verdict: Type.String({
           description:
             "pass — UAT succeeded; fail — UAT failed and the issue should return for fixes",
@@ -773,9 +815,23 @@ const plugin = {
         if (verdictValue === "fail" && suppliedReason.length < 3) {
           return jsonResult({ ok: false, error: "failure_summary_required" });
         }
-        const issueId = Number(params.issue_id);
+        // Issue resolution: an explicit issue_id wins (non-thread flows, byte-compatible with
+        // the pre-thread contract); otherwise the TRUSTED reply thread resolves it server-side —
+        // a user replying in the ask's own thread never has to name an issue.
+        const explicitId = Number(params.issue_id);
+        const hasExplicit = Number.isInteger(explicitId) && explicitId > 0;
+        const fromThread = hasExplicit
+          ? null
+          : await resolveIssueFromReplyThread(toolContext, channelUserId);
+        const issueId = hasExplicit ? explicitId : (fromThread?.issueId ?? 0);
         if (!Number.isInteger(issueId) || issueId <= 0) {
-          return jsonResult({ ok: false, error: "invalid_issue_id" });
+          return jsonResult({
+            ok: false,
+            error: "issue_required",
+            message:
+              "No issue_id was given and this message is not a reply in a Praxis ask's thread. " +
+              "Call praxis_my_issues to find the issue awaiting a verdict, then retry.",
+          });
         }
         if (!actor.inboundMessageId) {
           return jsonResult({
@@ -920,7 +976,12 @@ const plugin = {
               "Praxis recorded the verdict but did not return canonical acknowledgement copy. Do not retry this message; check issue status.",
           });
         }
-        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+        return jsonResult({
+          ok: res.ok,
+          status: res.status,
+          ...(fromThread ? { resolved_from_thread: fromThread.ref } : {}),
+          ...res.data,
+        });
       },
     }));
 
@@ -938,7 +999,7 @@ const plugin = {
         issue: Type.Optional(
           Type.String({
             description:
-              'The GitHub issue ref "owner/repo#N" (as shown in the thread root) — preferred',
+              'The GitHub issue ref "owner/repo#N". OMIT when the user replied in the ask\'s own thread — the trusted reply thread resolves the issue',
           }),
         ),
         issue_id: Type.Optional(
@@ -976,8 +1037,9 @@ const plugin = {
               "This transport did not provide a trusted inbound message id, so Praxis refused to mutate without retry-safe idempotency.",
           });
         }
-        // Resolve the issue: prefer the thread-root "owner/repo#N" ref (what humans and the
-        // root card speak); fall back to an explicit praxis id.
+        // Resolve the issue. Ladder: explicit praxis id, then the explicit "owner/repo#N" ref,
+        // then the TRUSTED reply thread (runtime-provided — a user answering in the ask's own
+        // thread never needs to name anything).
         let issueId = Number(params.issue_id);
         const ref = typeof params.issue === "string" ? params.issue.trim() : "";
         if ((!Number.isInteger(issueId) || issueId <= 0) && ref) {
@@ -996,8 +1058,21 @@ const plugin = {
           }
           issueId = resolved;
         }
+        const hasExplicit = Number.isInteger(issueId) && issueId > 0;
+        const fromThread = hasExplicit
+          ? null
+          : await resolveIssueFromReplyThread(toolContext, channelUserId);
+        if (!hasExplicit && fromThread) {
+          issueId = fromThread.issueId;
+        }
         if (!Number.isInteger(issueId) || issueId <= 0) {
-          return jsonResult({ ok: false, error: "invalid_issue_id" });
+          return jsonResult({
+            ok: false,
+            error: "issue_required",
+            message:
+              "No issue was given and this message is not a reply in a Praxis ask's thread. " +
+              "Call praxis_my_issues to find the issue with the open question, then retry.",
+          });
         }
         let issueResponse: Awaited<ReturnType<typeof getIssueResponse>>;
         try {
@@ -1103,7 +1178,12 @@ const plugin = {
               "Praxis recorded the information but did not return canonical acknowledgement copy. Do not retry this message; check issue status.",
           });
         }
-        return jsonResult({ ok: res.ok, status: res.status, ...res.data });
+        return jsonResult({
+          ok: res.ok,
+          status: res.status,
+          ...(fromThread ? { resolved_from_thread: fromThread.ref } : {}),
+          ...res.data,
+        });
       },
     }));
 

--- a/extensions/praxis-write/policy.test.ts
+++ b/extensions/praxis-write/policy.test.ts
@@ -3,6 +3,7 @@ import {
   type ActorContext,
   checkPolicy,
   confirmTokenMatches,
+  conversationIdempotencyKey,
   deriveActorContext,
   idempotencyKey,
   mintConfirmToken,
@@ -24,6 +25,7 @@ function actor(overrides: Partial<ActorContext> = {}): ActorContext {
     requestedBy: "alice",
     channel: "dev_praxis",
     messageId: "m-1",
+    inboundMessageId: "m-1",
     toolCallId: "call-1",
     ...overrides,
   };
@@ -31,7 +33,10 @@ function actor(overrides: Partial<ActorContext> = {}): ActorContext {
 
 describe("resolveWritePolicyConfig", () => {
   it("defaults to empty allowlists when unset or malformed", () => {
-    expect(resolveWritePolicyConfig(undefined)).toEqual({ allowedUsers: [], allowedChannels: [] });
+    expect(resolveWritePolicyConfig(undefined)).toEqual({
+      allowedUsers: [],
+      allowedChannels: [],
+    });
     expect(resolveWritePolicyConfig({ allowedUsers: "nope" })).toEqual({
       allowedUsers: [],
       allowedChannels: [],
@@ -41,7 +46,10 @@ describe("resolveWritePolicyConfig", () => {
   it("keeps only non-empty string entries", () => {
     expect(
       resolveWritePolicyConfig({ allowedUsers: ["alice", "", 7, "bob"], allowedChannels: ["c1"] }),
-    ).toEqual({ allowedUsers: ["alice", "bob"], allowedChannels: ["c1"] });
+    ).toEqual({
+      allowedUsers: ["alice", "bob"],
+      allowedChannels: ["c1"],
+    });
   });
 });
 
@@ -55,7 +63,12 @@ describe("checkPolicy", () => {
   });
 
   it("fails closed when neither allowlist is configured", () => {
-    expect(checkPolicy(actor(), { allowedUsers: [], allowedChannels: [] })).toEqual({
+    expect(
+      checkPolicy(actor(), {
+        allowedUsers: [],
+        allowedChannels: [],
+      }),
+    ).toEqual({
       allowed: false,
       reason: "write_policy_unconfigured",
     });
@@ -81,7 +94,10 @@ describe("checkPolicy", () => {
 
   it("allows when every configured dimension matches", () => {
     expect(
-      checkPolicy(actor(), { allowedUsers: ["alice"], allowedChannels: ["dev_praxis"] }),
+      checkPolicy(actor(), {
+        allowedUsers: ["alice"],
+        allowedChannels: ["dev_praxis"],
+      }),
     ).toEqual({ allowed: true });
   });
 
@@ -106,8 +122,21 @@ describe("deriveActorContext", () => {
       requestedBy: "alice",
       channel: "dev_praxis",
       messageId: "99",
+      inboundMessageId: "",
       toolCallId: "call-7",
     });
+  });
+
+  it("prefers the trusted inbound message id over the thread id", () => {
+    const ctx = {
+      requesterSenderId: "alice",
+      currentMessageId: "zoom-message-17",
+      deliveryContext: { channel: "dev_praxis", threadId: 99 },
+      sessionId: "sess-1",
+    };
+
+    expect(deriveActorContext(ctx, "call-7").messageId).toBe("zoom-message-17");
+    expect(deriveActorContext(ctx, "call-7").inboundMessageId).toBe("zoom-message-17");
   });
 
   it("falls back to messageChannel and sessionId, empty requester when absent", () => {
@@ -115,6 +144,7 @@ describe("deriveActorContext", () => {
       requestedBy: "",
       channel: "zoom",
       messageId: "sess-2",
+      inboundMessageId: "",
       toolCallId: "call-8",
     });
   });
@@ -129,6 +159,30 @@ describe("deriveActorContext", () => {
       deliveryContext: { channel: "zoom", to: "room-jid@conference.xmpp.zoom.us", threadId: 1 },
     };
     expect(deriveActorContext(ctx, "call-9").channel).toBe("room-jid@conference.xmpp.zoom.us");
+  });
+});
+
+describe("conversationIdempotencyKey", () => {
+  it("is stable across tool retries and changes with the inbound human message", () => {
+    const first = actor({ inboundMessageId: "zoom-message-17", toolCallId: "tool-a" });
+    const retry = actor({ inboundMessageId: "zoom-message-17", toolCallId: "tool-b" });
+    const later = actor({ inboundMessageId: "zoom-message-18", toolCallId: "tool-c" });
+
+    expect(conversationIdempotencyKey("verdict", 7, first)).toBe(
+      conversationIdempotencyKey("verdict", 7, retry),
+    );
+    expect(conversationIdempotencyKey("verdict", 7, first)).not.toBe(
+      conversationIdempotencyKey("verdict", 7, later),
+    );
+    expect(conversationIdempotencyKey("verdict", 7, first)).not.toBe(
+      conversationIdempotencyKey("info", 7, first),
+    );
+  });
+
+  it("fails closed when the transport did not provide a true inbound message id", () => {
+    expect(() => conversationIdempotencyKey("verdict", 7, actor({ inboundMessageId: "" }))).toThrow(
+      /inbound message id required/,
+    );
   });
 });
 
@@ -214,7 +268,11 @@ describe("mintFileIssueConfirmToken", () => {
   it("is bound to the repo and cannot be forged without the secret", () => {
     const a = mintFileIssueConfirmToken({ secret, fullName: "cw/praxis", title: "Fix x" });
     const otherRepo = mintFileIssueConfirmToken({ secret, fullName: "cw/other", title: "Fix x" });
-    const otherSecret = mintFileIssueConfirmToken({ secret: "x", fullName: "cw/praxis", title: "Fix x" });
+    const otherSecret = mintFileIssueConfirmToken({
+      secret: "x",
+      fullName: "cw/praxis",
+      title: "Fix x",
+    });
     expect(a).not.toBe(otherRepo);
     expect(a).not.toBe(otherSecret);
   });

--- a/extensions/praxis-write/policy.ts
+++ b/extensions/praxis-write/policy.ts
@@ -12,7 +12,7 @@
  *      preview) or that races a state change is rejected.
  */
 
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { PraxisIssueState } from "./praxis-write-client.js";
 
 /** Trusted, runtime-supplied request context. Mirrors the OpenClaw tool context
@@ -21,6 +21,7 @@ export interface ToolRequestContext {
   requesterSenderId?: string;
   messageChannel?: string;
   deliveryContext?: { channel?: string; to?: string; threadId?: string | number };
+  currentMessageId?: string;
   sessionId?: string;
 }
 
@@ -28,6 +29,7 @@ export interface ActorContext {
   requestedBy: string;
   channel: string;
   messageId: string;
+  inboundMessageId: string;
   toolCallId: string;
 }
 
@@ -65,13 +67,31 @@ export function deriveActorContext(ctx: ToolRequestContext, toolCallId: string):
     ctx.deliveryContext?.to ?? ctx.deliveryContext?.channel ?? ctx.messageChannel ?? "";
   const threadId = ctx.deliveryContext?.threadId;
   const messageId =
-    threadId !== undefined && threadId !== null ? String(threadId) : (ctx.sessionId ?? "");
+    ctx.currentMessageId ??
+    (threadId !== undefined && threadId !== null ? String(threadId) : (ctx.sessionId ?? ""));
   return {
     requestedBy: ctx.requesterSenderId ?? "",
     channel,
     messageId,
+    inboundMessageId: ctx.currentMessageId?.trim() ?? "",
     toolCallId,
   };
+}
+
+/** One human inbound message can cause at most one mutation of each conversation purpose.
+ * The key stays stable across model/tool retries and intentionally excludes lifecycle stage:
+ * a retry after uat1 advanced to user_uat must replay uat1, never become uat2. */
+export function conversationIdempotencyKey(
+  purpose: "verdict" | "info",
+  issueId: number,
+  actor: ActorContext,
+): string {
+  if (!actor.inboundMessageId) {
+    throw new Error("trusted inbound message id required for conversation idempotency");
+  }
+  const identity = `${actor.channel}\n${actor.requestedBy}\n${actor.inboundMessageId}`;
+  const digest = createHash("sha256").update(identity).digest("hex");
+  return `conversation:${purpose}:${issueId}:${digest}`;
 }
 
 /** Each configured dimension must match; an empty allowlist authorizes nobody.

--- a/extensions/praxis-write/praxis-write-client.test.ts
+++ b/extensions/praxis-write/praxis-write-client.test.ts
@@ -65,7 +65,14 @@ describe("praxisFetch", () => {
 
 describe("getIssue", () => {
   it("returns the issue state body", async () => {
-    const body = { id: 5, state: "blocked", state_reason: "no_response", version: 12 };
+    const body = {
+      id: 5,
+      repo: "cw/app",
+      source_issue: 50,
+      state: "blocked",
+      state_reason: "no_response",
+      version: 12,
+    };
     fetchMock.mockResolvedValue(mockResponse({ ok: true, status: 200, body }));
     expect(await getIssue(5)).toEqual(body);
     expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/v1/issues/5`);
@@ -141,11 +148,15 @@ describe("submitVerdict", () => {
       mockResponse({ ok: true, status: 200, body: { applied: true, state: "done" } }),
     );
     const res = await submitVerdict(7, {
-      kind: "uat1_pass",
+      kind: "uat_pass",
       reason: "feature verified",
       requested_by: "alice",
       channel: "zoom",
       channel_user_id: "alice",
+      message_id: "m-7",
+      idempotency_key: "call-7",
+      expected_state: "user_uat",
+      expected_version: 5,
     });
     expect(res).toEqual({ ok: true, status: 200, data: { applied: true, state: "done" } });
     const [url, init] = fetchMock.mock.calls[0];
@@ -153,11 +164,15 @@ describe("submitVerdict", () => {
     expect(init.method).toBe("POST");
     const sent = JSON.parse(init.body as string);
     expect(sent).toEqual({
-      kind: "uat1_pass",
+      kind: "uat_pass",
       reason: "feature verified",
       requested_by: "alice",
       channel: "zoom",
       channel_user_id: "alice",
+      message_id: "m-7",
+      idempotency_key: "call-7",
+      expected_state: "user_uat",
+      expected_version: 5,
     });
   });
 
@@ -166,15 +181,19 @@ describe("submitVerdict", () => {
       mockResponse({ ok: false, status: 403, body: { error: "identity_not_linked" } }),
     );
     const res = await submitVerdict(7, {
-      kind: "uat2_fail",
+      kind: "uat_fail",
       reason: "broken",
       requested_by: "alice",
       channel: "zoom",
       channel_user_id: "alice",
+      message_id: "m-8",
+      idempotency_key: "call-8",
+      expected_state: "user_uat",
+      expected_version: 5,
     });
     expect(res.ok).toBe(false);
     expect(res.status).toBe(403);
-    expect((res.data as Record<string, unknown>).error).toBe("identity_not_linked");
+    expect(res.data.error).toBe("identity_not_linked");
   });
 });
 
@@ -189,9 +208,7 @@ describe("startGithubLink", () => {
     );
     const res = await startGithubLink({ channel: "zoom", channel_user_id: "alice" });
     expect(res.ok).toBe(true);
-    expect((res.data as Record<string, unknown>).url).toBe(
-      "https://github.com/login/oauth/authorize?state=abc",
-    );
+    expect(res.data.url).toBe("https://github.com/login/oauth/authorize?state=abc");
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${BASE}/api/v1/identity/link`);
     expect(init.method).toBe("POST");
@@ -205,7 +222,7 @@ describe("startGithubLink", () => {
     );
     const res = await startGithubLink({ channel: "zoom", channel_user_id: "alice" });
     expect(res.ok).toBe(false);
-    expect((res.data as Record<string, unknown>).error).toBe("linking_not_configured");
+    expect(res.data.error).toBe("linking_not_configured");
   });
 });
 
@@ -220,7 +237,7 @@ describe("runSelfHeal", () => {
     );
     const res = await runSelfHeal({ repo: "cw/foo", mode: "create-issues", since_minutes: 90 });
     expect(res.ok).toBe(true);
-    expect((res.data as Record<string, unknown>).issues_created).toBe(1);
+    expect(res.data.issues_created).toBe(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${BASE}/api/v1/self-heal/run`);
     expect(init.method).toBe("POST");
@@ -247,7 +264,7 @@ describe("ingestIssue", () => {
       idempotency_key: "ingest:cw/foo:1015",
     });
     expect(res.ok).toBe(true);
-    expect((res.data as Record<string, unknown>).source_issue).toBe(1015);
+    expect(res.data.source_issue).toBe(1015);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${BASE}/api/v1/issues/ingest`);
     expect(init.method).toBe("POST");
@@ -276,7 +293,7 @@ describe("ingestIssue", () => {
     });
     expect(res.ok).toBe(false);
     expect(res.status).toBe(404);
-    expect((res.data as Record<string, unknown>).error).toBe("repo_not_onboarded");
+    expect(res.data.error).toBe("repo_not_onboarded");
   });
 });
 
@@ -299,7 +316,7 @@ describe("fileIssue", () => {
       idempotency_key: "file-issue:cloudwarriors-ai/praxis:Fix retry",
     });
     expect(res.ok).toBe(true);
-    expect((res.data as Record<string, unknown>).number).toBe(42);
+    expect(res.data.number).toBe(42);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(`${BASE}/api/v1/issues/file`);
     expect(init.method).toBe("POST");

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -293,6 +293,23 @@ export async function getMyIssues(params: {
   return praxisFetch<Record<string, unknown>>(`/api/v1/my/issues?${qs}`);
 }
 
+/** Thread-correlated resolution (Praxis /api/v1/my/thread-issue): map the TRUSTED reply thread
+ * root id to the one issue whose comms live in that thread, identity-scoped and role-gated.
+ * Unknown/foreign threads are undisclosed 404s. The caller forwards only the runtime-provided
+ * thread id — never a model-chosen value. */
+export async function resolveThreadIssue(params: {
+  channel: string;
+  channel_user_id: string;
+  thread_ref: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  const qs = new URLSearchParams({
+    channel: params.channel,
+    channel_user_id: params.channel_user_id,
+    thread_ref: params.thread_ref,
+  }).toString();
+  return praxisFetch<Record<string, unknown>>(`/api/v1/my/thread-issue?${qs}`);
+}
+
 /** Identity-scoped drill-down (Praxis /api/v1/my/issues/{id}): 404 unless the resolved user is
  * that issue's reporter — the end-user detail path; org-wide /issues/{id} stays operator-only. */
 export async function getMyIssue(

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -36,6 +36,7 @@ export interface PraxisIssueState {
   state: string;
   state_reason: string;
   version: number;
+  contracts?: string[];
 }
 
 /** The audit context recorded on the event row. Authorization is NOT here — it
@@ -84,6 +85,13 @@ export async function getIssue(issueId: number): Promise<PraxisIssueState> {
   return praxisGet<PraxisIssueState>(`/api/v1/issues/${issueId}`);
 }
 
+/** Non-throwing issue lookup for user-facing flows that must preserve structured 4xx bodies. */
+export async function getIssueResponse(
+  issueId: number,
+): Promise<PraxisResponse<PraxisIssueState & Record<string, unknown>>> {
+  return praxisFetch<PraxisIssueState & Record<string, unknown>>(`/api/v1/issues/${issueId}`);
+}
+
 /** Submit an operator command. Returns the raw structured result + HTTP status so
  * the tool surfaces Praxis's own error/applied/rejected/idempotent outcome verbatim.
  * The server derives any payload and binds authorization to its operator; we send
@@ -98,10 +106,10 @@ export async function submitCommand(
   });
 }
 
-/** The UAT verdict kinds accepted by the events endpoint. uat1 = dev_uat stage,
- * uat2 = user_uat stage. The correct kind is determined from the issue's current
- * state, not passed by the model. */
-export type UatVerdictKind = "uat1_pass" | "uat1_fail" | "uat2_pass" | "uat2_fail";
+/** Stage-neutral verdict kinds accepted by the conversation-aware events endpoint.
+ * Praxis resolves the persisted uat1/uat2 event server-side after first checking the
+ * inbound-message idempotency key, so a retry cannot change stages. */
+export type UatVerdictKind = "uat_pass" | "uat_fail";
 
 /** Map a Praxis issue state to its UAT kind prefix, or undefined when the issue
  * is not currently awaiting a UAT verdict. Exported for testing. */
@@ -125,6 +133,10 @@ export async function submitVerdict(
     requested_by: string;
     channel: string;
     channel_user_id: string;
+    message_id: string;
+    idempotency_key: string;
+    expected_state: "dev_uat" | "user_uat";
+    expected_version: number;
   },
 ): Promise<PraxisResponse<Record<string, unknown>>> {
   return praxisFetch<Record<string, unknown>>(`/api/v1/issues/${issueId}/events`, {
@@ -137,7 +149,9 @@ export async function submitVerdict(
  * (issue_dict exposes id + repo + source_issue). Returns undefined when not tracked. */
 export async function resolveIssueRef(ref: string): Promise<number | undefined> {
   const m = /^([\w.-]+\/[\w.-]+)#(\d+)$/.exec(ref.trim());
-  if (!m) return undefined;
+  if (!m) {
+    return undefined;
+  }
   const repo = m[1];
   const number = Number(m[2]);
   const res = await praxisGet<{ issues: Array<{ id: number; source_issue: number }> }>(
@@ -158,7 +172,8 @@ export async function submitNeedsInfoAnswer(
     requested_by: string;
     channel: string;
     channel_user_id: string;
-    idempotency_key?: string;
+    message_id: string;
+    idempotency_key: string;
   },
 ): Promise<PraxisResponse<Record<string, unknown>>> {
   return praxisFetch<Record<string, unknown>>(`/api/v1/issues/${issueId}/events`, {

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -310,6 +310,20 @@ export async function resolveThreadIssue(params: {
   return praxisFetch<Record<string, unknown>>(`/api/v1/my/thread-issue?${qs}`);
 }
 
+/** Open-ask resolution (Praxis /api/v1/my/open-ask): the ONE issue with a question addressed to
+ * this identity, resolved server-side. 404 = nothing waiting; 409 = several (body carries the
+ * candidate list). Removes the model's need to guess which issue a bare reply answers. */
+export async function resolveOpenAsk(params: {
+  channel: string;
+  channel_user_id: string;
+}): Promise<PraxisResponse<Record<string, unknown>>> {
+  const qs = new URLSearchParams({
+    channel: params.channel,
+    channel_user_id: params.channel_user_id,
+  }).toString();
+  return praxisFetch<Record<string, unknown>>(`/api/v1/my/open-ask?${qs}`);
+}
+
 /** Identity-scoped drill-down (Praxis /api/v1/my/issues/{id}): 404 unless the resolved user is
  * that issue's reporter — the end-user detail path; org-wide /issues/{id} stays operator-only. */
 export async function getMyIssue(

--- a/extensions/praxis-write/praxis-write-client.ts
+++ b/extensions/praxis-write/praxis-write-client.ts
@@ -113,12 +113,16 @@ export type UatVerdictKind = "uat_pass" | "uat_fail";
 
 /** Map a Praxis issue state to its UAT kind prefix, or undefined when the issue
  * is not currently awaiting a UAT verdict. Exported for testing. */
-export function mapStateToUatKindPrefix(state: string): "uat1" | "uat2" | undefined {
+export function mapStateToUatKindPrefix(state: string): "uat1" | "uat2" | "uat3" | undefined {
   if (state === "dev_uat") {
     return "uat1";
   }
   if (state === "user_uat") {
     return "uat2";
+  }
+  if (state === "prod_uat") {
+    // Prod round (repo opt-in): the reporter's prod confirmation. Server maps uat_pass -> uat3.
+    return "uat3";
   }
   return undefined;
 }

--- a/extensions/zoom/src/monitor-handler.ts
+++ b/extensions/zoom/src/monitor-handler.ts
@@ -192,6 +192,19 @@ function parseCrossTrainingArg(text: string): boolean | null {
   return match[1] === "on";
 }
 
+/**
+ * Agents whose own instructions define a strict relay/tool contract, and which must therefore NOT
+ * receive the "Respond as a general-purpose assistant" half of the DM context prefix.
+ *
+ * That directive lands in the most recency-privileged position — immediately above the user's words
+ * — and is replayed once per turn, so it accumulates and outranks the agent's own AGENTS.md. Live
+ * failure 2026-08-05: `praxis-dm` answered a Praxis needs-info question conversationally with ZERO
+ * tool calls (its AGENTS.md rules were present in the trajectory 4x; the injected clause appeared
+ * 13x). These agents still get the "not a customer support conversation" context, which is the part
+ * the prefix exists for — only the behavioural override is dropped.
+ */
+const DM_CONTRACT_AGENTS = new Set(["praxis-dm"]);
+
 const ADMIN_DOMAIN = process.env.ADMIN_DOMAIN?.toLowerCase().trim();
 
 /** Check if a sender (email or identifier) is from the admin domain. */
@@ -1833,13 +1846,29 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
     threadContext?: ZoomInboundThreadContext;
     threadStarterBody?: string;
   }) {
-    // For DMs, add context prefix so the agent knows this is NOT a customer support conversation
+    // For DMs, add context prefix so the agent knows this is NOT a customer support conversation.
+    // Contract agents (see DM_CONTRACT_AGENTS) get the context WITHOUT the behavioural override,
+    // which otherwise outranks their own instructions on recency and repetition.
     if (params.isDirect) {
-      params.text = [
+      const dmRoute = resolveZoomAgentRoute({
+        runtime: core,
+        cfg: core.config.loadConfig(),
+        senderId: params.senderId,
+        conversationId: params.conversationId,
+        channelJid: params.channelJid,
+        isDirect: true,
+        log,
+      });
+      const lines = [
         "[ADMIN DM] This is a direct message from an authorized team member, NOT a customer support conversation.",
-        "Do NOT use memory_search for customer training data. Respond as a general-purpose assistant.",
-        `Message: ${params.text}`,
-      ].join("\n");
+      ];
+      if (!DM_CONTRACT_AGENTS.has(dmRoute.agentId ?? "")) {
+        lines.push(
+          "Do NOT use memory_search for customer training data. Respond as a general-purpose assistant.",
+        );
+      }
+      lines.push(`Message: ${params.text}`);
+      params.text = lines.join("\n");
     }
     await routeMessageToAgent({ deps, ...params });
   }

--- a/extensions/zoom/src/monitor-handler.ts
+++ b/extensions/zoom/src/monitor-handler.ts
@@ -417,6 +417,14 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
     const isChannelMessage = toJid?.includes("@conference.") ?? false;
     const conversationId = isChannelMessage ? toJid : userJid;
 
+    // Trusted inbound identity for plugin-tool idempotency (praxis-write's retry-safe gate)
+    // and thread-correlated replies. bot_notification carries the provider message id at the
+    // payload top level — without this, every DM mutation is refused as unverifiable.
+    const botNotifThreadContext = parseZoomInboundThreadContext({
+      messageId: payload.messageId,
+      replyMainMessageId: payload.reply_main_message_id,
+    });
+
     log.debug("processing bot notification", {
       userJid,
       userName,
@@ -613,6 +621,7 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
         isDirect: false,
         channelJid: toJid,
         channelName,
+        threadContext: botNotifThreadContext,
       });
     } else {
       // Handle /channel-mode DM command (admin-only)
@@ -718,6 +727,7 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
         senderEmail: userEmail,
         text: messageText,
         isDirect: true,
+        threadContext: botNotifThreadContext,
       });
     }
   }

--- a/extensions/zoom/src/monitor-handler.ts
+++ b/extensions/zoom/src/monitor-handler.ts
@@ -421,8 +421,11 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
     // and thread-correlated replies. bot_notification carries the provider message id at the
     // payload top level — without this, every DM mutation is refused as unverifiable.
     const botNotifThreadContext = parseZoomInboundThreadContext({
-      messageId: payload.messageId,
-      replyMainMessageId: payload.reply_main_message_id,
+      // bot_notification has no messageId; triggerId is the unique per-message id.
+      messageId: payload.triggerId ?? payload.replyMainMessageId,
+      // Root id for thread replies, own id for top-level — a top-level value resolves to no
+      // praxis thread (different id space) and falls back harmlessly.
+      replyMainMessageId: payload.replyMainMessageId,
     });
 
     log.debug("processing bot notification", {

--- a/extensions/zoom/src/monitor-handler.ts
+++ b/extensions/zoom/src/monitor-handler.ts
@@ -627,7 +627,14 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
         return;
       }
 
-      // Route to agent with channel context (non-observe)
+      // Route to agent with channel context (non-observe).
+      // Deliberately NOT passing threadContext on the channel path: with the live
+      // threading config (enabled + sessionScope thread), a thread id here flips the
+      // route peer from channel-scoped to thread-scoped, which would change session
+      // scoping for every Zoom channel agent on this gateway. The DM path below is
+      // unaffected by that (thread scoping requires !isDirect), so praxis-dm still gets
+      // the correlation + idempotency id it needs. Revisit deliberately if thread-scoped
+      // channel sessions are wanted.
       await routeToAgent({
         conversationId: toJid,
         senderId: userJid,
@@ -637,7 +644,6 @@ export function createZoomMessageHandler(deps: ZoomMessageHandlerDeps) {
         isDirect: false,
         channelJid: toJid,
         channelName,
-        threadContext: botNotifThreadContext,
       });
     } else {
       // Handle /channel-mode DM command (admin-only)

--- a/extensions/zoom/src/monitor.ts
+++ b/extensions/zoom/src/monitor.ts
@@ -170,7 +170,7 @@ export async function monitorZoomProvider(opts: MonitorZoomOpts): Promise<Monito
 
   // Return a promise that stays pending until shutdown
   return new Promise<MonitorZoomResult>((resolve) => {
-    const httpServer = expressApp.listen(port, "127.0.0.1", () => {
+    const httpServer = expressApp.listen(port, () => {
       log.info(`zoom provider started on port ${port}`);
     });
 

--- a/extensions/zoom/src/monitor.ts
+++ b/extensions/zoom/src/monitor.ts
@@ -170,7 +170,7 @@ export async function monitorZoomProvider(opts: MonitorZoomOpts): Promise<Monito
 
   // Return a promise that stays pending until shutdown
   return new Promise<MonitorZoomResult>((resolve) => {
-    const httpServer = expressApp.listen(port, () => {
+    const httpServer = expressApp.listen(port, "127.0.0.1", () => {
       log.info(`zoom provider started on port ${port}`);
     });
 

--- a/extensions/zoom/src/types.ts
+++ b/extensions/zoom/src/types.ts
@@ -118,6 +118,8 @@ export type ZoomWebhookEvent = {
       selectedItem?: { value?: string; text?: string };
       toJid?: string;
       messageId?: string;
+      /** Present when the inbound message is a reply inside a thread. */
+      reply_main_message_id?: string;
       original?: { body?: Array<Record<string, unknown>> };
       userName?: string;
       channelName?: string;

--- a/extensions/zoom/src/types.ts
+++ b/extensions/zoom/src/types.ts
@@ -118,8 +118,11 @@ export type ZoomWebhookEvent = {
       selectedItem?: { value?: string; text?: string };
       toJid?: string;
       messageId?: string;
-      /** Present when the inbound message is a reply inside a thread. */
-      reply_main_message_id?: string;
+      /** Unique per-message trigger id on bot_notification events — the trusted inbound id. */
+      triggerId?: string;
+      /** The id a bot reply should thread under: the thread ROOT for thread replies, the
+       * message's own id for top-level messages. (Bot-event UUID space, not REST message ids.) */
+      replyMainMessageId?: string;
       original?: { body?: Array<Record<string, unknown>> };
       userName?: string;
       channelName?: string;

--- a/skills/praxis/SKILL.md
+++ b/skills/praxis/SKILL.md
@@ -2,9 +2,9 @@
 name: praxis
 description: >
   Support and triage for Praxis, the GitHub-issue resolution orchestrator. Diagnose stuck or
-  blocked issues, explain why an issue is where it is, and read its event trace — then escalate any
-  fix to a human (this skill is read-only). Use the praxis_* tools. Also covers the user-scoped
-  conversation flow ("my issues") when the praxis-write plugin is enabled for the agent.
+  blocked issues, explain recorded status, and handle verified needs-info or UAT replies with the
+  opt-in praxis_* tools. Also covers the user-scoped conversation flow ("my issues") when the
+  praxis-write plugin is enabled for the agent. Never initiate customer narration.
   Triggers: "why is issue X stuck", "diagnose praxis issue", "what's blocking", "praxis status",
   "is praxis stuck", "check praxis", "list blocked issues", "praxis issue [id]", "my issues",
   "what's the status of my stuff", "my open issues".
@@ -16,9 +16,8 @@ metadata:
 # Praxis support
 
 Praxis is a deterministic state machine that drives a GitHub issue from intake to done, wrapping the
-org autopilot/Sentinel engine as a swappable resolver. Your job here is **triage**: figure out _why_
-an issue is where it is, explain it plainly, and hand any required action to a human. **This skill is
-read-only** — see "Boundary" below.
+org autopilot/Sentinel engine as a swappable resolver. Diagnose from recorded facts. Only mutate
+when a verified user directly answers a Praxis prompt or explicitly requests an allowed action.
 
 ## Tools
 
@@ -31,6 +30,8 @@ read-only** — see "Boundary" below.
 - `praxis_list_events` — the full append-only event trace (audit trail) for an issue.
 - `praxis_diagnose_issue` — the primary triage tool. Aggregates fuses-vs-caps, open questions, the
   live resolver attempt, and unsettled outbox effects. Server-side redacted (no raw errors/tokens).
+- `praxis_provide_info` — relay the user's answer to the open needs-info question.
+- `praxis_submit_verdict` — relay `pass` or `fail: <what happened>` while awaiting user UAT.
 
 ## Lifecycle
 
@@ -67,10 +68,21 @@ fuse is why the issue is blocked.
      answer (open questions show `field`, `purpose`, `age_seconds`).
    - An unsettled `pending_effect` with `had_error: true` and rising `attempts`? A side-effect
      (dispatch/comms) is failing to send — flag it as an infra/engine problem, not issue content.
-3. **Escalate.** The fix for a stuck issue is almost always a privileged action (`unblock`,
-   `cancel`, `manual_override`) or a human reply (answering `needs_info`, giving a UAT verdict).
-   **None of those are available in this skill.** Tell the human exactly what action is needed and
-   who must take it; do not attempt it yourself.
+3. **Act only on an inbound request.** For needs-info or UAT, call the matching tool with the
+   user's words and relay its returned `message` verbatim. Bare `pass` is valid. `fail` requires a
+   concrete summary; ask for it if absent. Never invent success, identity, evidence, or state.
+
+## Shared-channel conversation contract
+
+- Respond only to a direct user question, an addressed message, or a reply in the issue thread.
+  Never send unsolicited lifecycle updates; Praxis owns proactive Received → Working → Ready copy.
+- For status, read/diagnose first. If all facts exist, reply exactly:
+  `Current status: <plain_status>.\nLast confirmed: <evidence> at <timestamp>.\nNext: <next_expected_event>.\nYour action: <user_action>.`
+- If those facts cannot be confirmed, reply exactly: `I can't confirm the current processing state
+for <issue_ref> right now. I've flagged it for human review rather than guessing.`
+- Relay successful `praxis_provide_info` and `praxis_submit_verdict` `message` fields verbatim.
+- If either tool returns `retryable: false`, do not resubmit the human's message. Read status first;
+  the original mutation may already be recorded.
 
 ## User-scoped conversation ("my issues")
 
@@ -96,10 +108,13 @@ GitHub login server-side, so a user only ever sees their own issues:
 (`praxis_list_issues`, `praxis_get_issue`, `praxis_list_events`, `praxis_diagnose_issue`) and the
 operator writes — the allowlist, not this document, is the enforcement.
 
-## Boundary (read-only)
+**Deployment contract:** deploy the Praxis server response contract before OpenClaw. The reactive
+tools automatically require `conversation_ack_v1` in the authoritative issue response and fail
+before mutation when an older server does not advertise it. Do not bypass that capability check.
 
-This skill's own tools only **read** Praxis. There are no unblock/cancel/override tools here by
-design. If your diagnosis concludes a mutation is needed, surface the recommendation and escalate
-to a human operator — never imply you performed it. Hardened, opt-in write tools (verdicts,
-needs-info relay, unblock/cancel, my-issues) live in the separate `praxis-write` plugin, each
-allowlist-gated and identity-bound.
+## Boundary
+
+Identity and authorization come only from trusted tool context. Do not accept model-supplied user
+identities, expose tokens, retry denied/stale writes, perform unsupported mutations, or paraphrase a
+tool acknowledgement. Escalate anything outside needs-info/UAT or the explicitly enabled operator
+tools to a human. The allowlist, not this document, remains the enforcement boundary.

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -192,6 +192,17 @@ describe("openclaw plugin tool context", () => {
     });
   });
 
+  it("forwards the trusted current inbound message id to plugin tools", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        currentMessageId: 9821,
+      },
+    });
+
+    expect(result.context.currentMessageId).toBe("9821");
+  });
+
   it("does not inject ambient thread defaults into plugin tools", async () => {
     const executeMock = vi.fn(async () => ({
       content: [{ type: "text" as const, text: "ok" }],

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -25,6 +25,7 @@ export type OpenClawPluginToolOptions = {
   modelProvider?: string;
   modelId?: string;
   requesterSenderId?: string | null;
+  currentMessageId?: string | number;
   requesterAgentIdOverride?: string;
   sessionId?: string;
   sandboxBrowserBridgeUrl?: string;
@@ -90,6 +91,8 @@ export function resolveOpenClawPluginToolInputs(params: {
       agentAccountId: options?.agentAccountId,
       deliveryContext,
       requesterSenderId: options?.requesterSenderId ?? undefined,
+      currentMessageId:
+        options?.currentMessageId === undefined ? undefined : String(options.currentMessageId),
       sandboxed: options?.sandboxed,
     },
     allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -359,6 +359,7 @@ export async function handleInlineActions(params: {
           originatingTo: ctx.OriginatingTo,
           to: ctx.To,
           messageThreadId: ctx.MessageThreadId,
+          currentMessageId: ctx.MessageSidFull ?? ctx.MessageSid,
           memberRoleIds: ctx.MemberRoleIds,
         },
         cfg,

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -46,6 +46,8 @@ export type OpenClawPluginToolContext = {
   deliveryContext?: DeliveryContext;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
   requesterSenderId?: string;
+  /** Trusted provider message id for the inbound turn, used for mutation idempotency. */
+  currentMessageId?: string;
   sandboxed?: boolean;
 };
 

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -42,6 +42,7 @@ type SkillDispatchMessageContext = {
   originatingTo?: string;
   to?: string;
   messageThreadId?: string | number;
+  currentMessageId?: string | number;
   memberRoleIds?: string[];
 };
 
@@ -173,6 +174,7 @@ export function resolveSkillDispatchTools(params: {
     agentAccountId: params.message.accountId,
     agentTo: params.message.originatingTo ?? params.message.to,
     agentThreadId: params.message.messageThreadId ?? undefined,
+    currentMessageId: params.message.currentMessageId,
     agentGroupId: groupId,
     agentGroupChannel: params.sessionEntry?.groupChannel,
     agentGroupSpace: params.sessionEntry?.space,


### PR DESCRIPTION
Draft pending #187 merge gates — deployed and live-verified on the dev gateway.

- DM contract agents skip the generic "respond as assistant" injection (praxis-dm follows its workspace contract)
- Misfiled verdicts on needs-info issues redirect to `praxis_provide_info` with the user's words
- `prod_uat` verdicts relay as uat3 (pairs with praxis `Repo.prod_uat_enabled`)

## Verification
Extension tests: 43 passed; the gateway image builds clean and the changes are live-verified end to end on the dev gateway (cube #45: prod verdict relayed, issue closed with attribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)